### PR TITLE
Make exec plugin more robust

### DIFF
--- a/cmd/gke-exec-auth-plugin/BUILD
+++ b/cmd/gke-exec-auth-plugin/BUILD
@@ -25,7 +25,6 @@ go_library(
         "//vendor/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate/csr:go_default_library",
     ],
@@ -39,10 +38,14 @@ go_binary(
 
 go_test(
     name = "go_default_test",
-    srcs = ["tpm_test.go"],
+    srcs = [
+        "request_test.go",
+        "tpm_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
         "//vendor/github.com/google/go-tpm/tpmutil:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )

--- a/cmd/gke-exec-auth-plugin/main.go
+++ b/cmd/gke-exec-auth-plugin/main.go
@@ -25,9 +25,8 @@ var (
 	// VMID token flags.
 	audience = flag.String("audience", "", "Audience field of for the VM ID token. Must be a URI.")
 	// TPM flags.
-	cacheDir      = flag.String("cache-dir", "/var/lib/kubelet/pki", "Path to directory to store key and certificate.")
-	bootstrapPath = flag.String("bootstrap-config-path", "/var/lib/kubelet/bootstrap-kubeconfig", "path to bootstrap kubeconfig")
-	tpmPath       = flag.String("tpm-path", "/dev/tpm0", "path to a TPM character device or socket")
+	cacheDir = flag.String("cache-dir", "/var/lib/kubelet/pki", "Path to directory to store key and certificate.")
+	tpmPath  = flag.String("tpm-path", "/dev/tpm0", "path to a TPM character device or socket")
 
 	scheme       = runtime.NewScheme()
 	codecs       = serializer.NewCodecFactory(scheme)
@@ -80,7 +79,7 @@ func writeResponse(token string, key, cert []byte) error {
 	resp := &clientauthentication.ExecCredential{
 		Status: &clientauthentication.ExecCredentialStatus{
 			// Make Kubelet poke us every hour, we'll cache the cert for longer.
-			ExpirationTimestamp: &metav1.Time{time.Now().Add(time.Hour)},
+			ExpirationTimestamp: &metav1.Time{time.Now().Add(responseExpiry)},
 			Token:               token,
 			ClientCertificateData: string(cert),
 			ClientKeyData:         string(key),

--- a/cmd/gke-exec-auth-plugin/request.go
+++ b/cmd/gke-exec-auth-plugin/request.go
@@ -4,41 +4,86 @@ import (
 	"crypto/sha512"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
+	"cloud.google.com/go/compute/metadata"
 	"github.com/golang/glog"
 	apicertificates "k8s.io/api/certificates/v1beta1"
 	certificates "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/certificate/csr"
 )
 
-func loadRESTClientConfig(kubeconfig string) (*rest.Config, error) {
-	// Load structured kubeconfig data from the given path.
-	loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
-	loadedConfig, err := loader.Load()
+const (
+	kubeEnvMetadata = "instance/attributes/kube-env"
+	kubeEnvCert     = "TPM_BOOTSTRAP_CERT: "
+	kubeEnvKey      = "TPM_BOOTSTRAP_KEY: "
+	kubeEnvMaster   = "KUBERNETES_MASTER_NAME: "
+
+	caFilePath = "/etc/srv/kubernetes/pki/ca-certificates.crt"
+)
+
+func requestCertificate(privateKey []byte) ([]byte, error) {
+	kubeEnv, err := metadata.Get(kubeEnvMetadata)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch kube-env: %v", err)
 	}
-	// Flatten the loaded data to a particular rest.Config based on the current context.
-	return clientcmd.NewNonInteractiveClientConfig(
-		*loadedConfig,
-		loadedConfig.CurrentContext,
-		&clientcmd.ConfigOverrides{},
-		loader,
-	).ClientConfig()
+	conf, err := kubeEnvToConfig(kubeEnv)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build REST config from kube-env: %v", err)
+	}
+	client, err := certificates.NewForConfig(conf)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create certificates signing request client: %v", err)
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine hostnamename: %v", err)
+	}
+
+	return processCSR(client.CertificateSigningRequests(), privateKey, hostname)
 }
 
-// requestCertificate will create a certificate signing request for a node
+func kubeEnvToConfig(kubeEnv string) (*rest.Config, error) {
+	// Scan each line looking at prefixes, extract the ones we care about.
+	lines := strings.Split(kubeEnv, "\n")
+	var key, cert, master string
+	for _, l := range lines {
+		switch {
+		case strings.HasPrefix(l, kubeEnvCert):
+			cert = strings.TrimPrefix(l, kubeEnvCert)
+		case strings.HasPrefix(l, kubeEnvKey):
+			key = strings.TrimPrefix(l, kubeEnvKey)
+		case strings.HasPrefix(l, kubeEnvMaster):
+			master = strings.TrimPrefix(l, kubeEnvMaster)
+		}
+	}
+	if key == "" || cert == "" || master == "" {
+		return nil, errors.New("kube-env doesn't have bootstrap credentials or master IP")
+	}
+	return &rest.Config{
+		Host: "https://" + master,
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: []byte(cert),
+			KeyData:  []byte(key),
+			CAFile:   caFilePath,
+		},
+		Timeout: 5 * time.Minute,
+	}, nil
+}
+
+// processCSR will create a certificate signing request for a node
 // (Organization and CommonName for the CSR will be set as expected for node
 // certificates) and send it to API server, then it will watch the object's
 // status, once approved by API server, it will return the API server's issued
 // certificate (pem-encoded). If there is any errors, or the watch timeouts, it
 // will return an error.
-func requestCertificate(client certificates.CertificateSigningRequestInterface, privateKeyData []byte, hostname string) ([]byte, error) {
+func processCSR(client certificates.CertificateSigningRequestInterface, privateKeyData []byte, hostname string) ([]byte, error) {
 	subject := &pkix.Name{
 		Organization: []string{"system:nodes"},
 		CommonName:   "system:node:" + hostname,
@@ -53,9 +98,10 @@ func requestCertificate(client certificates.CertificateSigningRequestInterface, 
 		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
 	}
 	glog.Info("CSR generated")
+
 	tpm, err := openTPM(*tpmPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed opening TPM device: %v", err)
 	}
 	defer tpm.close()
 	attestData, err := tpmAttest(tpm, privateKey)

--- a/cmd/gke-exec-auth-plugin/request_test.go
+++ b/cmd/gke-exec-auth-plugin/request_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestKubeEnvToConfig(t *testing.T) {
+	tests := []struct {
+		desc    string
+		kubeEnv string
+		wantErr bool
+	}{
+		{
+			desc: "success",
+			kubeEnv: `FOO: bar
+TPM_BOOTSTRAP_CERT: fake_cert
+TPM_BOOTSTRAP_KEY: fake_key
+BAZ: qux
+
+  indented line
+KUBERNETES_MASTER_NAME: 1.2.3.4`,
+		},
+		{
+			desc: "no cert",
+			kubeEnv: `TPM_BOOTSTRAP_KEY: fake_key
+KUBERNETES_MASTER_NAME: 1.2.3.4`,
+			wantErr: true,
+		},
+		{
+			desc: "no key",
+			kubeEnv: `TPM_BOOTSTRAP_CERT: fake_cert
+KUBERNETES_MASTER_NAME: 1.2.3.4`,
+			wantErr: true,
+		},
+		{
+			desc: "no master",
+			kubeEnv: `TPM_BOOTSTRAP_CERT: fake_cert
+TPM_BOOTSTRAP_KEY: fake_key`,
+			wantErr: true,
+		},
+		{
+			desc:    "empty",
+			wantErr: true,
+		},
+	}
+	wantConfig := &rest.Config{
+		Host: "https://1.2.3.4",
+		TLSClientConfig: rest.TLSClientConfig{
+			CertData: []byte("fake_cert"),
+			KeyData:  []byte("fake_key"),
+			CAFile:   caFilePath,
+		},
+		Timeout: 5 * time.Minute,
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := kubeEnvToConfig(tt.kubeEnv)
+			switch {
+			case err == nil && tt.wantErr:
+				t.Fatal("got nil error, want non-nil")
+			case err != nil && !tt.wantErr:
+				t.Fatalf("got error %v, want nil", err)
+			case err == nil:
+				if !reflect.DeepEqual(got, wantConfig) {
+					t.Errorf("got config %+v\nwant config %+v", got, wantConfig)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. rotate when cert is >1d old
2. rotate when cert expires in <1hr
3. if rotation fails, use old cert if still valid
4. if TPM attestation fails, use old bootstrap flow