### PR TITLE
Add TPM mode to exec auth plugin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,6 +9,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/awly/tpmtls"
+  packages = ["tpmkey"]
+  revision = "1762e6d698862efd5f6b9aec1eb3eedf97594314"
+
+[[projects]]
+  branch = "master"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
@@ -65,6 +71,15 @@
   ]
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/go-tpm"
+  packages = [
+    "tpm2",
+    "tpmutil"
+  ]
+  revision = "c1c9f6aa4acef48f689c983db26d7b5066cb1c32"
 
 [[projects]]
   branch = "master"
@@ -587,6 +602,7 @@
     "transport",
     "util/buffer",
     "util/cert",
+    "util/certificate/csr",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -669,6 +685,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e44bc0ff694d49a1e45522b91d61867f5cbc0776e9ceb5adb89628171962ca06"
+  inputs-digest = "77e262a06015f994c651eea0459404aa173bf8397f68dcb6cbd0081bfe2a3f33"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/gke-exec-auth-plugin/BUILD
+++ b/cmd/gke-exec-auth-plugin/BUILD
@@ -1,19 +1,33 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "cache.go",
+        "main.go",
+        "request.go",
+        "tpm.go",
+    ],
     importpath = "k8s.io/cloud-provider-gcp/cmd/gke-exec-auth-plugin",
     visibility = ["//visibility:private"],
     deps = [
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
+        "//vendor/github.com/awly/tpmtls/tpmkey:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
+        "//vendor/github.com/google/go-tpm/tpmutil:go_default_library",
+        "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
+        "//vendor/k8s.io/client-go/util/certificate/csr:go_default_library",
     ],
 )
 
@@ -21,4 +35,14 @@ go_binary(
     name = "gke-exec-auth-plugin",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["tpm_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
+        "//vendor/github.com/google/go-tpm/tpmutil:go_default_library",
+    ],
 )

--- a/cmd/gke-exec-auth-plugin/cache.go
+++ b/cmd/gke-exec-auth-plugin/cache.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/golang/glog"
+	certificates "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/util/cert"
+)
+
+const (
+	certFileName = "kubelet-client.crt"
+	keyFileName  = "kubelet-client.key"
+
+	rotationThreshold = 24 * time.Hour
+)
+
+func getKeyCert() ([]byte, []byte, error) {
+	if key, cert, ok := getExistingKeyCert(*cacheDir); ok {
+		glog.Info("re-using cached key and certificate")
+		return key, cert, nil
+	}
+
+	glog.Info("generating new private key")
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: cert.ECPrivateKeyBlockType, Bytes: keyBytes})
+
+	glog.Info("requesting new certificate")
+	bootstrapConfig, err := loadRESTClientConfig(*bootstrapPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to load bootstrap kubeconfig: %v", err)
+	}
+	bootstrapClient, err := certificates.NewForConfig(bootstrapConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create certificates signing request client: %v", err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to determine hostnamename: %v", err)
+	}
+
+	certPEM, err := requestCertificate(bootstrapClient.CertificateSigningRequests(), keyPEM, hostname)
+	if err != nil {
+		return nil, nil, err
+	}
+	glog.Info("CSR approved, received certificate")
+
+	if err := writeKeyCert(*cacheDir, keyPEM, certPEM); err != nil {
+		return nil, nil, err
+	}
+	return keyPEM, certPEM, nil
+}
+
+func getExistingKeyCert(dir string) ([]byte, []byte, bool) {
+	key, err := ioutil.ReadFile(filepath.Join(dir, keyFileName))
+	if err != nil {
+		return nil, nil, false
+	}
+	cert, err := ioutil.ReadFile(filepath.Join(dir, certFileName))
+	if err != nil {
+		return nil, nil, false
+	}
+	// Check cert expiration.
+	certRaw, _ := pem.Decode(cert)
+	if certRaw != nil {
+		glog.Error("failed parsing existing cert")
+		return nil, nil, false
+	}
+	parsedCert, err := x509.ParseCertificate(certRaw.Bytes)
+	if err != nil {
+		glog.Errorf("failed parsing existing cert: %v", err)
+		return nil, nil, false
+	}
+	if diff := time.Now().Sub(parsedCert.NotAfter); diff < rotationThreshold {
+		if diff < 0 {
+			glog.Warningf("existing cert expired %v ago, requesting new one", -diff)
+		} else {
+			glog.Infof("existing cert will expire in %v, requesting new one", diff)
+		}
+		return nil, nil, false
+	}
+	return key, cert, true
+}
+
+func writeKeyCert(dir string, key, cert []byte) error {
+	if err := ioutil.WriteFile(filepath.Join(dir, keyFileName), key, os.FileMode(0600)); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(dir, certFileName), cert, os.FileMode(0644))
+}

--- a/cmd/gke-exec-auth-plugin/request.go
+++ b/cmd/gke-exec-auth-plugin/request.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"crypto/sha512"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	apicertificates "k8s.io/api/certificates/v1beta1"
+	certificates "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/certificate/csr"
+)
+
+func loadRESTClientConfig(kubeconfig string) (*rest.Config, error) {
+	// Load structured kubeconfig data from the given path.
+	loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	loadedConfig, err := loader.Load()
+	if err != nil {
+		return nil, err
+	}
+	// Flatten the loaded data to a particular rest.Config based on the current context.
+	return clientcmd.NewNonInteractiveClientConfig(
+		*loadedConfig,
+		loadedConfig.CurrentContext,
+		&clientcmd.ConfigOverrides{},
+		loader,
+	).ClientConfig()
+}
+
+// requestCertificate will create a certificate signing request for a node
+// (Organization and CommonName for the CSR will be set as expected for node
+// certificates) and send it to API server, then it will watch the object's
+// status, once approved by API server, it will return the API server's issued
+// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
+// will return an error.
+func requestCertificate(client certificates.CertificateSigningRequestInterface, privateKeyData []byte, hostname string) ([]byte, error) {
+	subject := &pkix.Name{
+		Organization: []string{"system:nodes"},
+		CommonName:   "system:node:" + hostname,
+	}
+
+	privateKey, err := cert.ParsePrivateKeyPEM(privateKeyData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
+	}
+	csrData, err := cert.MakeCSR(privateKey, subject, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
+	}
+	glog.Info("CSR generated")
+	tpm, err := openTPM(*tpmPath)
+	if err != nil {
+		return nil, err
+	}
+	defer tpm.close()
+	attestData, err := tpmAttest(tpm, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add TPM attestation: %v", err)
+	}
+	csrData = append(csrData, attestData...)
+	glog.Info("added TPM attestation")
+
+	usages := []apicertificates.KeyUsage{
+		apicertificates.UsageDigitalSignature,
+		apicertificates.UsageKeyEncipherment,
+		apicertificates.UsageClientAuth,
+	}
+	name := digestedName(privateKeyData, subject, usages)
+	req, err := csr.RequestCertificate(client, csrData, name, usages, privateKey)
+	if err != nil {
+		return nil, err
+	}
+	return csr.WaitForCertificate(client, req, 3600*time.Second)
+}
+
+// This digest should include all the relevant pieces of the CSR we care about.
+// We can't direcly hash the serialized CSR because of random padding that we
+// regenerate every loop and we include usages which are not contained in the
+// CSR. This needs to be kept up to date as we add new fields to the node
+// certificates and with ensureCompatible.
+func digestedName(privateKeyData []byte, subject *pkix.Name, usages []apicertificates.KeyUsage) string {
+	hash := sha512.New512_256()
+
+	// Here we make sure two different inputs can't write the same stream
+	// to the hash. This delimiter is not in the base64.URLEncoding
+	// alphabet so there is no way to have spill over collisions. Without
+	// it 'CN:foo,ORG:bar' hashes to the same value as 'CN:foob,ORG:ar'
+	const delimiter = '|'
+	encode := base64.RawURLEncoding.EncodeToString
+
+	write := func(data []byte) {
+		hash.Write([]byte(encode(data)))
+		hash.Write([]byte{delimiter})
+	}
+
+	write(privateKeyData)
+	write([]byte(subject.CommonName))
+	for _, v := range subject.Organization {
+		write([]byte(v))
+	}
+	for _, v := range usages {
+		write([]byte(v))
+	}
+
+	return "node-csr-" + encode(hash.Sum(nil))
+}

