### PR TITLE
Use dedicated clients for informer/approver/signer

### DIFF
--- a/tools/env.sh
+++ b/tools/env.sh
@@ -1,3 +1,3 @@
 DEVEL_REGISTRY="gcr.io" # replace with your registry
 DEVEL_REPO="mikedanese-k8s" # replace with your repo
-CERT_CONTROLLER_VERSION="v1.11.0-r1" # k8s version - controller version
+CERT_CONTROLLER_VERSION="v1.11.0-r3" # k8s version - controller version


### PR DESCRIPTION
This should cut down ~400ms CSR updates due to shared quota