### PR TITLE
Check EK cert against root CA

### DIFF
--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -7,6 +7,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "ca_cache.go",
         "controller.go",
         "gke_approver.go",
         "gke_signer.go",
@@ -65,6 +66,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "ca_cache_test.go",
         "gke_approver_test.go",
         "gke_signer_test.go",
         "node_annotater_test.go",

--- a/cmd/gcp-controller-manager/app/ca_cache.go
+++ b/cmd/gcp-controller-manager/app/ca_cache.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// This should (almost) never change. If root key is compromised, rotation
+	// will be a long and painful effort.
+	rootCertURL = "https://pki.goog/cloud_integrity/tpm_ek_root_1.crt"
+	// Intermediate CA URL looks like
+	// http://pki.goog/cloud_integrity/tpm_ek_intermediate_h1_2018.crt.
+	intermediateCAPrefix = "http://pki.goog/cloud_integrity/tpm_ek_intermediate_"
+
+	crlCacheDuration = 10 * time.Minute
+)
+
+type caCache struct {
+	rootCertURL string
+	interPrefix string
+
+	mu    sync.RWMutex
+	certs map[string]*x509.Certificate
+	crls  map[string]*cachedCRL
+}
+
+type cachedCRL struct {
+	crl       *pkix.CertificateList
+	fetchedAt time.Time
+}
+
+// verify checks that cert is signed by the CA and has not been revoked.
+func (c *caCache) verify(cert *x509.Certificate) error {
+	// Check leaf cert issuers against a known intermediate CA prefix.
+	var interCertURL string
+	for _, url := range cert.IssuingCertificateURL {
+		if strings.HasPrefix(url, c.interPrefix) {
+			interCertURL = url
+			break
+		}
+	}
+	if interCertURL == "" {
+		return fmt.Errorf("none of the CAs %q in leaf cert start with %q", cert.IssuingCertificateURL, c.interPrefix)
+	}
+	// Get intermediate and root CA certs.
+	interCert, err := c.getCert(interCertURL)
+	if err != nil {
+		return err
+	}
+	rootCert, err := c.getCert(c.rootCertURL)
+	if err != nil {
+		return err
+	}
+	// Verify leaf cert chain up to root CA.
+	opts := x509.VerifyOptions{
+		Roots:         x509.NewCertPool(),
+		Intermediates: x509.NewCertPool(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+	opts.Roots.AddCert(rootCert)
+	opts.Intermediates.AddCert(interCert)
+	if _, err := cert.Verify(opts); err != nil {
+		return err
+	}
+
+	// Check intermediate and root CRLs for revoked certs.
+	if err := c.checkCRLs(interCert, cert); err != nil {
+		return fmt.Errorf("checking intermediate CA CRL: %v", err)
+	}
+	if err := c.checkCRLs(rootCert, interCert); err != nil {
+		return fmt.Errorf("checking root CA CRL: %v", err)
+	}
+	return nil
+}
+
+// getCert returns cached certificate for given URL or fetches it.
+func (c *caCache) getCert(url string) (*x509.Certificate, error) {
+	// First, check with a read-lock to avoid global locking.
+	c.mu.RLock()
+	crt, ok := c.certs[url]
+	c.mu.RUnlock()
+	if ok {
+		return crt, nil
+	}
+
+	// Not in cache. Grab the global write lock.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Check again to make sure another goroutine didn't fetch this cert before
+	// we got the lock.
+	crt, ok = c.certs[url]
+	if ok {
+		return crt, nil
+	}
+
+	// Fetch and cache the cert.
+	crt, err := fetchCert(url)
+	if err != nil {
+		return nil, err
+	}
+	c.certs[url] = crt
+	return crt, nil
+}
+
+// checkCRLs checks all CRLDistributionPoints in child, making sure child isn't
+// revoked. If child is revoked or CRL isn't signed by parent, return an error.
+func (c *caCache) checkCRLs(parent, child *x509.Certificate) error {
+	if len(child.CRLDistributionPoints) == 0 {
+		return fmt.Errorf("CRLDistributionPoints empty in child certificate")
+	}
+	for _, url := range child.CRLDistributionPoints {
+		crl, err := c.getCRL(url, parent)
+		if err != nil {
+			return err
+		}
+		for _, rc := range crl.TBSCertList.RevokedCertificates {
+			if rc.SerialNumber.Cmp(child.SerialNumber) == 0 {
+				return fmt.Errorf("certificate serial number %s was revoked", child.SerialNumber)
+			}
+		}
+	}
+	return nil
+}
+
+// getCRL returns cached CRL for given URL or fetches it. CRL must be signed by
+// cert. If cached CRL is old, a fresh copy is fetched.
+func (c *caCache) getCRL(url string, cert *x509.Certificate) (*pkix.CertificateList, error) {
+	// See comments in getCert for explanation of locking pattern.
+	//
+	// getCRL also ignores cached CRLs if they are older than the threshold.
+	c.mu.RLock()
+	crl, ok := c.crls[url]
+	c.mu.RUnlock()
+	if ok && time.Since(crl.fetchedAt) < crlCacheDuration {
+		return crl.crl, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	crl, ok = c.crls[url]
+	if ok && time.Since(crl.fetchedAt) < crlCacheDuration {
+		return crl.crl, nil
+	}
+
+	crlRaw, err := fetchCRL(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %q: %v", url, err)
+	}
+	if err := cert.CheckCRLSignature(crlRaw); err != nil {
+		return nil, fmt.Errorf("verifying CRL signature for %q: %v", url, err)
+	}
+	c.crls[url] = &cachedCRL{crl: crlRaw, fetchedAt: time.Now()}
+	return crlRaw, nil
+}
+
+func fetchCert(url string) (*x509.Certificate, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseCertificate(raw)
+}
+
+func fetchCRL(url string) (*pkix.CertificateList, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return x509.ParseDERCRL(raw)
+}

--- a/cmd/gcp-controller-manager/app/ca_cache_test.go
+++ b/cmd/gcp-controller-manager/app/ca_cache_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"testing"
+	"time"
+)
+
+func TestCACacheVerify(t *testing.T) {
+	var ca fakeCA
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		switch path.Base(r.URL.Path) {
+		case "root.crt":
+			rw.Write(ca.rootCert)
+		case "intermediate.crt":
+			rw.Write(ca.intermediateCert)
+		case "self-signed-intermediate.crt":
+			rw.Write(ca.selfSignedIntermediateCert)
+		case "root.crl":
+			rw.Write(ca.rootCRL)
+		case "intermediate.crl":
+			rw.Write(ca.intermediateCRL)
+		case "self-signed-intermediate.crl":
+			rw.Write(ca.selfSignedIntermediateCRL)
+		default:
+			http.Error(rw, "not found", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	ca = initFakeCA(t, srv.URL)
+
+	c := &caCache{
+		rootCertURL: srv.URL + "/root.crt",
+		interPrefix: srv.URL,
+		certs:       make(map[string]*x509.Certificate),
+		crls:        make(map[string]*cachedCRL),
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		if err := c.verify(ca.validCert); err != nil {
+			t.Errorf("verifying valid certificate: got %v, want nil", err)
+		}
+	})
+	if err := c.verify(ca.validCert); err != nil {
+		t.Errorf("verifying valid certificate: got %v, want nil", err)
+	}
+	for desc, invalidCert := range ca.invalidCerts {
+		t.Run(desc, func(t *testing.T) {
+			t.Parallel()
+			if err := c.verify(invalidCert); err == nil {
+				t.Errorf("verifying invalid certificate: got nil, want non-nil error")
+			}
+		})
+	}
+}
+
+type fakeCA struct {
+	rootCert, intermediateCert, selfSignedIntermediateCert []byte
+	rootCRL, intermediateCRL, selfSignedIntermediateCRL    []byte
+	validCert                                              *x509.Certificate
+	invalidCerts                                           map[string]*x509.Certificate
+}
+
+func initFakeCA(t *testing.T, srvURL string) fakeCA {
+	t.Helper()
+	ca := fakeCA{invalidCerts: make(map[string]*x509.Certificate)}
+
+	rootTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:         true,
+		BasicConstraintsValid: true,
+	}
+	rootCertDER, rootCert, rootKey := makeCert(t, rootTmpl, rootTmpl, nil)
+	ca.rootCert = rootCertDER
+	interTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:         true,
+		BasicConstraintsValid: true,
+		CRLDistributionPoints: []string{srvURL + "/root.crl"},
+	}
+	interCertDER, interCert, interKey := makeCert(t, interTmpl, rootCert, rootKey)
+	ca.intermediateCert = interCertDER
+
+	_, ca.validCert, _ = makeCert(t, &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		IssuingCertificateURL: []string{srvURL + "/intermediate.crt"},
+		CRLDistributionPoints: []string{srvURL + "/intermediate.crl"},
+	}, interCert, interKey)
+
+	_, ca.invalidCerts["revoked"], _ = makeCert(t, &x509.Certificate{
+		SerialNumber:          big.NewInt(4),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		IssuingCertificateURL: []string{srvURL + "/intermediate.crt"},
+		CRLDistributionPoints: []string{srvURL + "/intermediate.crl"},
+	}, interCert, interKey)
+	_, ca.invalidCerts["no CRL"], _ = makeCert(t, &x509.Certificate{
+		SerialNumber:          big.NewInt(4),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		IssuingCertificateURL: []string{srvURL + "/intermediate.crt"},
+	}, interCert, interKey)
+	selfSignedTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(99),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	_, ca.invalidCerts["self signed"], _ = makeCert(t, selfSignedTmpl, selfSignedTmpl, nil)
+	_, ca.invalidCerts["wrong intermediate link"], _ = makeCert(t, &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		IssuingCertificateURL: []string{"http://example.com/wrong-intermediate.crt"},
+		CRLDistributionPoints: []string{srvURL + "/intermediate.crl"},
+	}, interCert, interKey)
+
+	selfSignedInterTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:         true,
+		BasicConstraintsValid: true,
+		CRLDistributionPoints: []string{srvURL + "/root.crl"},
+	}
+	selfSignedInterCertDER, selfSignedInterCert, selfSignedInterKey := makeCert(t, selfSignedInterTmpl, selfSignedInterTmpl, nil)
+	ca.selfSignedIntermediateCert = selfSignedInterCertDER
+	wrongInterLeafTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		IssuingCertificateURL: []string{srvURL + "/self-signed-intermediate.crt"},
+		CRLDistributionPoints: []string{srvURL + "/self-signed-intermediate.crl"},
+	}
+	_, ca.invalidCerts["self-signed intermediate"], _ = makeCert(t, wrongInterLeafTmpl, selfSignedInterCert, selfSignedInterKey)
+
+	var err error
+	ca.rootCRL, err = rootCert.CreateCRL(rand.Reader, rootKey, nil, time.Now(), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca.intermediateCRL, err = interCert.CreateCRL(rand.Reader, interKey, []pkix.RevokedCertificate{{
+		SerialNumber:   big.NewInt(4),
+		RevocationTime: time.Now(),
+	}}, time.Now(), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca.selfSignedIntermediateCRL, err = selfSignedInterCert.CreateCRL(rand.Reader, selfSignedInterKey, nil, time.Now(), time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ca
+}
+
+func makeCert(t *testing.T, tmpl, parent *x509.Certificate, parentKey crypto.PrivateKey) ([]byte, *x509.Certificate, crypto.PrivateKey) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parentKey == nil {
+		parentKey = key
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, parent, key.Public(), parentKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return certDER, cert, key
+}


### PR DESCRIPTION
Root CA lives at a well-known URL. Implement a cache in front of it and
refresh every hour.
Check EK certs signature as well as CA CRLs.