--- a/cmd/gke-exec-auth-plugin/tpm.go
+++ b/cmd/gke-exec-auth-plugin/tpm.go
@@ -1,0 +1,276 @@
+package main
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"reflect"
+	"time"
+
+	"github.com/awly/tpmtls/tpmkey"
+	"github.com/golang/glog"
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+const (
+	// Documented constant NVRAM addresses for AIK template and certificate
+	// inside the TPM.
+	aikCertIndex     = 0x01c10000
+	aikTemplateIndex = 0x01c10001
+)
+
+// TPM 2.0 specification can be found at
+// https://trustedcomputinggroup.org/resource/tpm-library-specification/
+//
+// Most relevant are "Part 1: Architecture" and  "Part 3: Commands".
+
+type tpmDevice interface {
+	createPrimary(tpm2.Public) (tpmutil.Handle, crypto.PublicKey, error)
+	createPrimaryRawTemplate([]byte) (tpmutil.Handle, crypto.PublicKey, error)
+	certify(tpmutil.Handle, tpmutil.Handle) ([]byte, []byte, error)
+	nvRead(tpmutil.Handle) ([]byte, error)
+	loadExternal(tpm2.Public, tpm2.Private) (tpmutil.Handle, error)
+	privateKey(tpmutil.Handle, crypto.PublicKey) crypto.PrivateKey
+	flush(tpmutil.Handle)
+	close() error
+}
+
+type realTPM struct {
+	rwc io.ReadWriteCloser
+}
+
+func openTPM(path string) (*realTPM, error) {
+	rw, err := tpm2.OpenTPM(path)
+	if err != nil {
+		return nil, fmt.Errorf("tpm2.OpenTPM(%q): %v", path, err)
+	}
+	return &realTPM{rw}, nil
+}
+
+func (t *realTPM) createPrimary(pub tpm2.Public) (tpmutil.Handle, crypto.PublicKey, error) {
+	return tpm2.CreatePrimary(t.rwc, tpm2.HandleEndorsement, tpm2.PCRSelection{}, "", "", pub)
+}
+func (t *realTPM) createPrimaryRawTemplate(pub []byte) (tpmutil.Handle, crypto.PublicKey, error) {
+	return tpm2.CreatePrimaryRawTemplate(t.rwc, tpm2.HandleEndorsement, tpm2.PCRSelection{}, "", "", pub)
+}
+func (t *realTPM) certify(kh, aikh tpmutil.Handle) ([]byte, []byte, error) {
+	return tpm2.Certify(t.rwc, "", "", kh, aikh, nil)
+}
+func (t *realTPM) nvRead(h tpmutil.Handle) ([]byte, error) {
+	return tpm2.NVRead(t.rwc, h)
+}
+func (t *realTPM) loadExternal(pub tpm2.Public, priv tpm2.Private) (tpmutil.Handle, error) {
+	kh, _, err := tpm2.LoadExternal(t.rwc, pub, priv, tpm2.HandleNull)
+	return kh, err
+}
+func (t *realTPM) privateKey(h tpmutil.Handle, pub crypto.PublicKey) crypto.PrivateKey {
+	return tpmkey.FromHandle(t.rwc, h, pub, "")
+}
+func (t *realTPM) flush(h tpmutil.Handle) {
+	if err := tpm2.FlushContext(t.rwc, h); err != nil {
+		glog.Errorf("tpm2.Flush(0x%x): %v", h, err)
+	}
+}
+func (t *realTPM) close() error { return t.rwc.Close() }
+
+// tpmAttest generates an attestation signature for privateKey using AIK in
+// TPM. Returned bytes are concatenated PEM blocks of the signature,
+// attestation data and AIK certificate.
+//
+// High-level flow (TPM commands in parens):
+// - load AIK from template in NVRAM (TPM2_NV_ReadPublic, TPM2_NV_Read,
+//   TPM2_CreatePrimary)
+// - load privateKey into the TPM (TPM2_LoadExternal)
+// - certify (sign) privateKey with AIK (TPM2_Certify)
+// - read AIK certificate from NVRAM (TPM2_NV_ReadPubluc, TPM2_NV_Read)
+func tpmAttest(dev tpmDevice, privateKey crypto.PrivateKey) ([]byte, error) {
+	aikh, aikPub, err := loadPrimaryKey(dev)
+	if err != nil {
+		return nil, fmt.Errorf("loadPrimaryKey: %v", err)
+	}
+	defer dev.flush(aikh)
+	glog.Info("loaded AIK")
+
+	kh, err := loadTLSKey(dev, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("loadTLSKey: %v", err)
+	}
+	defer dev.flush(kh)
+	glog.Info("loaded TLS key")
+
+	attest, sig, err := dev.certify(kh, aikh)
+	if err != nil {
+		return nil, fmt.Errorf("certify failed: %v", err)
+	}
+	glog.Info("TLS key certified by AIK")
+
+	// Sanity-check the signature.
+	attestHash := sha256.Sum256(attest)
+	if err := rsa.VerifyPKCS1v15(aikPub.(*rsa.PublicKey), crypto.SHA256, attestHash[:], sig); err != nil {
+		return nil, fmt.Errorf("Signature verification failed: %v", err)
+	}
+	glog.Info("certification signature verified with AIK public key")
+
+	aikCertRaw, aikCert, err := readAIKCert(dev, aikh, aikPub)
+	if err != nil {
+		return nil, fmt.Errorf("reading AIK cert: %v", err)
+	}
+	glog.Info("AIK cert loaded")
+
+	// Sanity-check that AIK cert matches AIK.
+	aikCertPub := aikCert.PublicKey.(*rsa.PublicKey)
+	if !reflect.DeepEqual(aikPub, aikCertPub) {
+		return nil, fmt.Errorf("AIK public key doesn't match certificate public key")
+	}
+	if err := rsa.VerifyPKCS1v15(aikCertPub, crypto.SHA256, attestHash[:], sig); err != nil {
+		return nil, fmt.Errorf("verifying certification signature with AIK cert: %v", err)
+	}
+
+	return bytes.Join([][]byte{
+		pem.EncodeToMemory(&pem.Block{
+			Type:  "ATTESTATION CERTIFICATE",
+			Bytes: aikCertRaw,
+		}),
+		pem.EncodeToMemory(&pem.Block{
+			Type:  "ATTESTATION DATA",
+			Bytes: attest,
+		}),
+		pem.EncodeToMemory(&pem.Block{
+			Type:  "ATTESTATION SIGNATURE",
+			Bytes: sig,
+		}),
+	}, nil), nil
+}
+
+func loadPrimaryKey(dev tpmDevice) (tpmutil.Handle, crypto.PublicKey, error) {
+	// Temporary hack while AIK template is not available.
+	// TODO(awly): remove this.
+	pub := tpm2.Public{
+		Type:       tpm2.AlgRSA,
+		NameAlg:    tpm2.AlgSHA1,
+		Attributes: tpm2.FlagSign | tpm2.FlagSensitiveDataOrigin | tpm2.FlagUserWithAuth,
+		RSAParameters: &tpm2.RSAParams{
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgRSASSA,
+				Hash: tpm2.AlgSHA256,
+			},
+			KeyBits: 2048,
+			Modulus: big.NewInt(0),
+		},
+	}
+	return dev.createPrimary(pub)
+
+	// Actual final implementation.
+	aikTemplate, err := dev.nvRead(aikTemplateIndex)
+	if err != nil {
+		return 0, nil, fmt.Errorf("tpm2.NVRead(AIK template): %v", err)
+	}
+	aikh, aikPub, err := dev.createPrimaryRawTemplate(aikTemplate)
+	if err != nil {
+		return 0, nil, fmt.Errorf("tpm2.CreatePrimary: %v", err)
+	}
+	return aikh, aikPub, nil
+}
+
+func readAIKCert(dev tpmDevice, aikh tpmutil.Handle, aikPub crypto.PublicKey) ([]byte, *x509.Certificate, error) {
+	// Temporary hack while AIK cert is not available.
+	// TODO(awly): remove this and aikh argument.
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Acme Co"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+
+	pk := dev.privateKey(aikh, aikPub)
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, aikPub, pk)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+	fakeCrt, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+	return derBytes, fakeCrt, nil
+
+	// Actual AIK cert loading.
+	//
+	// TODO(awly): if cert is not available, write a JSON blob with VM
+	// identity.
+	aikCert, err := dev.nvRead(tpmutil.Handle(aikCertIndex))
+	if err != nil {
+		return nil, nil, fmt.Errorf("tpm2.NVRead(AIK cert): %v", err)
+	}
+
+	crt, err := x509.ParseCertificate(aikCert)
+	if err != nil {
+		return aikCert, nil, fmt.Errorf("parsing AIK cert: %v", err)
+	}
+	return aikCert, crt, nil
+}
+
+var toTPMCurves = map[string]tpm2.EllipticCurve{
+	"P-224": tpm2.CurveNISTP224,
+	"P-256": tpm2.CurveNISTP256,
+	"P-384": tpm2.CurveNISTP384,
+	"P-521": tpm2.CurveNISTP521,
+}
+
+func loadTLSKey(dev tpmDevice, privateKey crypto.PrivateKey) (tpmutil.Handle, error) {
+	pk, ok := privateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return 0, fmt.Errorf("only EC keys are supported, got %T", privateKey)
+	}
+	curveName := pk.Curve.Params().Name
+	curve, ok := toTPMCurves[curveName]
+	if !ok {
+		return 0, fmt.Errorf("EC curve %q not supported by TPM", curveName)
+	}
+	pub := tpm2.Public{
+		Type:       tpm2.AlgECC,
+		NameAlg:    tpm2.AlgSHA1,
+		Attributes: tpm2.FlagSign | tpm2.FlagSensitiveDataOrigin | tpm2.FlagUserWithAuth,
+		ECCParameters: &tpm2.ECCParams{
+			CurveID: curve,
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgECDSA,
+				Hash: tpm2.AlgSHA1,
+			},
+			Point: tpm2.ECPoint{
+				X: pk.X,
+				Y: pk.Y,
+			},
+		},
+	}
+	private := tpm2.Private{
+		Type:      tpm2.AlgECC,
+		Sensitive: pk.D.Bytes(),
+	}
+	kh, err := dev.loadExternal(pub, private)
+	if err != nil {
+		return 0, fmt.Errorf("loadExternal: %v", err)
+	}
+	return kh, nil
+}

--- a/cmd/gke-exec-auth-plugin/tpm_test.go
+++ b/cmd/gke-exec-auth-plugin/tpm_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+const primaryHandle tpmutil.Handle = 1
+
+type fakeTPM struct {
+	primary    *rsa.PrivateKey
+	loaded     map[tpmutil.Handle]tpm2.Public
+	nextHandle tpmutil.Handle
+}
+
+func newFakeTPM(t *testing.T) *fakeTPM {
+	primary, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &fakeTPM{
+		primary:    primary,
+		loaded:     make(map[tpmutil.Handle]tpm2.Public),
+		nextHandle: primaryHandle + 1,
+	}
+}
+
+func (t *fakeTPM) createPrimary(pub tpm2.Public) (tpmutil.Handle, crypto.PublicKey, error) {
+	return primaryHandle, t.primary.Public(), nil
+}
+func (t *fakeTPM) createPrimaryRawTemplate(pub []byte) (tpmutil.Handle, crypto.PublicKey, error) {
+	return primaryHandle, t.primary.Public(), nil
+}
+func (t *fakeTPM) certify(kh, aikh tpmutil.Handle) ([]byte, []byte, error) {
+	pub, ok := t.loaded[kh]
+	if !ok {
+		return nil, nil, fmt.Errorf("handle %v not loaded", kh)
+	}
+	if aikh != primaryHandle {
+		return nil, nil, errors.New("aik handle passed to certify isn't primaryHandle")
+	}
+	attest, err := json.Marshal(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	attestHash := sha256.Sum256(attest)
+	sig, err := rsa.SignPKCS1v15(rand.Reader, t.primary, crypto.SHA256, attestHash[:])
+	if err != nil {
+		return nil, nil, err
+	}
+	return attest, sig, nil
+}
+func (t *fakeTPM) nvRead(h tpmutil.Handle) ([]byte, error) {
+	// TODO(awly): when aikCert/Template are available, add hardcoded values.
+	return nil, errors.New("not supported")
+}
+func (t *fakeTPM) loadExternal(pub tpm2.Public, priv tpm2.Private) (tpmutil.Handle, error) {
+	t.loaded[t.nextHandle] = pub
+	h := t.nextHandle
+	t.nextHandle++
+	return h, nil
+}
+func (t *fakeTPM) privateKey(h tpmutil.Handle, pub crypto.PublicKey) crypto.PrivateKey {
+	if h != primaryHandle {
+		return nil
+	}
+	return t.primary
+}
+func (t *fakeTPM) flush(h tpmutil.Handle) { delete(t.loaded, h) }
+func (t *fakeTPM) close() error           { return nil }
+
+func TestTPMAttest(t *testing.T) {
+	dev := newFakeTPM(t)
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocksRaw, err := tpmAttest(dev, pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dev.loaded) > 0 {
+		t.Errorf("%d handles not flushed in TPM", len(dev.loaded))
+	}
+
+	wantBlocks := []string{"ATTESTATION CERTIFICATE", "ATTESTATION DATA", "ATTESTATION SIGNATURE"}
+	for i, want := range wantBlocks {
+		var b *pem.Block
+		b, blocksRaw = pem.Decode(blocksRaw)
+		if b == nil {
+			t.Fatalf("missing PEM blocks %q in attestation data", wantBlocks[i:])
+		}
+		if b.Type != want {
+			t.Errorf("got block %q, want %q", b.Type, want)
+		}
+	}
+}

--- a/vendor/github.com/awly/tpmtls/tpmkey/BUILD
+++ b/vendor/github.com/awly/tpmtls/tpmkey/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tpmkey.go"],
+    importmap = "io_k8s_cloud_provider_gcp/vendor/github.com/awly/tpmtls/tpmkey",
+    importpath = "github.com/awly/tpmtls/tpmkey",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
+        "//vendor/github.com/google/go-tpm/tpmutil:go_default_library",
+    ],
+)

--- a/vendor/github.com/awly/tpmtls/tpmkey/tpmkey.go
+++ b/vendor/github.com/awly/tpmtls/tpmkey/tpmkey.go
@@ -1,0 +1,108 @@
+// Package tpmkey implements crypto.PrivateKey using a TPM.
+package tpmkey
+
+import (
+	"crypto"
+	"encoding/asn1"
+	"io"
+	"math/big"
+	"sync"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpmutil"
+)
+
+type privateKey struct {
+	pub  crypto.PublicKey
+	pass string
+
+	mu     *sync.Mutex
+	rw     io.ReadWriter
+	closer io.Closer
+	h      tpmutil.Handle
+}
+
+// Private represents a TPM-connected private key. This key can be used as
+// PrivateKey in tls.Certificate.
+type Private interface {
+	crypto.Signer
+	io.Closer
+}
+
+// Primary creates an ECDSA primary key under specified hierarchy.
+//
+// User must call Close on the returned key when done to free resources in the
+// TPM. Exiting the process without calling Close doesn't free the resources.
+func PrimaryECC(path string, hierarchy tpmutil.Handle) (Private, error) {
+	rwc, err := tpmutil.OpenTPM(path)
+	if err != nil {
+		return nil, err
+	}
+	public := tpm2.Public{
+		Type:       tpm2.AlgECC,
+		NameAlg:    tpm2.AlgSHA1,
+		Attributes: tpm2.FlagSign | tpm2.FlagSensitiveDataOrigin | tpm2.FlagUserWithAuth,
+		ECCParameters: &tpm2.ECCParams{
+			Sign: &tpm2.SigScheme{
+				Alg:  tpm2.AlgECDSA,
+				Hash: tpm2.AlgSHA256,
+			},
+			CurveID: tpm2.CurveNISTP256,
+			Point:   tpm2.ECPoint{X: big.NewInt(0), Y: big.NewInt(0)},
+		},
+	}
+
+	h, pub, err := tpm2.CreatePrimary(rwc, hierarchy, tpm2.PCRSelection{}, "", "", public)
+	if err != nil {
+		rwc.Close()
+		return nil, err
+	}
+
+	return &privateKey{rw: rwc, closer: rwc, h: h, pub: pub, mu: &sync.Mutex{}}, nil
+}
+
+// FromHandle returns a Private implementation using a provided key handle and
+// open TPM device at rw. Calling Close on returned Private is a no-op.
+func FromHandle(rw io.ReadWriter, h tpmutil.Handle, pub crypto.PublicKey, pass string) Private {
+	return &privateKey{rw: rw, h: h, pub: pub, mu: &sync.Mutex{}, pass: pass}
+}
+
+func (pk *privateKey) Close() error {
+	pk.mu.Lock()
+	defer pk.mu.Unlock()
+
+	if pk.rw == nil {
+		return nil
+	}
+	if pk.h != 0 {
+		tpm2.FlushContext(pk.rw, pk.h)
+	}
+
+	var err error
+	if pk.closer != nil {
+		err = pk.closer.Close()
+	}
+	pk.rw = nil
+	pk.closer = nil
+	return err
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func (pk *privateKey) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	pk.mu.Lock()
+	defer pk.mu.Unlock()
+
+	sig, err := tpm2.Sign(pk.rw, pk.h, pk.pass, digest)
+	if err != nil {
+		return nil, err
+	}
+	if sig.RSA != nil {
+		return sig.RSA.Signature, nil
+	}
+	return asn1.Marshal(ecdsaSignature{sig.ECC.R, sig.ECC.S})
+}
+
+func (pk *privateKey) Public() crypto.PublicKey { return pk.pub }

--- a/vendor/github.com/google/go-tpm/LICENSE
+++ b/vendor/github.com/google/go-tpm/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/go-tpm/tpm2/BUILD
+++ b/vendor/github.com/google/go-tpm/tpm2/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "constants.go",
+        "structures.go",
+        "tpm2.go",
+    ],
+    importmap = "io_k8s_cloud_provider_gcp/vendor/github.com/google/go-tpm/tpm2",
+    importpath = "github.com/google/go-tpm/tpm2",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/google/go-tpm/tpmutil:go_default_library"],
+)

