### PR TITLE
Add GCB config for gke-exec-auth-plugin

### DIFF
--- a/cmd/gke-exec-auth-plugin/cloudbuild.yaml
+++ b/cmd/gke-exec-auth-plugin/cloudbuild.yaml
@@ -1,0 +1,13 @@
+steps:
+- name: 'gcr.io/cloud-builders/bazel'
+  args: ['build', '--', '//...', '-//vendor/...']
+- name: 'gcr.io/cloud-builders/bazel'
+  args: ['test', '--test_output=errors', '--', '//...', '-//vendor/...']
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['-m', 'cp', 'bazel-bin/cmd/gke-exec-auth-plugin/linux_amd64_stripped/gke-exec-auth-plugin', 'gs://gke-prod-binaries/gke-exec-auth-plugin/$_PLUGIN_VER/gke-exec-auth-plugin']
+timeout: 1200s
+options:
+  machineType: 'N1_HIGHCPU_8'
+  substitutionOption: 'MUST_MATCH'
+substitutions:
+  _PLUGIN_VER: v0.0.1


### PR DESCRIPTION
Builds, tests and pushes to GCS in a versioned directory. This won't
trigger rebuilds on commit (yet).