### PR TITLE
Rotate kubelet certs after 10 days

### DIFF
--- a/cmd/gke-exec-auth-plugin/cache.go
+++ b/cmd/gke-exec-auth-plugin/cache.go
@@ -21,7 +21,7 @@ const (
 
 	// Minimum age of existing certificate before triggering rotation.
 	// Assuming no rotation errors, this is cert rotation period.
-	rotationThreshold = 24 * time.Hour
+	rotationThreshold = 10 * 24 * time.Hour // 10 days
 	// Caching duration for caller - will exec this plugin after this period.
 	responseExpiry = time.Hour
 )

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -1,3 +1,3 @@
 DEVEL_REGISTRY="gcr.io" # replace with your registry
 DEVEL_REPO="mikedanese-k8s" # replace with your repo
-CERT_CONTROLLER_VERSION="v1.11.0-r4" # k8s version - controller version
+CERT_CONTROLLER_VERSION="v1.11.0-r5" # k8s version - controller version


### PR DESCRIPTION
This was different from approved design:
- kubelet caches for 1h in memory
- exec plugin caches for 10 days on disk
- certs issued for 1yr