--- a/vendor/github.com/google/go-tpm/tpm2/README.md
+++ b/vendor/github.com/google/go-tpm/tpm2/README.md
@@ -1,0 +1,19 @@
+# TPM 2.0 client library
+
+## Integration tests
+
+`tpm2_test.go` contains integration tests that run against a real TPM device
+(emulated or hardware).
+
+By default, running `go test` will skip them. To run the tests on a host with
+available TPM device, run
+
+```
+go test --tpm_path=/dev/tpm0
+```
+
+where `/dev/tpm0` is path to a TPM character device or a Unix socket.
+
+Tip: if your TPM host is remote and you don't want to install Go on it, use `go
+test -c` to compile a test binary. It can be copied to remote host and run
+without extra dependencies.

--- a/vendor/github.com/google/go-tpm/tpm2/constants.go
+++ b/vendor/github.com/google/go-tpm/tpm2/constants.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm2
+
+import (
+	"crypto/elliptic"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+func init() {
+	tpmutil.UseTPM20LengthPrefixSize()
+}
+
+// Algorithm represents a TPM_ALG_ID value.
+type Algorithm uint16
+
+// IsNull returns true if a is AlgNull or zero (unset).
+func (a Algorithm) IsNull() bool {
+	return a == AlgNull || a == AlgUnknown
+}
+
+// Supported Algorithms.
+const (
+	AlgUnknown   Algorithm = 0x0000
+	AlgRSA       Algorithm = 0x0001
+	AlgSHA1      Algorithm = 0x0004
+	AlgAES       Algorithm = 0x0006
+	AlgKeyedHash Algorithm = 0x0008
+	AlgSHA256    Algorithm = 0x000B
+	AlgSHA384    Algorithm = 0x000C
+	AlgSHA512    Algorithm = 0x000D
+	AlgNull      Algorithm = 0x0010
+	AlgRSASSA    Algorithm = 0x0014
+	AlgRSAES     Algorithm = 0x0015
+	AlgRSAPSS    Algorithm = 0x0016
+	AlgOAEP      Algorithm = 0x0017
+	AlgECDSA     Algorithm = 0x0018
+	AlgECDH      Algorithm = 0x0019
+	AlgECDAA     Algorithm = 0x001A
+	AlgKDF2      Algorithm = 0x0021
+	AlgECC       Algorithm = 0x0023
+	AlgCTR       Algorithm = 0x0040
+	AlgOFB       Algorithm = 0x0041
+	AlgCBC       Algorithm = 0x0042
+	AlgCFB       Algorithm = 0x0043
+	AlgECB       Algorithm = 0x0044
+)
+
+// SessionType defines the type of session created in StartAuthSession.
+type SessionType uint8
+
+// Supported session types.
+const (
+	SessionHMAC   SessionType = 0x00
+	SessionPolicy SessionType = 0x01
+	SessionTrial  SessionType = 0x03
+)
+
+// KeyProp is a bitmask used in Attributes field of key templates. Individual
+// flags should be OR-ed to form a full mask.
+type KeyProp uint32
+
+// Key properties.
+const (
+	FlagFixedTPM            KeyProp = 0x00000002
+	FlagFixedParent         KeyProp = 0x00000010
+	FlagSensitiveDataOrigin KeyProp = 0x00000020
+	FlagUserWithAuth        KeyProp = 0x00000040
+	FlagAdminWithPolicy     KeyProp = 0x00000080
+	FlagRestricted          KeyProp = 0x00010000
+	FlagDecrypt             KeyProp = 0x00020000
+	FlagSign                KeyProp = 0x00040000
+
+	FlagSealDefault   = FlagFixedTPM | FlagFixedParent
+	FlagSignerDefault = FlagSign | FlagRestricted | FlagFixedTPM |
+		FlagFixedParent | FlagSensitiveDataOrigin | FlagUserWithAuth
+	FlagStorageDefault = FlagDecrypt | FlagRestricted | FlagFixedTPM |
+		FlagFixedParent | FlagSensitiveDataOrigin | FlagUserWithAuth
+)
+
+// Reserved Handles.
+const (
+	HandleOwner tpmutil.Handle = 0x40000001 + iota
+	HandleRevoke
+	HandleTransport
+	HandleOperator
+	HandleAdmin
+	HandleEK
+	HandleNull
+	HandleUnassigned
+	HandlePasswordSession
+	HandleLockout
+	HandleEndorsement
+	HandlePlatform
+)
+
+// Capability identifies some TPM property or state type.
+type Capability uint32
+
+// TPM Capabilies.
+const (
+	CapabilityAlgs Capability = iota
+	CapabilityHandles
+	CapabilityCommands
+	CapabilityPPCommands
+	CapabilityAuditCommands
+	CapabilityPCRs
+	CapabilityTPMProperties
+	CapabilityPCRProperties
+	CapabilityECCCurves
+	CapabilityAuthPolicies
+)
+
+const (
+	tagNull          tpmutil.Tag = 0x8000
+	tagNoSessions    tpmutil.Tag = 0x8001
+	tagSessions      tpmutil.Tag = 0x8002
+	tagAttestCertify tpmutil.Tag = 0x8017
+	tagHashCheck     tpmutil.Tag = 0x8024
+)
+
+// StartupType instructs the TPM on how to handle its state during Shutdown or
+// Startup.
+type StartupType uint16
+
+// Startup types
+const (
+	StartupClear StartupType = iota
+	StartupState
+)
+
+// EllipticCurve identifies specific EC curves.
+type EllipticCurve uint16
+
+// ECC curves supported by TPM 2.0 spec.
+const (
+	CurveNISTP192 = EllipticCurve(iota + 1)
+	CurveNISTP224
+	CurveNISTP256
+	CurveNISTP384
+	CurveNISTP521
+
+	CurveBNP256 = EllipticCurve(iota + 10)
+	CurveBNP638
+
+	CurveSM2P256 = EllipticCurve(0x0020)
+)
+
+var toGoCurve = map[EllipticCurve]elliptic.Curve{
+	CurveNISTP224: elliptic.P224(),
+	CurveNISTP256: elliptic.P256(),
+	CurveNISTP384: elliptic.P384(),
+	CurveNISTP521: elliptic.P521(),
+}
+
+// Supported TPM operations.
+const (
+	cmdEvictControl       tpmutil.Command = 0x00000120
+	cmdUndefineSpace      tpmutil.Command = 0x00000122
+	cmdClockSet           tpmutil.Command = 0x00000128
+	cmdDefineSpace        tpmutil.Command = 0x0000012A
+	cmdPCRAllocate        tpmutil.Command = 0x0000012B
+	cmdCreatePrimary      tpmutil.Command = 0x00000131
+	cmdIncrementNVCounter tpmutil.Command = 0x00000134
+	cmdWriteNV            tpmutil.Command = 0x00000137
+	cmdPCREvent           tpmutil.Command = 0x0000013C
+	cmdStartup            tpmutil.Command = 0x00000144
+	cmdShutdown           tpmutil.Command = 0x00000145
+	cmdStirRandom         tpmutil.Command = 0x00000146
+	cmdActivateCredential tpmutil.Command = 0x00000147
+	cmdCertify            tpmutil.Command = 0x00000148
+	cmdReadNV             tpmutil.Command = 0x0000014E
+	cmdCreate             tpmutil.Command = 0x00000153
+	cmdLoad               tpmutil.Command = 0x00000157
+	cmdQuote              tpmutil.Command = 0x00000158
+	cmdSign               tpmutil.Command = 0x0000015D
+	cmdUnseal             tpmutil.Command = 0x0000015E
+	cmdContextLoad        tpmutil.Command = 0x00000161
+	cmdContextSave        tpmutil.Command = 0x00000162
+	cmdFlushContext       tpmutil.Command = 0x00000165
+	cmdLoadExternal       tpmutil.Command = 0x00000167
+	cmdMakeCredential     tpmutil.Command = 0x00000168
+	cmdReadPublicNV       tpmutil.Command = 0x00000169
+	cmdReadPublic         tpmutil.Command = 0x00000173
+	cmdStartAuthSession   tpmutil.Command = 0x00000176
+	cmdGetCapability      tpmutil.Command = 0x0000017A
+	cmdGetRandom          tpmutil.Command = 0x0000017B
+	cmdHash               tpmutil.Command = 0x0000017D
+	cmdPCRRead            tpmutil.Command = 0x0000017E
+	cmdPolicyPCR          tpmutil.Command = 0x0000017F
+	cmdReadClock          tpmutil.Command = 0x00000181
+	cmdPCRExtend          tpmutil.Command = 0x00000182
+	cmdPolicyGetDigest    tpmutil.Command = 0x00000189
+	cmdPolicyPassword     tpmutil.Command = 0x0000018C
+)
+
+// Regular TPM 2.0 devices use 24-bit mask (3 bytes) for PCR selection.
+const sizeOfPCRSelect = 3
+
+// digestSize returns the size of a digest for hashing algorithm alg, or 0 if
+// it's not recognized.
+func digestSize(alg Algorithm) int {
+	switch alg {
+	case AlgSHA1:
+		return sha1.Size
+	case AlgSHA256:
+		return sha256.Size
+	case AlgSHA512:
+		return sha512.Size
+	default:
+		return 0
+	}
+}
+
+const defaultRSAExponent = 1<<16 + 1
+
+var hashConstructors = map[Algorithm]func() hash.Hash{
+	AlgSHA1:   sha1.New,
+	AlgSHA256: sha256.New,
+	AlgSHA384: sha512.New384,
+	AlgSHA512: sha512.New,
+}

--- a/vendor/github.com/google/go-tpm/tpm2/structures.go
+++ b/vendor/github.com/google/go-tpm/tpm2/structures.go
@@ -1,0 +1,522 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpm2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// NVPublic contains the public area of an NV index.
+type NVPublic struct {
+	NVIndex    tpmutil.Handle
+	NameAlg    Algorithm
+	Attributes KeyProp
+	AuthPolicy []byte
+	DataSize   uint16
+}
+
+type tpmsSensitiveCreate struct {
+	UserAuth []byte
+	Data     []byte
+}
+
+// PCRSelection contains a slice of PCR indexes and a hash algorithm used in
+// them.
+type PCRSelection struct {
+	Hash Algorithm
+	PCRs []int
+}
+
+type tpmsPCRSelection struct {
+	Hash Algorithm
+	Size byte
+	PCRs tpmutil.RawBytes
+}
+
+// Public contains the public area of an object.
+type Public struct {
+	Type       Algorithm
+	NameAlg    Algorithm
+	Attributes KeyProp
+	AuthPolicy []byte
+
+	// Only one of the Parameters fields should be set. When encoding/decoding,
+	// one will be picked based on Type.
+	RSAParameters *RSAParams
+	ECCParameters *ECCParams
+}
+
+func (p Public) encode() ([]byte, error) {
+	head, err := tpmutil.Pack(p.Type, p.NameAlg, p.Attributes, p.AuthPolicy)
+	if err != nil {
+		return nil, err
+	}
+	var params []byte
+	switch p.Type {
+	case AlgRSA:
+		params, err = p.RSAParameters.encode()
+	case AlgECC:
+		params, err = p.ECCParameters.encode()
+	default:
+		err = fmt.Errorf("unsupported type in TPMT_PUBLIC: %v", p.Type)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return concat(head, params)
+}
+
+func decodePublic(in *bytes.Buffer) (Public, error) {
+	var pub Public
+	var err error
+	if err = tpmutil.UnpackBuf(in, &pub.Type, &pub.NameAlg, &pub.Attributes, &pub.AuthPolicy); err != nil {
+		return pub, fmt.Errorf("decoding TPMT_PUBLIC: %v", err)
+	}
+
+	switch pub.Type {
+	case AlgRSA:
+		pub.RSAParameters, err = decodeRSAParams(in)
+	case AlgECC:
+		pub.ECCParameters, err = decodeECCParams(in)
+	default:
+		err = fmt.Errorf("unsupported type in TPMT_PUBLIC: %v", pub.Type)
+	}
+	return pub, err
+}
+
+// RSAParams represents parameters of an RSA key pair.
+//
+// Symmetric and Sign may be nil, depending on key Attributes in Public.
+// Modulus must always be non-nil.
+type RSAParams struct {
+	Symmetric *SymScheme
+	Sign      *SigScheme
+	KeyBits   uint16
+	Exponent  uint32
+	Modulus   *big.Int
+}
+
+func (p *RSAParams) encode() ([]byte, error) {
+	if p == nil {
+		return nil, nil
+	}
+	sym, err := p.Symmetric.encode()
+	if err != nil {
+		return nil, err
+	}
+	sig, err := p.Sign.encode()
+	if err != nil {
+		return nil, err
+	}
+	if p.Modulus == nil {
+		return nil, errors.New("RSAParams.Modulus must be set")
+	}
+	rest, err := tpmutil.Pack(p.KeyBits, p.Exponent, p.Modulus.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return concat(sym, sig, rest)
+}
+
+func decodeRSAParams(in *bytes.Buffer) (*RSAParams, error) {
+	var params RSAParams
+	var err error
+
+	if params.Symmetric, err = decodeSymScheme(in); err != nil {
+		return nil, err
+	}
+	if params.Sign, err = decodeSigScheme(in); err != nil {
+		return nil, err
+	}
+	var modBytes []byte
+	if err := tpmutil.UnpackBuf(in, &params.KeyBits, &params.Exponent, &modBytes); err != nil {
+		return nil, err
+	}
+	if params.Exponent == 0 {
+		params.Exponent = defaultRSAExponent
+	}
+	params.Modulus = new(big.Int).SetBytes(modBytes)
+	return &params, nil
+}
+
+// ECCParams represents parameters of an ECC key pair.
+//
+// Symmetric, Sign and KDF may be nil, depending on key Attributes in Public.
+type ECCParams struct {
+	Symmetric *SymScheme
+	Sign      *SigScheme
+	CurveID   EllipticCurve
+	KDF       *KDFScheme
+	Point     ECPoint
+}
+
+// ECPoint represents a ECC coordinates for a point.
+type ECPoint struct {
+	X, Y *big.Int
+}
+
+func (p *ECCParams) encode() ([]byte, error) {
+	if p == nil {
+		return nil, nil
+	}
+	sym, err := p.Symmetric.encode()
+	if err != nil {
+		return nil, err
+	}
+	sig, err := p.Sign.encode()
+	if err != nil {
+		return nil, err
+	}
+	curve, err := tpmutil.Pack(p.CurveID)
+	if err != nil {
+		return nil, err
+	}
+	kdf, err := p.KDF.encode()
+	if err != nil {
+		return nil, err
+	}
+	point, err := tpmutil.Pack(p.Point.X.Bytes(), p.Point.Y.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return concat(sym, sig, curve, kdf, point)
+}
+
+func decodeECCParams(in *bytes.Buffer) (*ECCParams, error) {
+	var params ECCParams
+	var err error
+
+	if params.Symmetric, err = decodeSymScheme(in); err != nil {
+		return nil, err
+	}
+	if params.Sign, err = decodeSigScheme(in); err != nil {
+		return nil, err
+	}
+	if err := tpmutil.UnpackBuf(in, &params.CurveID); err != nil {
+		return nil, err
+	}
+	if params.KDF, err = decodeKDFScheme(in); err != nil {
+		return nil, err
+	}
+	var x, y []byte
+	if err := tpmutil.UnpackBuf(in, &x, &y); err != nil {
+		return nil, err
+	}
+	params.Point.X = new(big.Int).SetBytes(x)
+	params.Point.Y = new(big.Int).SetBytes(y)
+	return &params, nil
+}
+
+// SymScheme represents a symmetric encryption scheme.
+type SymScheme struct {
+	Alg     Algorithm
+	KeyBits uint16
+	Mode    Algorithm
+}
+
+func (s *SymScheme) encode() ([]byte, error) {
+	if s == nil || s.Alg.IsNull() {
+		return tpmutil.Pack(AlgNull)
+	}
+	return tpmutil.Pack(s.Alg, s.KeyBits, s.Mode)
+}
+
+func decodeSymScheme(in *bytes.Buffer) (*SymScheme, error) {
+	var scheme SymScheme
+	if err := tpmutil.UnpackBuf(in, &scheme.Alg); err != nil {
+		return nil, err
+	}
+	if scheme.Alg == AlgNull {
+		return nil, nil
+	}
+	if err := tpmutil.UnpackBuf(in, &scheme.KeyBits, &scheme.Mode); err != nil {
+		return nil, err
+	}
+	return &scheme, nil
+}
+
+// SigScheme represents a signing scheme.
+type SigScheme struct {
+	Alg  Algorithm
+	Hash Algorithm
+}
+
+func (s *SigScheme) encode() ([]byte, error) {
+	if s == nil || s.Alg.IsNull() {
+		return tpmutil.Pack(AlgNull)
+	}
+	return tpmutil.Pack(s.Alg, s.Hash)
+}
+
+func decodeSigScheme(in *bytes.Buffer) (*SigScheme, error) {
+	var scheme SigScheme
+	if err := tpmutil.UnpackBuf(in, &scheme.Alg); err != nil {
+		return nil, err
+	}
+	if scheme.Alg == AlgNull {
+		return nil, nil
+	}
+	if err := tpmutil.UnpackBuf(in, &scheme.Hash); err != nil {
+		return nil, err
+	}
+	return &scheme, nil
+}
+
+// KDFScheme represents a KDF (Key Derivation Function) scheme.
+type KDFScheme struct {
+	Alg  Algorithm
+	Hash Algorithm
+}
+
+func (s *KDFScheme) encode() ([]byte, error) {
+	if s == nil || s.Alg.IsNull() {
+		return tpmutil.Pack(AlgNull)
+	}
+	return tpmutil.Pack(s.Alg, s.Hash)
+}
+
+func decodeKDFScheme(in *bytes.Buffer) (*KDFScheme, error) {
+	var scheme KDFScheme
+	if err := tpmutil.UnpackBuf(in, &scheme.Alg); err != nil {
+		return nil, err
+	}
+	if scheme.Alg == AlgNull {
+		return nil, nil
+	}
+	if err := tpmutil.UnpackBuf(in, &scheme.Hash); err != nil {
+		return nil, err
+	}
+	return &scheme, nil
+}
+
+// Signature combines all possible signatures from RSA and ECC keys. Only one
+// of RSA or ECC will be populated.
+type Signature struct {
+	Alg Algorithm
+	RSA *SignatureRSA
+	ECC *SignatureECC
+}
+
+func decodeSignature(in *bytes.Buffer) (*Signature, error) {
+	var sig Signature
+	if err := tpmutil.UnpackBuf(in, &sig.Alg); err != nil {
+		return nil, err
+	}
+	switch sig.Alg {
+	case AlgRSASSA:
+		sig.RSA = new(SignatureRSA)
+		if err := tpmutil.UnpackBuf(in, sig.RSA); err != nil {
+			return nil, err
+		}
+	case AlgECDSA:
+		sig.ECC = new(SignatureECC)
+		var r, s []byte
+		if err := tpmutil.UnpackBuf(in, &sig.ECC.HashAlg, &r, &s); err != nil {
+			return nil, err
+		}
+		sig.ECC.R = big.NewInt(0).SetBytes(r)
+		sig.ECC.S = big.NewInt(0).SetBytes(s)
+	default:
+		return nil, fmt.Errorf("unsupported signature algorithm 0x%x", sig.Alg)
+	}
+	return &sig, nil
+}
+
+// SignatureRSA is an RSA-specific signature value.
+type SignatureRSA struct {
+	HashAlg   Algorithm
+	Signature []byte
+}
+
+// SignatureECC is an ECC-specific signature value.
+type SignatureECC struct {
+	HashAlg Algorithm
+	R       *big.Int
+	S       *big.Int
+}
+
+// Private contains private section of a TPM key.
+type Private struct {
+	Type      Algorithm
+	AuthValue []byte
+	SeedValue []byte
+	Sensitive []byte
+}
+
+func (p Private) encode() ([]byte, error) {
+	if p.Type.IsNull() {
+		return nil, nil
+	}
+	return tpmutil.Pack(p)
+}
+
+type tpmtSigScheme struct {
+	Scheme Algorithm
+	Hash   Algorithm
+}
+
+// AttestationData contains data attested by TPM commands (like Certify).
+type AttestationData struct {
+	Magic               uint32
+	Type                tpmutil.Tag
+	QualifiedSigner     Name
+	ExtraData           []byte
+	ClockInfo           ClockInfo
+	FirmwareVersion     uint64
+	AttestedCertifyInfo *CertifyInfo
+}
+
+// DecodeAttestationData decode a TPMS_ATTEST message. No error is returned if
+// the input has extra trailing data.
+func DecodeAttestationData(in []byte) (*AttestationData, error) {
+	buf := bytes.NewBuffer(in)
+
+	var ad AttestationData
+	if err := tpmutil.UnpackBuf(buf, &ad.Magic, &ad.Type); err != nil {
+		return nil, fmt.Errorf("decoding Magic/Type: %v", err)
+	}
+	n, err := decodeName(buf)
+	if err != nil {
+		return nil, fmt.Errorf("decoding QualifiedSigner: %v", err)
+	}
+	ad.QualifiedSigner = *n
+	if err := tpmutil.UnpackBuf(buf, &ad.ExtraData, &ad.ClockInfo, &ad.FirmwareVersion); err != nil {
+		return nil, fmt.Errorf("decoding ExtraData/ClockInfo/FirmwareVersion: %v", err)
+	}
+
+	// The spec specifies several other types of attestation data. We only need
+	// parsing of Certify attestation data for now. If you need support for
+	// other attestation types, add them here.
+	if ad.Type != tagAttestCertify {
+		return nil, fmt.Errorf("only Certify attestation structure is supported, got type 0x%x", ad.Type)
+	}
+	if ad.AttestedCertifyInfo, err = decodeCertifyInfo(buf); err != nil {
+		return nil, fmt.Errorf("decoding AttestedCertifyInfo: %v", err)
+	}
+	return &ad, nil
+}
+
+// CertifyInfo contains Certify-specific data for TPMS_ATTEST.
+type CertifyInfo struct {
+	Name          Name
+	QualifiedName Name
+}
+
+func decodeCertifyInfo(in *bytes.Buffer) (*CertifyInfo, error) {
+	var ci CertifyInfo
+
+	n, err := decodeName(in)
+	if err != nil {
+		return nil, fmt.Errorf("decoding Name: %v", err)
+	}
+	ci.Name = *n
+
+	n, err = decodeName(in)
+	if err != nil {
+		return nil, fmt.Errorf("decoding QualifiedName: %v", err)
+	}
+	ci.QualifiedName = *n
+
+	return &ci, nil
+}
+
+// Name contains a name for TPM entities. Only one of Handle/Digest should be
+// set.
+type Name struct {
+	Handle *tpmutil.Handle
+	Digest *HashValue
+}
+
+func decodeName(in *bytes.Buffer) (*Name, error) {
+	var nameBuf []byte
+	if err := tpmutil.UnpackBuf(in, &nameBuf); err != nil {
+		return nil, err
+	}
+
+	name := new(Name)
+	switch len(nameBuf) {
+	case 0:
+		// No name is present.
+	case 4:
+		name.Handle = new(tpmutil.Handle)
+		if err := tpmutil.UnpackBuf(bytes.NewBuffer(nameBuf), name.Handle); err != nil {
+			return nil, fmt.Errorf("decoding Handle: %v", err)
+		}
+	default:
+		var err error
+		name.Digest, err = decodeHashValue(bytes.NewBuffer(nameBuf))
+		if err != nil {
+			return nil, fmt.Errorf("decoding Digest: %v", err)
+		}
+	}
+	return name, nil
+}
+
+// MatchesPublic compares Digest in Name against given Public structure. Note:
+// this only works for regular Names, not Qualified Names.
+func (n Name) MatchesPublic(p Public) (bool, error) {
+	buf, err := p.encode()
+	if err != nil {
+		return false, err
+	}
+	if n.Digest == nil {
+		return false, errors.New("Name doesn't have a Digest, can't compare to Public")
+	}
+	hfn, ok := hashConstructors[n.Digest.Alg]
+	if !ok {
+		return false, fmt.Errorf("Name hash algorithm 0x%x not supported", n.Digest.Alg)
+	}
+
+	h := hfn()
+	h.Write(buf)
+	digest := h.Sum(nil)
+
+	return bytes.Equal(digest, n.Digest.Value), nil
+}
+
+// HashValue is an algorithm-specific hash value.
+type HashValue struct {
+	Alg   Algorithm
+	Value []byte
+}
+
+func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
+	var hv HashValue
+	if err := tpmutil.UnpackBuf(in, &hv.Alg); err != nil {
+		return nil, fmt.Errorf("decoding Alg: %v", err)
+	}
+	hfn, ok := hashConstructors[hv.Alg]
+	if !ok {
+		return nil, fmt.Errorf("unsupported hash algorithm type 0x%x", hv.Alg)
+	}
+	hv.Value = make([]byte, hfn().Size())
+	if _, err := in.Read(hv.Value); err != nil {
+		return nil, fmt.Errorf("decoding Value: %v", err)
+	}
+	return &hv, nil
+}
+
+// ClockInfo contains TPM state info included in AttestationData.
+type ClockInfo struct {
+	Clock        uint64
+	ResetCount   uint32
+	RestartCount uint32
+	Safe         byte
+}

--- a/vendor/github.com/google/go-tpm/tpm2/tpm2.go
+++ b/vendor/github.com/google/go-tpm/tpm2/tpm2.go
@@ -1,0 +1,1079 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tpm2 supports direct communication with a TPM 2.0 device under Linux.
+package tpm2
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"io"
+
+	"github.com/google/go-tpm/tpmutil"
+)
+
+// OpenTPM opens a channel to the TPM at the given path. If the file is a
+// device, then it treats it like a normal TPM device, and if the file is a
+// Unix domain socket, then it opens a connection to the socket.
+var OpenTPM = tpmutil.OpenTPM
+
+// GetRandom gets random bytes from the TPM.
+func GetRandom(rw io.ReadWriteCloser, size uint16) ([]byte, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdGetRandom, size)
+	if err != nil {
+		return nil, err
+	}
+
+	var randBytes []byte
+	if _, err := tpmutil.Unpack(resp, &randBytes); err != nil {
+		return nil, err
+	}
+	return randBytes, nil
+}
+
+// FlushContext removes an object or session under handle to be removed from
+// the TPM. This must be called for any loaded handle to avoid out-of-memory
+// errors in TPM.
+func FlushContext(rw io.ReadWriter, handle tpmutil.Handle) error {
+	_, err := runCommand(rw, tagNoSessions, cmdFlushContext, handle)
+	return err
+}
+
+func encodeTPMLPCRSelection(sel PCRSelection) ([]byte, error) {
+	if len(sel.PCRs) == 0 {
+		return tpmutil.Pack(uint32(0))
+	}
+
+	// PCR selection is a variable-size bitmask, where position of a set bit is
+	// the selected PCR index.
+	// Size of the bitmask in bytes is pre-pended. It should be at least
+	// sizeOfPCRSelect.
+	//
+	// For example, selecting PCRs 3 and 9 looks like:
+	// size(3)  mask     mask     mask
+	// 00000011 00000000 00000001 00000100
+	ts := tpmsPCRSelection{
+		Hash: sel.Hash,
+		Size: sizeOfPCRSelect,
+		PCRs: make([]byte, sizeOfPCRSelect),
+	}
+	// sel.PCRs parameter is indexes of PCRs, convert that to set bits.
+	for _, n := range sel.PCRs {
+		byteNum := n / 8
+		bytePos := byte(1 << byte(n%8))
+		ts.PCRs[byteNum] |= bytePos
+	}
+	// Only encode 1 TPMS_PCR_SELECT value.
+	return tpmutil.Pack(uint32(1), ts)
+}
+
+func decodeTPMLPCRSelection(buf *bytes.Buffer) (PCRSelection, error) {
+	var count uint32
+	var sel PCRSelection
+	if err := tpmutil.UnpackBuf(buf, &count); err != nil {
+		return sel, err
+	}
+	if count != 1 {
+		return sel, fmt.Errorf("decoding TPML_PCR_SELECTION list longer than 1 is not supported (got length %d)", count)
+	}
+
+	// See comment in encodeTPMLPCRSelection for details on this format.
+	var ts tpmsPCRSelection
+	if err := tpmutil.UnpackBuf(buf, &ts.Hash, &ts.Size); err != nil {
+		return sel, err
+	}
+	ts.PCRs = make([]byte, ts.Size)
+	if _, err := buf.Read(ts.PCRs); err != nil {
+		return sel, err
+	}
+
+	sel.Hash = ts.Hash
+	for i := 0; i < int(ts.Size); i++ {
+		for j := 0; j < 8; j++ {
+			set := ts.PCRs[i] & byte(1<<byte(j))
+			if set == 0 {
+				continue
+			}
+			sel.PCRs = append(sel.PCRs, 8*i+j)
+		}
+	}
+	return sel, nil
+}
+
+func decodeReadPCRs(in []byte) (map[int][]byte, error) {
+	buf := bytes.NewBuffer(in)
+	var updateCounter uint32
+	if err := tpmutil.UnpackBuf(buf, &updateCounter); err != nil {
+		return nil, err
+	}
+
+	sel, err := decodeTPMLPCRSelection(buf)
+	if err != nil {
+		return nil, fmt.Errorf("decoding TPML_PCR_SELECTION: %v", err)
+	}
+
+	var digestCount uint32
+	if err = tpmutil.UnpackBuf(buf, &digestCount); err != nil {
+		return nil, fmt.Errorf("decoding TPML_DIGEST length: %v", err)
+	}
+	if int(digestCount) != len(sel.PCRs) {
+		return nil, fmt.Errorf("received %d PCRs but %d digests", len(sel.PCRs), digestCount)
+	}
+
+	vals := make(map[int][]byte)
+	for _, pcr := range sel.PCRs {
+		var val []byte
+		if err = tpmutil.UnpackBuf(buf, &val); err != nil {
+			return nil, fmt.Errorf("decoding TPML_DIGEST item: %v", err)
+		}
+		vals[pcr] = val
+	}
+	return vals, nil
+}
+
+// ReadPCRs reads PCR values from the TPM.
+func ReadPCRs(rw io.ReadWriter, sel PCRSelection) (map[int][]byte, error) {
+	cmd, err := encodeTPMLPCRSelection(sel)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, tagNoSessions, cmdPCRRead, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeReadPCRs(resp)
+}
+
+func decodeReadClock(in []byte) (uint64, uint64, error) {
+	var curTime, curClock uint64
+
+	if _, err := tpmutil.Unpack(in, &curTime, &curClock); err != nil {
+		return 0, 0, err
+	}
+	return curTime, curClock, nil
+}
+
+// ReadClock returns current clock values from the TPM.
+//
+// First return value is time in milliseconds since TPM was initialized (since
+// system startup).
+//
+// Second return value is time in milliseconds since TPM reset (since Storage
+// Primary Seed is changed).
+func ReadClock(rw io.ReadWriter) (uint64, uint64, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdReadClock)
+	if err != nil {
+		return 0, 0, err
+	}
+	return decodeReadClock(resp)
+}
+
+func decodeGetCapability(in []byte) (Capability, []tpmutil.Handle, error) {
+	var moreData byte
+	var capReported Capability
+
+	buf := bytes.NewBuffer(in)
+	if err := tpmutil.UnpackBuf(buf, &moreData, &capReported); err != nil {
+		return 0, nil, err
+	}
+	// Only TPM_CAP_HANDLES handled.
+	if capReported != CapabilityHandles {
+		return 0, nil, fmt.Errorf("Only TPM_CAP_HANDLES supported, got %v", capReported)
+	}
+
+	var numHandles uint32
+	if err := tpmutil.UnpackBuf(buf, &numHandles); err != nil {
+		return 0, nil, err
+	}
+
+	var handles []tpmutil.Handle
+	for i := 0; i < int(numHandles); i++ {
+		var handle tpmutil.Handle
+		if err := tpmutil.UnpackBuf(buf, &handle); err != nil {
+			return 0, nil, err
+		}
+		handles = append(handles, handle)
+	}
+
+	return capReported, handles, nil
+}
+
+// GetCapability returns various information about the TPM state.
+//
+// Currently only CapabilityHandles is supported (list active handles).
+func GetCapability(rw io.ReadWriter, cap Capability, count uint32, property uint32) ([]tpmutil.Handle, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdGetCapability, cap, property, count)
+	if err != nil {
+		return nil, err
+	}
+	_, handles, err := decodeGetCapability(resp)
+	if err != nil {
+		return nil, err
+	}
+	return handles, nil
+}
+
+func encodePasswordAuthArea(passwords ...string) ([]byte, error) {
+	var res []byte
+	for _, p := range passwords {
+		// Empty nonce.
+		var nonce []byte
+		// continueSession set, all other bits clear.
+		attributes := byte(1)
+		buf, err := tpmutil.Pack(HandlePasswordSession, nonce, attributes, []byte(p))
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, buf...)
+	}
+
+	size, err := tpmutil.Pack(uint32(len(res)))
+	if err != nil {
+		return nil, err
+	}
+
+	return concat(size, res)
+}
+
+func encodePCREvent(pcr tpmutil.Handle, eventData []byte) ([]byte, error) {
+	ha, err := tpmutil.Pack(pcr, HandleNull)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea("")
+	if err != nil {
+		return nil, err
+	}
+	event, err := tpmutil.Pack(eventData)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, event)
+}
+
+// PCREvent writes an update to the specified PCR.
+func PCREvent(rw io.ReadWriter, pcr tpmutil.Handle, eventData []byte) error {
+	cmd, err := encodePCREvent(pcr, eventData)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagSessions, cmdPCREvent, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func encodeSensitiveArea(s tpmsSensitiveCreate) ([]byte, error) {
+	// TPMS_SENSITIVE_CREATE
+	buf, err := tpmutil.Pack(s)
+	if err != nil {
+		return nil, err
+	}
+	// TPM2B_SENSITIVE_CREATE
+	return tpmutil.Pack(buf)
+}
+
+// encodeCreate works for both TPM2_Create and TPM2_CreatePrimary.
+func encodeCreate(owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) ([]byte, error) {
+	inPublic, err := pub.encode()
+	if err != nil {
+		return nil, err
+	}
+	return encodeCreateRawTemplate(owner, sel, parentPassword, ownerPassword, inPublic)
+}
+
+func encodeCreateRawTemplate(owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, inPublic []byte) ([]byte, error) {
+	parent, err := tpmutil.Pack(owner)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(parentPassword)
+	if err != nil {
+		return nil, err
+	}
+	inSensitive, err := encodeSensitiveArea(tpmsSensitiveCreate{UserAuth: []byte(ownerPassword)})
+	if err != nil {
+		return nil, err
+	}
+	publicBlob, err := tpmutil.Pack(inPublic)
+	if err != nil {
+		return nil, err
+	}
+	outsideInfo, err := tpmutil.Pack([]byte(nil))
+	if err != nil {
+		return nil, err
+	}
+	creationPCR, err := encodeTPMLPCRSelection(sel)
+	if err != nil {
+		return nil, err
+	}
+	return concat(
+		parent,
+		auth,
+		inSensitive,
+		publicBlob,
+		outsideInfo,
+		creationPCR,
+	)
+}
+
+func decodeCreatePrimary(in []byte) (tpmutil.Handle, crypto.PublicKey, error) {
+	var handle tpmutil.Handle
+	var paramSize uint32
+
+	buf := bytes.NewBuffer(in)
+	// Handle and auth data.
+	if err := tpmutil.UnpackBuf(buf, &handle, &paramSize); err != nil {
+		return 0, nil, err
+	}
+
+	var public []byte
+	if err := tpmutil.UnpackBuf(buf, &public); err != nil {
+		return 0, nil, fmt.Errorf("decoding TPM2B_PUBLIC: %v", err)
+	}
+
+	pub, err := decodePublic(bytes.NewBuffer(public))
+	if err != nil {
+		return 0, nil, err
+	}
+	var pubKey crypto.PublicKey
+	switch pub.Type {
+	case AlgRSA:
+		// Endianness of big.Int.Bytes/SetBytes and modulus in the TPM is the same
+		// (big-endian).
+		pubKey = &rsa.PublicKey{N: pub.RSAParameters.Modulus, E: int(pub.RSAParameters.Exponent)}
+	case AlgECC:
+		curve, ok := toGoCurve[pub.ECCParameters.CurveID]
+		if !ok {
+			return 0, nil, fmt.Errorf("can't map TPM EC curve ID 0x%x to Go elliptic.Curve value", pub.ECCParameters.CurveID)
+		}
+		pubKey = &ecdsa.PublicKey{
+			X:     pub.ECCParameters.Point.X,
+			Y:     pub.ECCParameters.Point.Y,
+			Curve: curve,
+		}
+	default:
+		return 0, nil, fmt.Errorf("unsupported primary key type 0x%x", pub.Type)
+	}
+	return handle, pubKey, nil
+}
+
+// CreatePrimary initializes the primary key in a given hierarchy.
+// Second return value is the public part of the generated key.
+func CreatePrimary(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) (tpmutil.Handle, crypto.PublicKey, error) {
+	cmd, err := encodeCreate(owner, sel, parentPassword, ownerPassword, pub)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdCreatePrimary, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return decodeCreatePrimary(resp)
+}
+
+// CreatePrimaryRawTemplate is CreatePrimary, but with the public template
+// (TPMT_PUBLIC) provided pre-encoded. This is commonly used with key templates
+// stored in NV RAM.
+func CreatePrimaryRawTemplate(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, public []byte) (tpmutil.Handle, crypto.PublicKey, error) {
+	cmd, err := encodeCreateRawTemplate(owner, sel, parentPassword, ownerPassword, public)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdCreatePrimary, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return decodeCreatePrimary(resp)
+}
+
+func decodeReadPublic(in []byte) (Public, []byte, []byte, error) {
+	var resp struct {
+		Public        []byte
+		Name          []byte
+		QualifiedName []byte
+	}
+	if _, err := tpmutil.Unpack(in, &resp); err != nil {
+		return Public{}, nil, nil, err
+	}
+	pub, err := decodePublic(bytes.NewBuffer(resp.Public))
+	if err != nil {
+		return Public{}, nil, nil, err
+	}
+	return pub, resp.Name, resp.QualifiedName, nil
+}
+
+// ReadPublic reads the public part of the object under handle.
+// Returns the public data, name and qualified name.
+func ReadPublic(rw io.ReadWriter, handle tpmutil.Handle) (Public, []byte, []byte, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdReadPublic, handle)
+	if err != nil {
+		return Public{}, nil, nil, err
+	}
+
+	return decodeReadPublic(resp)
+}
+
+func decodeCreateKey(in []byte) ([]byte, []byte, error) {
+	var resp struct {
+		Handle  tpmutil.Handle
+		Private []byte
+		Public  []byte
+	}
+
+	if _, err := tpmutil.Unpack(in, &resp); err != nil {
+		return nil, nil, err
+	}
+	return resp.Private, resp.Public, nil
+}
+
+// CreateKey creates a new key pair under the owner handle.
+// Returns private key and public key blobs.
+func CreateKey(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) ([]byte, []byte, error) {
+	cmd, err := encodeCreate(owner, sel, parentPassword, ownerPassword, pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdCreate, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeCreateKey(resp)
+}
+
+func encodeLoad(parentHandle tpmutil.Handle, parentAuth string, publicBlob, privateBlob []byte) ([]byte, error) {
+	ah, err := tpmutil.Pack(parentHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(parentAuth)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(privateBlob, publicBlob)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ah, auth, params)
+}
+
+func decodeLoad(in []byte) (tpmutil.Handle, []byte, error) {
+	var handle tpmutil.Handle
+	var paramSize uint32
+	var name []byte
+
+	if _, err := tpmutil.Unpack(in, &handle, &paramSize, &name); err != nil {
+		return 0, nil, err
+	}
+	return handle, name, nil
+}
+
+// Load loads public/private blobs into an object in the TPM.
+// Returns loaded object handle and its name.
+func Load(rw io.ReadWriter, parentHandle tpmutil.Handle, parentAuth string, publicBlob, privateBlob []byte) (tpmutil.Handle, []byte, error) {
+	cmd, err := encodeLoad(parentHandle, parentAuth, publicBlob, privateBlob)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdLoad, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return 0, nil, err
+	}
+	return decodeLoad(resp)
+}
+
+func encodeLoadExternal(pub Public, private Private, hierarchy tpmutil.Handle) ([]byte, error) {
+	privateBlob, err := private.encode()
+	if err != nil {
+		return nil, err
+	}
+	publicBlob, err := pub.encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return tpmutil.Pack(privateBlob, publicBlob, hierarchy)
+}
+
+func decodeLoadExternal(in []byte) (tpmutil.Handle, []byte, error) {
+	var handle tpmutil.Handle
+	var name []byte
+
+	if _, err := tpmutil.Unpack(in, &handle, &name); err != nil {
+		return 0, nil, err
+	}
+	return handle, name, nil
+}
+
+// LoadExternal loads a public (and optionally a private) key into an object in
+// the TPM. Returns loaded object handle and its name.
+func LoadExternal(rw io.ReadWriter, pub Public, private Private, hierarchy tpmutil.Handle) (tpmutil.Handle, []byte, error) {
+	cmd, err := encodeLoadExternal(pub, private, hierarchy)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := runCommand(rw, tagNoSessions, cmdLoadExternal, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return 0, nil, err
+	}
+	handle, name, err := decodeLoadExternal(resp)
+	if err != nil {
+		return 0, nil, err
+	}
+	return handle, name, nil
+}
+
+// PolicyPassword sets password authorization requirement on the object.
+func PolicyPassword(rw io.ReadWriter, handle tpmutil.Handle) error {
+	_, err := runCommand(rw, tagNoSessions, cmdPolicyPassword, handle)
+	return err
+}
+
+func encodePolicyPCR(session tpmutil.Handle, expectedDigest []byte, sel PCRSelection) ([]byte, error) {
+	params, err := tpmutil.Pack(session, expectedDigest)
+	if err != nil {
+		return nil, err
+	}
+	pcrs, err := encodeTPMLPCRSelection(sel)
+	if err != nil {
+		return nil, err
+	}
+	return concat(params, pcrs)
+}
+
+// PolicyPCR sets PCR state binding for authorization on a session.
+func PolicyPCR(rw io.ReadWriter, session tpmutil.Handle, expectedDigest []byte, sel PCRSelection) error {
+	cmd, err := encodePolicyPCR(session, expectedDigest, sel)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagNoSessions, cmdPolicyPCR, tpmutil.RawBytes(cmd))
+	return err
+}
+
+// PolicyGetDigest returns the current policyDigest of the session.
+func PolicyGetDigest(rw io.ReadWriter, handle tpmutil.Handle) ([]byte, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdPolicyGetDigest, handle)
+	if err != nil {
+		return nil, err
+	}
+
+	var digest []byte
+	_, err = tpmutil.Unpack(resp, &digest)
+	return digest, err
+}
+
+func encodeStartAuthSession(tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym, hashAlg Algorithm) ([]byte, error) {
+	ha, err := tpmutil.Pack(tpmKey, bindKey)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(nonceCaller, secret, se, sym, hashAlg)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, params)
+}
+
+func decodeStartAuthSession(in []byte) (tpmutil.Handle, []byte, error) {
+	var handle tpmutil.Handle
+	var nonce []byte
+	if _, err := tpmutil.Unpack(in, &handle, &nonce); err != nil {
+		return 0, nil, err
+	}
+	return handle, nonce, nil
+}
+
+// StartAuthSession initializes a session object.
+// Returns session handle and the initial nonce from the TPM.
+func StartAuthSession(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym, hashAlg Algorithm) (tpmutil.Handle, []byte, error) {
+	cmd, err := encodeStartAuthSession(tpmKey, bindKey, nonceCaller, secret, se, sym, hashAlg)
+	if err != nil {
+		return 0, nil, err
+	}
+	resp, err := runCommand(rw, tagNoSessions, cmdStartAuthSession, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return 0, nil, err
+	}
+	return decodeStartAuthSession(resp)
+}
+
+func encodeUnseal(itemHandle tpmutil.Handle, password string) ([]byte, error) {
+	ha, err := tpmutil.Pack(itemHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(password)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth)
+}
+
+func decodeUnseal(in []byte) ([]byte, error) {
+	var paramSize uint32
+	var unsealed []byte
+
+	if _, err := tpmutil.Unpack(in, &paramSize, &unsealed); err != nil {
+		return nil, err
+	}
+	return unsealed, nil
+}
+
+// Unseal returns the data for a loaded sealed object.
+func Unseal(rw io.ReadWriter, itemHandle tpmutil.Handle, password string) ([]byte, error) {
+	cmd, err := encodeUnseal(itemHandle, password)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdUnseal, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeUnseal(resp)
+}
+
+func encodeQuote(signingHandle tpmutil.Handle, parentPassword, ownerPassword string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, error) {
+	ha, err := tpmutil.Pack(signingHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(parentPassword)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(toQuote, sigAlg)
+	if err != nil {
+		return nil, err
+	}
+	pcrs, err := encodeTPMLPCRSelection(sel)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params, pcrs)
+}
+
+func decodeQuote(in []byte) ([]byte, *Signature, error) {
+	buf := bytes.NewBuffer(in)
+	var paramSize uint32
+	var attest []byte
+	if err := tpmutil.UnpackBuf(buf, &paramSize, &attest); err != nil {
+		return nil, nil, err
+	}
+	sig, err := decodeSignature(buf)
+	return attest, sig, err
+}
+
+// Quote returns a quote of PCR values. A quote is a signature of the PCR
+// values, created using a signing TPM key.
+//
+// Returns attestation data and the signature.
+//
+// Note: currently only RSA signatures are supported.
+func Quote(rw io.ReadWriter, signingHandle tpmutil.Handle, parentPassword, ownerPassword string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, *Signature, error) {
+	cmd, err := encodeQuote(signingHandle, parentPassword, ownerPassword, toQuote, sel, sigAlg)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdQuote, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeQuote(resp)
+}
+
+func encodeActivateCredential(activeHandle tpmutil.Handle, keyHandle tpmutil.Handle, activePassword, protectorPassword string, credBlob, secret []byte) ([]byte, error) {
+	ha, err := tpmutil.Pack(activeHandle, keyHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(activePassword, protectorPassword)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(credBlob, secret)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+func decodeActivateCredential(in []byte) ([]byte, error) {
+	var paramSize uint32
+	var certInfo []byte
+
+	if _, err := tpmutil.Unpack(in, &paramSize, &certInfo); err != nil {
+		return nil, err
+	}
+	return certInfo, nil
+}
+
+// ActivateCredential associates an object with a credential.
+// Returns decrypted certificate information.
+func ActivateCredential(rw io.ReadWriter, activeHandle, keyHandle tpmutil.Handle, activePassword, protectorPassword string, credBlob, secret []byte) ([]byte, error) {
+	cmd, err := encodeActivateCredential(activeHandle, keyHandle, activePassword, protectorPassword, credBlob, secret)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdActivateCredential, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeActivateCredential(resp)
+}
+
+func encodeMakeCredential(protectorHandle tpmutil.Handle, credential, activeName []byte) ([]byte, error) {
+	ha, err := tpmutil.Pack(protectorHandle)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(credential, activeName)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, params)
+}
+
+func decodeMakeCredential(in []byte) ([]byte, []byte, error) {
+	var credBlob []byte
+	var encryptedSecret []byte
+
+	if _, err := tpmutil.Unpack(in, &credBlob, &encryptedSecret); err != nil {
+		return nil, nil, err
+	}
+	return credBlob, encryptedSecret, nil
+}
+
+// MakeCredential creates an encrypted credential for use in MakeCredential.
+// Returns encrypted credential and wrapped secret used to encrypt it.
+func MakeCredential(rw io.ReadWriter, protectorHandle tpmutil.Handle, credential, activeName []byte) ([]byte, []byte, error) {
+	cmd, err := encodeMakeCredential(protectorHandle, credential, activeName)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, tagNoSessions, cmdMakeCredential, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeMakeCredential(resp)
+}
+
+func encodeEvictControl(ownerAuth string, owner, objectHandle, persistentHandle tpmutil.Handle) ([]byte, error) {
+	ha, err := tpmutil.Pack(owner, objectHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(ownerAuth)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(persistentHandle)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// EvictControl toggles persistence of an object within the TPM.
+func EvictControl(rw io.ReadWriter, ownerAuth string, owner, objectHandle, persistentHandle tpmutil.Handle) error {
+	cmd, err := encodeEvictControl(ownerAuth, owner, objectHandle, persistentHandle)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagSessions, cmdEvictControl, tpmutil.RawBytes(cmd))
+	return err
+}
+
+// ContextSave returns an encrypted version of the session, object or sequence
+// context for storage outside of the TPM. The handle references context to
+// store.
+func ContextSave(rw io.ReadWriter, handle tpmutil.Handle) ([]byte, error) {
+	return runCommand(rw, tagNoSessions, cmdContextSave, handle)
+}
+
+// ContextLoad reloads context data created by ContextSave.
+func ContextLoad(rw io.ReadWriter, saveArea []byte) (tpmutil.Handle, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdContextLoad, tpmutil.RawBytes(saveArea))
+	if err != nil {
+		return 0, err
+	}
+	var handle tpmutil.Handle
+	_, err = tpmutil.Unpack(resp, &handle)
+	return handle, err
+}
+
+func encodeIncrementNV(handle tpmutil.Handle, authString string) ([]byte, error) {
+	auth, err := encodePasswordAuthArea(authString)
+	if err != nil {
+		return nil, err
+	}
+	out, err := tpmutil.Pack(handle, handle)
+	if err != nil {
+		return nil, err
+	}
+	return concat(out, auth)
+}
+
+// NVIncrement increments a counter in NVRAM.
+func NVIncrement(rw io.ReadWriter, handle tpmutil.Handle, authString string) error {
+	cmd, err := encodeIncrementNV(handle, authString)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagSessions, cmdIncrementNVCounter, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func encodeUndefineSpace(ownerAuth string, owner, index tpmutil.Handle) ([]byte, error) {
+	auth, err := encodePasswordAuthArea(ownerAuth)
+	if err != nil {
+		return nil, err
+	}
+	out, err := tpmutil.Pack(owner, index)
+	if err != nil {
+		return nil, err
+	}
+	return concat(out, auth)
+}
+
+// NVUndefineSpace removes an index from TPM's NV storage.
+func NVUndefineSpace(rw io.ReadWriter, ownerAuth string, owner, index tpmutil.Handle) error {
+	cmd, err := encodeUndefineSpace(ownerAuth, owner, index)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagSessions, cmdUndefineSpace, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func encodeDefineSpace(owner, handle tpmutil.Handle, ownerAuth, authVal string, attributes uint32, policy []byte, dataSize uint16) ([]byte, error) {
+	ha, err := tpmutil.Pack(owner)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(ownerAuth)
+	if err != nil {
+		return nil, err
+	}
+	publicInfo, err := tpmutil.Pack(handle, AlgSHA1, attributes, policy, dataSize)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack([]byte(authVal), publicInfo)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// NVDefineSpace creates an index in TPM's NV storage.
+func NVDefineSpace(rw io.ReadWriter, owner, handle tpmutil.Handle, ownerAuth, authString string, policy []byte, attributes uint32, dataSize uint16) error {
+	cmd, err := encodeDefineSpace(owner, handle, ownerAuth, authString, attributes, policy, dataSize)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, tagSessions, cmdDefineSpace, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func decodeNVReadPublic(in []byte) (NVPublic, error) {
+	var pub NVPublic
+	var buf []byte
+	if _, err := tpmutil.Unpack(in, &buf); err != nil {
+		return pub, err
+	}
+	_, err := tpmutil.Unpack(buf, &pub)
+	return pub, err
+}
+
+func decodeNVRead(in []byte) ([]byte, error) {
+	var sessionAttributes uint32
+	var data []byte
+	if _, err := tpmutil.Unpack(in, &sessionAttributes, &data); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func encodeNVRead(handle tpmutil.Handle, authString string, offset, dataSize uint16) ([]byte, error) {
+	ha, err := tpmutil.Pack(handle, handle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(authString)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(dataSize, offset)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// NVRead reads a full data blob from an NV index.
+func NVRead(rw io.ReadWriter, index tpmutil.Handle) ([]byte, error) {
+	// Read public area to determine data size.
+	resp, err := runCommand(rw, tagNoSessions, cmdReadPublicNV, index)
+	if err != nil {
+		return nil, fmt.Errorf("running NV_ReadPublic command: %v", err)
+	}
+	pub, err := decodeNVReadPublic(resp)
+	if err != nil {
+		return nil, fmt.Errorf("decoding NV_ReadPublic response: %v", err)
+	}
+
+	// Read pub.DataSize of actual data.
+	cmd, err := encodeNVRead(index, "", 0, pub.DataSize)
+	if err != nil {
+		return nil, fmt.Errorf("building NV_Read command: %v", err)
+	}
+	resp, err = runCommand(rw, tagSessions, cmdReadNV, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, fmt.Errorf("running NV_Read command: %v", err)
+	}
+	return decodeNVRead(resp)
+}
+
+// Hash computes a hash of data in buf using the TPM.
+func Hash(rw io.ReadWriter, alg Algorithm, buf []byte) ([]byte, error) {
+	resp, err := runCommand(rw, tagNoSessions, cmdHash, buf, alg, HandleNull)
+	if err != nil {
+		return nil, err
+	}
+
+	var digest []byte
+	if _, err = tpmutil.Unpack(resp, &digest); err != nil {
+		return nil, err
+	}
+	return digest, nil
+}
+
+// Startup initializes a TPM (usually done by the OS).
+func Startup(rw io.ReadWriter, typ StartupType) error {
+	_, err := runCommand(rw, tagNoSessions, cmdStartup, typ)
+	return err
+}
+
+// Shutdown shuts down a TPM (usually done by the OS).
+func Shutdown(rw io.ReadWriter, typ StartupType) error {
+	_, err := runCommand(rw, tagNoSessions, cmdShutdown, typ)
+	return err
+}
+
+func encodeSign(key tpmutil.Handle, password string, digest []byte) ([]byte, error) {
+	ha, err := tpmutil.Pack(key)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodePasswordAuthArea(password)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(digest, AlgNull, tagHashCheck, HandleNull, []byte(nil))
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+func decodeSign(buf []byte) (*Signature, error) {
+	in := bytes.NewBuffer(buf)
+	var paramSize uint32
+	if err := tpmutil.UnpackBuf(in, &paramSize); err != nil {
+		return nil, err
+	}
+	return decodeSignature(in)
+}
+
+// Sign computes a signature for digest using a given loaded key. Signature
+// algorithm depends on the key type.
+func Sign(rw io.ReadWriter, key tpmutil.Handle, password string, digest []byte) (*Signature, error) {
+	cmd, err := encodeSign(key, password, digest)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdSign, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeSign(resp)
+}
+
+func encodeCertify(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, error) {
+	ha, err := tpmutil.Pack(object, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	auth, err := encodePasswordAuthArea(parentAuth, ownerAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := tpmtSigScheme{AlgRSASSA, AlgSHA256}
+	// Use signing key's scheme.
+	params, err := tpmutil.Pack(qualifyingData, scheme)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+func decodeCertify(resp []byte) ([]byte, []byte, error) {
+	var paramSize uint32
+	var attest, signature []byte
+	var sigAlg, hashAlg Algorithm
+	if _, err := tpmutil.Unpack(resp, &paramSize, &attest, &sigAlg, &hashAlg, &signature); err != nil {
+		return nil, nil, err
+	}
+	return attest, signature, nil
+}
+
+// Certify generates a signature of a loaded TPM object with a signing key
+// signer. Returned values are: attestation data (TPMS_ATTEST), signature and
+// error, if any.
+func Certify(rw io.ReadWriter, parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
+	cmd, err := encodeCertify(parentAuth, ownerAuth, object, signer, qualifyingData)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, tagSessions, cmdCertify, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeCertify(resp)
+}
+
+func runCommand(rw io.ReadWriter, tag tpmutil.Tag, cmd tpmutil.Command, in ...interface{}) ([]byte, error) {
+	resp, code, err := tpmutil.RunCommand(rw, tag, cmd, in...)
+	if err != nil {
+		return nil, err
+	}
+	if code != tpmutil.RCSuccess {
+		return nil, fmt.Errorf("response status 0x%x", code)
+	}
+	return resp, nil
+}
+
+// concat is a helper for encoding functions that separately encode handle,
+// auth and param areas. A nil error is always returned, so that callers can
+// simply return concat(a, b, c).
+func concat(chunks ...[]byte) ([]byte, error) {
+	return bytes.Join(chunks, nil), nil
+}

--- a/vendor/github.com/google/go-tpm/tpmutil/BUILD
+++ b/vendor/github.com/google/go-tpm/tpmutil/BUILD
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "encoding.go",
+        "run.go",
+        "structures.go",
+    ],
+    importmap = "io_k8s_cloud_provider_gcp/vendor/github.com/google/go-tpm/tpmutil",
+    importpath = "github.com/google/go-tpm/tpmutil",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/google/go-tpm/tpmutil/encoding.go
+++ b/vendor/github.com/google/go-tpm/tpmutil/encoding.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpmutil
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+// lengthPrefixSize is the size in bytes of length prefix for byte slices.
+//
+// In TPM 1.2 this is 4 bytes.
+// In TPM 2.0 this is 2 bytes.
+var lengthPrefixSize int
+
+const (
+	tpm12PrefixSize = 4
+	tpm20PrefixSize = 2
+)
+
+// UseTPM12LengthPrefixSize makes Pack/Unpack use TPM 1.2 encoding for byte
+// arrays.
+func UseTPM12LengthPrefixSize() {
+	lengthPrefixSize = tpm12PrefixSize
+}
+
+// UseTPM20LengthPrefixSize makes Pack/Unpack use TPM 2.0 encoding for byte
+// arrays.
+func UseTPM20LengthPrefixSize() {
+	lengthPrefixSize = tpm20PrefixSize
+}
+
+// packedSize computes the size of a sequence of types that can be passed to
+// binary.Read or binary.Write.
+func packedSize(elts ...interface{}) (int, error) {
+	var size int
+	for _, e := range elts {
+		v := reflect.ValueOf(e)
+		switch v.Kind() {
+		case reflect.Ptr:
+			s, err := packedSize(reflect.Indirect(v).Interface())
+			if err != nil {
+				return 0, err
+			}
+
+			size += s
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				s, err := packedSize(v.Field(i).Interface())
+				if err != nil {
+					return 0, err
+				}
+
+				size += s
+			}
+		case reflect.Slice:
+			switch s := e.(type) {
+			case []byte:
+				size += lengthPrefixSize + len(s)
+			case RawBytes:
+				size += len(s)
+			default:
+				return 0, fmt.Errorf("encoding of %T is not supported, only []byte and RawBytes slices are", e)
+			}
+		default:
+			s := binary.Size(e)
+			if s < 0 {
+				return 0, fmt.Errorf("can't calculate size of type %T", e)
+			}
+
+			size += s
+		}
+	}
+
+	return size, nil
+}
+
+// packWithHeader takes a header and a sequence of elements that are either of
+// fixed length or slices of fixed-length types and packs them into a single
+// byte array using binary.Write. It updates the CommandHeader to have the right
+// length.
+func packWithHeader(ch commandHeader, cmd ...interface{}) ([]byte, error) {
+	hdrSize := binary.Size(ch)
+	bodySize, err := packedSize(cmd...)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't compute packed size for message body: %v", err)
+	}
+	ch.Size = uint32(hdrSize + bodySize)
+	in := []interface{}{ch}
+	in = append(in, cmd...)
+	return Pack(in...)
+}
+
+// Pack encodes a set of elements into a single byte array, using
+// encoding/binary. This means that all the elements must be encodeable
+// according to the rules of encoding/binary.
+//
+// It has one difference from encoding/binary: it encodes byte slices with a
+// prepended length, to match how the TPM encodes variable-length arrays. If
+// you wish to add a byte slice without length prefix, use RawBytes.
+func Pack(elts ...interface{}) ([]byte, error) {
+	if lengthPrefixSize == 0 {
+		return nil, errors.New("lengthPrefixSize must be initialized")
+	}
+
+	buf := new(bytes.Buffer)
+	if err := packType(buf, elts...); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// packType recursively packs types the same way that encoding/binary does
+// under binary.BigEndian, but with one difference: it packs a byte slice as a
+// lengthPrefixSize size followed by the bytes. The function unpackType
+// performs the inverse operation of unpacking slices stored in this manner and
+// using encoding/binary for everything else.
+func packType(buf io.Writer, elts ...interface{}) error {
+	for _, e := range elts {
+		v := reflect.ValueOf(e)
+		switch v.Kind() {
+		case reflect.Ptr:
+			if err := packType(buf, reflect.Indirect(v).Interface()); err != nil {
+				return err
+			}
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				if err := packType(buf, v.Field(i).Interface()); err != nil {
+					return err
+				}
+			}
+		case reflect.Slice:
+			switch s := e.(type) {
+			case []byte:
+				switch lengthPrefixSize {
+				case tpm20PrefixSize:
+					if err := binary.Write(buf, binary.BigEndian, uint16(len(s))); err != nil {
+						return err
+					}
+				case tpm12PrefixSize:
+					if err := binary.Write(buf, binary.BigEndian, uint32(len(s))); err != nil {
+						return err
+					}
+				default:
+					return fmt.Errorf("lengthPrefixSize is %d, must be either 2 or 4", lengthPrefixSize)
+				}
+				if err := binary.Write(buf, binary.BigEndian, s); err != nil {
+					return err
+				}
+			case RawBytes:
+				if err := binary.Write(buf, binary.BigEndian, s); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("only []byte and RawBytes slices are supported, got %T", e)
+			}
+		default:
+			if err := binary.Write(buf, binary.BigEndian, e); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// Unpack is a convenience wrapper around UnpackBuf. Unpack returns the number
+// of bytes read from b to fill elts and error, if any.
+func Unpack(b []byte, elts ...interface{}) (int, error) {
+	buf := bytes.NewBuffer(b)
+	err := UnpackBuf(buf, elts...)
+	read := len(b) - buf.Len()
+	return read, err
+}
+
+// UnpackBuf recursively unpacks types from a reader just as encoding/binary
+// does under binary.BigEndian, but with one difference: it unpacks a byte
+// slice by first reading an integer with lengthPrefixSize bytes, then reading
+// that many bytes. It assumes that incoming values are pointers to values so
+// that, e.g., underlying slices can be resized as needed.
+func UnpackBuf(buf io.Reader, elts ...interface{}) error {
+	for _, e := range elts {
+		v := reflect.ValueOf(e)
+		k := v.Kind()
+		if k != reflect.Ptr {
+			return fmt.Errorf("all values passed to Unpack must be pointers, got %v", k)
+		}
+
+		if v.IsNil() {
+			return errors.New("can't fill a nil pointer")
+		}
+
+		iv := reflect.Indirect(v)
+		switch iv.Kind() {
+		case reflect.Struct:
+			// Decompose the struct and copy over the values.
+			for i := 0; i < iv.NumField(); i++ {
+				if err := UnpackBuf(buf, iv.Field(i).Addr().Interface()); err != nil {
+					return err
+				}
+			}
+		case reflect.Slice:
+			var size int
+			_, isHandles := e.(*[]Handle)
+
+			switch {
+			// []Handle always uses 2-byte length, even with TPM 1.2.
+			case isHandles:
+				var tmpSize uint16
+				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
+					return err
+				}
+				size = int(tmpSize)
+			// TPM 2.0
+			case lengthPrefixSize == tpm20PrefixSize:
+				var tmpSize uint16
+				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
+					return err
+				}
+				size = int(tmpSize)
+			// TPM 1.2
+			case lengthPrefixSize == tpm12PrefixSize:
+				var tmpSize uint32
+				if err := binary.Read(buf, binary.BigEndian, &tmpSize); err != nil {
+					return err
+				}
+				size = int(tmpSize)
+			default:
+				return fmt.Errorf("lengthPrefixSize is %d, must be either 2 or 4", lengthPrefixSize)
+			}
+
+			// A zero size is used by the TPM to signal that certain elements
+			// are not present.
+			if size == 0 {
+				continue
+			}
+
+			// Make len(e) match size exactly.
+			switch b := e.(type) {
+			case *[]byte:
+				if len(*b) >= size {
+					*b = (*b)[:size]
+				} else {
+					*b = append(*b, make([]byte, size-len(*b))...)
+				}
+			case *[]Handle:
+				if len(*b) >= size {
+					*b = (*b)[:size]
+				} else {
+					*b = append(*b, make([]Handle, size-len(*b))...)
+				}
+			default:
+				return fmt.Errorf("can't fill pointer to %T, only []byte or []Handle slices", e)
+			}
+
+			if err := binary.Read(buf, binary.BigEndian, e); err != nil {
+				return err
+			}
+		default:
+			if err := binary.Read(buf, binary.BigEndian, e); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}

--- a/vendor/github.com/google/go-tpm/tpmutil/run.go
+++ b/vendor/github.com/google/go-tpm/tpmutil/run.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tpmutil provides common utility functions for both TPM 1.2 and TPM 2.0 devices.
+//
+// Users should call either UseTPM12LengthPrefixSize or
+// UseTPM20LengthPrefixSize before using this package, depending on their type
+// of TPM device.
+package tpmutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+// OpenTPM opens a channel to the TPM at the given path. If the file is a
+// device, then it treats it like a normal TPM device, and if the file is a
+// Unix domain socket, then it opens a connection to the socket.
+func OpenTPM(path string) (io.ReadWriteCloser, error) {
+	// If it's a regular file, then open it
+	var rwc io.ReadWriteCloser
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if fi.Mode()&os.ModeDevice != 0 {
+		var f *os.File
+		f, err = os.OpenFile(path, os.O_RDWR, 0600)
+		if err != nil {
+			return nil, err
+		}
+		rwc = io.ReadWriteCloser(f)
+	} else if fi.Mode()&os.ModeSocket != 0 {
+		uc, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: path, Net: "unix"})
+		if err != nil {
+			return nil, err
+		}
+		rwc = io.ReadWriteCloser(uc)
+	} else {
+		return nil, fmt.Errorf("unsupported TPM file mode %s", fi.Mode().String())
+	}
+
+	return rwc, nil
+}
+
+const maxTPMResponse = 4096
+
+// RunCommand executes cmd with given tag and arguments. Returns TPM response
+// body (without response header) and response code from the header. Returned
+// error may be nil if response code is not RCSuccess; caller should check
+// both.
+func RunCommand(rw io.ReadWriter, tag Tag, cmd Command, in ...interface{}) ([]byte, ResponseCode, error) {
+	if rw == nil {
+		return nil, 0, errors.New("nil TPM handle")
+	}
+
+	ch := commandHeader{tag, 0, cmd}
+	inb, err := packWithHeader(ch, in...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if _, err := rw.Write(inb); err != nil {
+		return nil, 0, err
+	}
+
+	outb := make([]byte, maxTPMResponse)
+	outlen, err := rw.Read(outb)
+	if err != nil {
+		return nil, 0, err
+	}
+	// Resize the buffer to match the amount read from the TPM.
+	outb = outb[:outlen]
+
+	var rh responseHeader
+	read, err := Unpack(outb, &rh)
+	if err != nil {
+		return nil, 0, err
+	}
+	outb = outb[read:]
+
+	if rh.Res != RCSuccess {
+		return nil, rh.Res, nil
+	}
+
+	return outb, rh.Res, nil
+}

--- a/vendor/github.com/google/go-tpm/tpmutil/structures.go
+++ b/vendor/github.com/google/go-tpm/tpmutil/structures.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2018, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpmutil
+
+// RawBytes is for Pack and RunCommand arguments that are already encoded.
+// Compared to []byte, RawBytes will not be prepended with slice length during
+// encoding.
+type RawBytes []byte
+
+// Tag is a command tag.
+type Tag uint16
+
+// Command is an identifier of a TPM command.
+type Command uint32
+
+// A commandHeader is the header for a TPM command.
+type commandHeader struct {
+	Tag  Tag
+	Size uint32
+	Cmd  Command
+}
+
+// ResponseCode is a response code returned by TPM.
+type ResponseCode uint32
+
+// RCSuccess is response code for successful command. Identical for TPM 1.2 and
+// 2.0.
+const RCSuccess ResponseCode = 0x000
+
+// A responseHeader is a header for TPM responses.
+type responseHeader struct {
+	Tag  Tag
+	Size uint32
+	Res  ResponseCode
+}
+
+// A Handle is a reference to a TPM object.
+type Handle uint32

--- a/vendor/k8s.io/client-go/pkg/apis/clientauthentication/types.go
+++ b/vendor/k8s.io/client-go/pkg/apis/clientauthentication/types.go
@@ -58,6 +58,9 @@ type ExecCredentialStatus struct {
 	ExpirationTimestamp *metav1.Time
 	// Token is a bearer token used by the client for request authentication.
 	Token string
+	// PEM-encoded client TLS certificate and key.
+	ClientCertificateData string
+	ClientKeyData         string
 }
 
 // Response defines metadata about a failed request, including HTTP status code and

--- a/vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/types.go
+++ b/vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1/types.go
@@ -52,12 +52,20 @@ type ExecCredentialSpec struct {
 }
 
 // ExecCredentialStatus holds credentials for the transport to use.
+//
+// Token and ClientKeyData are sensitive fields. This data should only be
+// transmitted in-memory between client and exec plugin process. Exec plugin
+// itself should at least be protected via file permissions.
 type ExecCredentialStatus struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	// +optional
 	ExpirationTimestamp *metav1.Time `json:"expirationTimestamp,omitempty"`
 	// Token is a bearer token used by the client for request authentication.
 	Token string `json:"token,omitempty"`
+	// PEM-encoded client TLS certificates (including intermediates, if any).
+	ClientCertificateData string `json:"clientCertificateData,omitempty"`
+	// PEM-encoded private key for the above certificate.
+	ClientKeyData string `json:"clientKeyData,omitempty"`
 }
 
 // Response defines metadata about a failed request, including HTTP status code and

--- a/vendor/k8s.io/client-go/util/certificate/csr/BUILD
+++ b/vendor/k8s.io/client-go/util/certificate/csr/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["csr.go"],
+    importmap = "io_k8s_cloud_provider_gcp/vendor/k8s.io/client-go/util/certificate/csr",
+    importpath = "k8s.io/client-go/util/certificate/csr",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
+    ],
+)

--- a/vendor/k8s.io/client-go/util/certificate/csr/csr.go
+++ b/vendor/k8s.io/client-go/util/certificate/csr/csr.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csr
+
+import (
+	"crypto"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"github.com/golang/glog"
+	"reflect"
+	"time"
+
+	certificates "k8s.io/api/certificates/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+// RequestNodeCertificate will create a certificate signing request for a node
+// (Organization and CommonName for the CSR will be set as expected for node
+// certificates) and send it to API server, then it will watch the object's
+// status, once approved by API server, it will return the API server's issued
+// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
+// will return an error. This is intended for use on nodes (kubelet and
+// kubeadm).
+func RequestNodeCertificate(client certificatesclient.CertificateSigningRequestInterface, privateKeyData []byte, nodeName types.NodeName) (certData []byte, err error) {
+	subject := &pkix.Name{
+		Organization: []string{"system:nodes"},
+		CommonName:   "system:node:" + string(nodeName),
+	}
+
+	privateKey, err := certutil.ParsePrivateKeyPEM(privateKeyData)
+	if err != nil {
+		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
+	}
+	csrData, err := certutil.MakeCSR(privateKey, subject, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
+	}
+
+	usages := []certificates.KeyUsage{
+		certificates.UsageDigitalSignature,
+		certificates.UsageKeyEncipherment,
+		certificates.UsageClientAuth,
+	}
+	name := digestedName(privateKeyData, subject, usages)
+	req, err := RequestCertificate(client, csrData, name, usages, privateKey)
+	if err != nil {
+		return nil, err
+	}
+	return WaitForCertificate(client, req, 3600*time.Second)
+}
+
+// RequestCertificate will either use an existing (if this process has run
+// before but not to completion) or create a certificate signing request using the
+// PEM encoded CSR and send it to API server, then it will watch the object's
+// status, once approved by API server, it will return the API server's issued
+// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
+// will return an error.
+func RequestCertificate(client certificatesclient.CertificateSigningRequestInterface, csrData []byte, name string, usages []certificates.KeyUsage, privateKey interface{}) (req *certificates.CertificateSigningRequest, err error) {
+	csr := &certificates.CertificateSigningRequest{
+		// Username, UID, Groups will be injected by API server.
+		TypeMeta: metav1.TypeMeta{Kind: "CertificateSigningRequest"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: csrData,
+			Usages:  usages,
+		},
+	}
+	if len(csr.Name) == 0 {
+		csr.GenerateName = "csr-"
+	}
+
+	req, err = client.Create(csr)
+	switch {
+	case err == nil:
+	case errors.IsAlreadyExists(err) && len(name) > 0:
+		glog.Infof("csr for this node already exists, reusing")
+		req, err = client.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return nil, formatError("cannot retrieve certificate signing request: %v", err)
+		}
+		if err := ensureCompatible(req, csr, privateKey); err != nil {
+			return nil, fmt.Errorf("retrieved csr is not compatible: %v", err)
+		}
+		glog.Infof("csr for this node is still valid")
+	default:
+		return nil, formatError("cannot create certificate signing request: %v", err)
+	}
+	return req, nil
+}
+
+// WaitForCertificate waits for a certificate to be issued until timeout, or returns an error.
+func WaitForCertificate(client certificatesclient.CertificateSigningRequestInterface, req *certificates.CertificateSigningRequest, timeout time.Duration) (certData []byte, err error) {
+	fieldSelector := fields.OneTermEqualSelector("metadata.name", req.Name).String()
+
+	event, err := cache.ListWatchUntil(
+		timeout,
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.FieldSelector = fieldSelector
+				return client.List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.FieldSelector = fieldSelector
+				return client.Watch(options)
+			},
+		},
+		func(event watch.Event) (bool, error) {
+			switch event.Type {
+			case watch.Modified, watch.Added:
+			case watch.Deleted:
+				return false, fmt.Errorf("csr %q was deleted", req.Name)
+			default:
+				return false, nil
+			}
+			csr := event.Object.(*certificates.CertificateSigningRequest)
+			if csr.UID != req.UID {
+				return false, fmt.Errorf("csr %q changed UIDs", csr.Name)
+			}
+			for _, c := range csr.Status.Conditions {
+				if c.Type == certificates.CertificateDenied {
+					return false, fmt.Errorf("certificate signing request is not approved, reason: %v, message: %v", c.Reason, c.Message)
+				}
+				if c.Type == certificates.CertificateApproved && csr.Status.Certificate != nil {
+					return true, nil
+				}
+			}
+			return false, nil
+		},
+	)
+	if err == wait.ErrWaitTimeout {
+		return nil, wait.ErrWaitTimeout
+	}
+	if err != nil {
+		return nil, formatError("cannot watch on the certificate signing request: %v", err)
+	}
+
+	return event.Object.(*certificates.CertificateSigningRequest).Status.Certificate, nil
+}
+
+// This digest should include all the relevant pieces of the CSR we care about.
+// We can't direcly hash the serialized CSR because of random padding that we
+// regenerate every loop and we include usages which are not contained in the
+// CSR. This needs to be kept up to date as we add new fields to the node
+// certificates and with ensureCompatible.
+func digestedName(privateKeyData []byte, subject *pkix.Name, usages []certificates.KeyUsage) string {
+	hash := sha512.New512_256()
+
+	// Here we make sure two different inputs can't write the same stream
+	// to the hash. This delimiter is not in the base64.URLEncoding
+	// alphabet so there is no way to have spill over collisions. Without
+	// it 'CN:foo,ORG:bar' hashes to the same value as 'CN:foob,ORG:ar'
+	const delimiter = '|'
+	encode := base64.RawURLEncoding.EncodeToString
+
+	write := func(data []byte) {
+		hash.Write([]byte(encode(data)))
+		hash.Write([]byte{delimiter})
+	}
+
+	write(privateKeyData)
+	write([]byte(subject.CommonName))
+	for _, v := range subject.Organization {
+		write([]byte(v))
+	}
+	for _, v := range usages {
+		write([]byte(v))
+	}
+
+	return "node-csr-" + encode(hash.Sum(nil))
+}
+
+// ensureCompatible ensures that a CSR object is compatible with an original CSR
+func ensureCompatible(new, orig *certificates.CertificateSigningRequest, privateKey interface{}) error {
+	newCsr, err := ParseCSR(new)
+	if err != nil {
+		return fmt.Errorf("unable to parse new csr: %v", err)
+	}
+	origCsr, err := ParseCSR(orig)
+	if err != nil {
+		return fmt.Errorf("unable to parse original csr: %v", err)
+	}
+	if !reflect.DeepEqual(newCsr.Subject, origCsr.Subject) {
+		return fmt.Errorf("csr subjects differ: new: %#v, orig: %#v", newCsr.Subject, origCsr.Subject)
+	}
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return fmt.Errorf("privateKey is not a signer")
+	}
+	newCsr.PublicKey = signer.Public()
+	if err := newCsr.CheckSignature(); err != nil {
+		return fmt.Errorf("error validating signature new CSR against old key: %v", err)
+	}
+	if len(new.Status.Certificate) > 0 {
+		certs, err := certutil.ParseCertsPEM(new.Status.Certificate)
+		if err != nil {
+			return fmt.Errorf("error parsing signed certificate for CSR: %v", err)
+		}
+		now := time.Now()
+		for _, cert := range certs {
+			if now.After(cert.NotAfter) {
+				return fmt.Errorf("one of the certificates for the CSR has expired: %s", cert.NotAfter)
+			}
+		}
+	}
+	return nil
+}
+
+// formatError preserves the type of an API message but alters the message. Expects
+// a single argument format string, and returns the wrapped error.
+func formatError(format string, err error) error {
+	if s, ok := err.(errors.APIStatus); ok {
+		se := &errors.StatusError{ErrStatus: s.Status()}
+		se.ErrStatus.Message = fmt.Sprintf(format, se.ErrStatus.Message)
+		return se
+	}
+	return fmt.Errorf(format, err)
+}
+
+// ParseCSR extracts the CSR from the API object and decodes it.
+func ParseCSR(obj *certificates.CertificateSigningRequest) (*x509.CertificateRequest, error) {
+	// extract PEM from request object
+	pemBytes := obj.Spec.Request
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("PEM block type must be CERTIFICATE REQUEST")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return csr, nil
+}


### PR DESCRIPTION
TPM mode bootstraps TLS key/cert using k8s CSR endpoint with TPM
attestation. The key/cert are cached returned instead of a token.

Note: some parts of the implementation are stubbed out temporarily for
testing.