### PR TITLE
Refactor gcp-controller-manager startup

### DIFF
--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -11,6 +11,7 @@ go_library(
         "controller.go",
         "gke_approver.go",
         "gke_signer.go",
+        "loops.go",
         "node_annotater.go",
         "options.go",
     ],

--- a/cmd/gcp-controller-manager/app/controller.go
+++ b/cmd/gcp-controller-manager/app/controller.go
@@ -99,7 +99,7 @@ func Run(s *GCPControllerManager) error {
 		},
 		"certificate-signer": func(ctx ControllerContext) error {
 			signerClient := ctx.Client()
-			signer, err := newGKESigner(s.ClusterSigningGKEKubeconfig, s.ClusterSigningGKERetryBackoff.Duration, ctx.Recorder(), signerClient)
+			signer, err := newGKESigner(s.ClusterSigningGKEKubeconfig, ctx.Recorder(), signerClient)
 			if err != nil {
 				return err
 			}

--- a/cmd/gcp-controller-manager/app/controller.go
+++ b/cmd/gcp-controller-manager/app/controller.go
@@ -67,61 +67,86 @@ func Run(s *GCPControllerManager) error {
 		return err
 	}
 
-	kubeClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "gke-certificates-controller"))
+	gcpCfg, err := loadGCPConfig(s)
 	if err != nil {
 		return err
 	}
-
-	approverOpts, err := loadApproverOptions(s)
-	if err != nil {
-		return err
-	}
-
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.Infof)
-	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
-	recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{Component: "gke-certificates-controller"})
 
 	clientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: kubeconfig}
 
-	informerClient := clientBuilder.ClientOrDie("certificate-controller-informer")
+	informerClient := clientBuilder.ClientOrDie("gcp-controller-manager-shared-informer")
 	sharedInformers := informers.NewSharedInformerFactory(informerClient, time.Duration(12)*time.Hour)
 
-	approverClient := clientBuilder.ClientOrDie("certificate-controller-approver")
-	approver := newGKEApprover(approverOpts, approverClient)
-	approveController := certificates.NewCertificateController(
-		approverClient,
-		sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),
-		approver.handle,
-	)
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{
+		Interface: v1core.New(clientBuilder.ClientOrDie("gcp-controller-manager").CoreV1().RESTClient()).Events(""),
+	})
 
-	signerClient := clientBuilder.ClientOrDie("certificate-controller-signer")
-	signer, err := newGKESigner(s.ClusterSigningGKEKubeconfig, s.ClusterSigningGKERetryBackoff.Duration, recorder, signerClient)
-	if err != nil {
-		return err
-	}
-	signController := certificates.NewCertificateController(
-		signerClient,
-		sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),
-		signer.handle,
-	)
+	// We append GCP to all of these to disambiguate them in API server and audit
+	// logs. These loops are intentionally started in a random order.
+	loops := map[string]func(ControllerContext) error{
+		"certificate-approver": func(ctx ControllerContext) error {
+			approverClient := ctx.Client()
+			approver := newGKEApprover(gcpCfg, approverClient)
+			approveController := certificates.NewCertificateController(
+				approverClient,
+				sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),
+				approver.handle,
+			)
+			go approveController.Run(5, ctx.Done())
+			return nil
+		},
+		"certificate-signer": func(ctx ControllerContext) error {
+			signerClient := ctx.Client()
+			signer, err := newGKESigner(s.ClusterSigningGKEKubeconfig, s.ClusterSigningGKERetryBackoff.Duration, ctx.Recorder(), signerClient)
+			if err != nil {
+				return err
+			}
+			signController := certificates.NewCertificateController(
+				signerClient,
+				sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),
+				signer.handle,
+			)
 
-	nodeAnnotaterClient := clientBuilder.ClientOrDie("node-annotater")
-	nodeAnnotateController, err := newNodeAnnotator(
-		nodeAnnotaterClient,
-		sharedInformers.Core().V1().Nodes(),
-		approverOpts.tokenSource,
-	)
-	if err != nil {
-		return err
+			go signController.Run(5, ctx.Done())
+			return nil
+		},
+		"node-annotater": func(ctx ControllerContext) error {
+			nodeAnnotaterClient := ctx.Client()
+			nodeAnnotateController, err := newNodeAnnotator(
+				nodeAnnotaterClient,
+				sharedInformers.Core().V1().Nodes(),
+				gcpCfg.TokenSource,
+			)
+			if err != nil {
+				return err
+			}
+			go nodeAnnotateController.Run(5, ctx.Done())
+			return nil
+		},
 	}
 
 	run := func(stopCh <-chan struct{}) {
 		sharedInformers.Start(stopCh)
-		// controller.Run calls block forever.
-		go approveController.Run(5, stopCh)
-		go signController.Run(5, stopCh)
-		go nodeAnnotateController.Run(5, stopCh)
+		for name, loop := range loops {
+			name = "gcp-" + name
+			loopClient, err := clientBuilder.Client(name)
+			if err != nil {
+				glog.Fatalf("Failed to start client for %q: %v", name, err)
+			}
+			if loop(&simpleCtx{
+				client:          loopClient,
+				sharedInformers: sharedInformers,
+				recorder: eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{
+					Component: name,
+				}),
+				gcpCfg: gcpCfg,
+				stopCh: stopCh,
+			}); err != nil {
+				glog.Fatalf("Failed to start %q: %v", name, err)
+			}
+		}
 		<-stopCh
 	}
 
@@ -130,7 +155,9 @@ func Run(s *GCPControllerManager) error {
 		if err != nil {
 			return err
 		}
-		leaderElectionConfig, err := makeLeaderElectionConfig(s.LeaderElectionConfig, leaderElectionClient, recorder)
+		leaderElectionConfig, err := makeLeaderElectionConfig(s.LeaderElectionConfig, leaderElectionClient, eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{
+			Component: "gcp-controller-manager-leader-election",
+		}))
 		if err != nil {
 			return err
 		}

--- a/cmd/gcp-controller-manager/app/controller.go
+++ b/cmd/gcp-controller-manager/app/controller.go
@@ -85,6 +85,9 @@ func Run(s *GCPControllerManager) error {
 	run := func(stopCh <-chan struct{}) {
 		sharedInformers.Start(stopCh)
 		for name, loop := range loops() {
+			if !s.isEnabled(name) {
+				continue
+			}
 			name = "gcp-" + name
 			loopClient, err := clientBuilder.Client(name)
 			if err != nil {

--- a/cmd/gcp-controller-manager/app/gke_approver.go
+++ b/cmd/gcp-controller-manager/app/gke_approver.go
@@ -410,7 +410,7 @@ func validateTPMAttestation(opts GCPConfig, csr *capi.CertificateSigningRequest,
 		glog.Errorf("Parsing ATTESTATION_CERTIFICATE: %v", err)
 		return false
 	}
-	if err := opts.tpmCACache.verify(aikCert); err != nil {
+	if err := opts.TPMEndorsementCACache.verify(aikCert); err != nil {
 		glog.Errorf("Verifying EK certificate validity: %v", err)
 		return false
 	}

--- a/cmd/gcp-controller-manager/app/gke_signer.go
+++ b/cmd/gcp-controller-manager/app/gke_signer.go
@@ -48,6 +48,8 @@ var (
 	}, []string{"status"})
 )
 
+const ClusterSigningGKERetryBackoff = 500 * time.Millisecond
+
 func init() {
 	prometheus.MustRegister(csrSigningStatus)
 	prometheus.MustRegister(csrSigningLatency)
@@ -64,8 +66,8 @@ type gkeSigner struct {
 }
 
 // newGKESigner will create a new instance of a gkeSigner.
-func newGKESigner(kubeConfigFile string, retryBackoff time.Duration, recorder record.EventRecorder, client clientset.Interface) (*gkeSigner, error) {
-	webhook, err := webhook.NewGenericWebhook(legacyscheme.Scheme, legacyscheme.Codecs, kubeConfigFile, groupVersions, retryBackoff)
+func newGKESigner(kubeConfigFile string, recorder record.EventRecorder, client clientset.Interface) (*gkeSigner, error) {
+	webhook, err := webhook.NewGenericWebhook(legacyscheme.Scheme, legacyscheme.Codecs, kubeConfigFile, groupVersions, ClusterSigningGKERetryBackoff)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +75,7 @@ func newGKESigner(kubeConfigFile string, retryBackoff time.Duration, recorder re
 	return &gkeSigner{
 		webhook:        webhook,
 		kubeConfigFile: kubeConfigFile,
-		retryBackoff:   retryBackoff,
+		retryBackoff:   ClusterSigningGKERetryBackoff,
 		recorder:       recorder,
 		client:         client,
 	}, nil

--- a/cmd/gcp-controller-manager/app/gke_signer_test.go
+++ b/cmd/gcp-controller-manager/app/gke_signer_test.go
@@ -103,7 +103,7 @@ func TestGKESigner(t *testing.T) {
 			t.Fatalf("error closing kubeconfig template: %v", err)
 		}
 
-		signer, err := newGKESigner(kubeConfig.Name(), 0, record.NewFakeRecorder(10), nil)
+		signer, err := newGKESigner(kubeConfig.Name(), time.Duration(0), record.NewFakeRecorder(10), nil)
 		if err != nil {
 			t.Fatalf("error creating GKESigner: %v", err)
 		}

--- a/cmd/gcp-controller-manager/app/gke_signer_test.go
+++ b/cmd/gcp-controller-manager/app/gke_signer_test.go
@@ -103,7 +103,7 @@ func TestGKESigner(t *testing.T) {
 			t.Fatalf("error closing kubeconfig template: %v", err)
 		}
 
-		signer, err := newGKESigner(kubeConfig.Name(), time.Duration(0), record.NewFakeRecorder(10), nil)
+		signer, err := newGKESigner(kubeConfig.Name(), record.NewFakeRecorder(10), nil)
 		if err != nil {
 			t.Fatalf("error creating GKESigner: %v", err)
 		}

--- a/cmd/gcp-controller-manager/app/loops.go
+++ b/cmd/gcp-controller-manager/app/loops.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"sort"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"golang.org/x/oauth2"
+	compute "google.golang.org/api/compute/v1"
+	gcfg "gopkg.in/gcfg.v1"
+	warnings "gopkg.in/warnings.v0"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
+)
+
+type ControllerContext interface {
+	Client() clientset.Interface
+	SharedInformers() informers.SharedInformerFactory
+	Recorder() record.EventRecorder
+	GCP() GCPConfig
+	Done() <-chan struct{}
+}
+
+type simpleCtx struct {
+	client          clientset.Interface
+	sharedInformers informers.SharedInformerFactory
+	recorder        record.EventRecorder
+	gcpCfg          GCPConfig
+	stopCh          <-chan struct{}
+}
+
+func (sc *simpleCtx) Client() clientset.Interface {
+	return sc.client
+}
+
+func (sc *simpleCtx) SharedInformers() informers.SharedInformerFactory {
+	return sc.sharedInformers
+}
+
+func (sc *simpleCtx) Recorder() record.EventRecorder {
+	return sc.recorder
+}
+
+func (sc *simpleCtx) GCP() GCPConfig {
+	return sc.gcpCfg
+}
+
+func (sc *simpleCtx) Done() <-chan struct{} {
+	return sc.stopCh
+}
+
+type GCPConfig struct {
+	ClusterName           string
+	ProjectID             string
+	Zones                 []string
+	TokenSource           oauth2.TokenSource
+	TPMEndorsementCACache *caCache
+}
+
+func loadGCPConfig(s *GCPControllerManager) (GCPConfig, error) {
+	var cfg GCPConfig
+
+	// Load gce.conf.
+	gceConfig := struct {
+		Global struct {
+			ProjectID string `gcfg:"project-id"`
+			TokenURL  string `gcfg:"token-url"`
+			TokenBody string `gcfg:"token-body"`
+		}
+	}{}
+	// ReadFileInfo will return warnings for extra fields in gce.conf we don't
+	// care about. Wrap with FatalOnly to discard those.
+	if err := warnings.FatalOnly(gcfg.ReadFileInto(&gceConfig, s.GCEConfigPath)); err != nil {
+		return cfg, err
+	}
+	cfg.ProjectID = gceConfig.Global.ProjectID
+	// Get the token source for GCE API.
+	cfg.TokenSource = gce.NewAltTokenSource(gceConfig.Global.TokenURL, gceConfig.Global.TokenBody)
+
+	// Get cluster zone from metadata server.
+	zone, err := metadata.Zone()
+	if err != nil {
+		return cfg, err
+	}
+	// Extract region name from zone.
+	if len(zone) < 2 {
+		return cfg, fmt.Errorf("invalid master zone: %q", zone)
+	}
+	region := zone[:len(zone)-2]
+	// Load all zones in the same region.
+	client := oauth2.NewClient(context.Background(), cfg.TokenSource)
+	cs, err := compute.New(client)
+	if err != nil {
+		return cfg, fmt.Errorf("creating GCE API client: %v", err)
+	}
+	allZones, err := compute.NewZonesService(cs).List(cfg.ProjectID).Do()
+	if err != nil {
+		return cfg, err
+	}
+	for _, z := range allZones.Items {
+		if strings.HasPrefix(z.Name, region) {
+			cfg.Zones = append(cfg.Zones, z.Name)
+		}
+	}
+	if len(cfg.Zones) == 0 {
+		return cfg, fmt.Errorf("can't find zones for region %q", region)
+	}
+	// Put master's zone first.
+	sort.Slice(cfg.Zones, func(i, j int) bool { return cfg.Zones[i] == zone })
+
+	cfg.ClusterName, err = metadata.Get("instance/attributes/cluster-name")
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.TPMEndorsementCACache = &caCache{
+		rootCertURL: rootCertURL,
+		interPrefix: intermediateCAPrefix,
+		certs:       make(map[string]*x509.Certificate),
+		crls:        make(map[string]*cachedCRL),
+	}
+
+	return cfg, nil
+}

--- a/cmd/gcp-controller-manager/app/options.go
+++ b/cmd/gcp-controller-manager/app/options.go
@@ -19,6 +19,7 @@ limitations under the License.
 package app
 
 import (
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ func (s *GCPControllerManager) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.StringVar(&s.ClusterSigningGKEKubeconfig, "cluster-signing-gke-kubeconfig", s.ClusterSigningGKEKubeconfig, "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
 	fs.StringVar(&s.GCEConfigPath, "gce-config", s.GCEConfigPath, "Path to gce.conf.")
-	fs.StringSliceVar(&s.Controllers, "controller", s.Controllers, "Controllers to enable.")
+	fs.StringSliceVar(&s.Controllers, "controllers", s.Controllers, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
 	leaderelectionconfig.BindFlags(&s.LeaderElectionConfig, fs)
 }
 

--- a/cmd/gcp-controller-manager/app/options.go
+++ b/cmd/gcp-controller-manager/app/options.go
@@ -31,11 +31,9 @@ import (
 
 // GCPControllerManager is the main context object for the package.
 type GCPControllerManager struct {
-	Kubeconfig                    string
-	ClusterSigningGKEKubeconfig   string
-	ClusterSigningGKERetryBackoff metav1.Duration
-	ApproveAllKubeletCSRsForGroup string
-	GCEConfigPath                 string
+	Kubeconfig                  string
+	ClusterSigningGKEKubeconfig string
+	GCEConfigPath               string
 
 	LeaderElectionConfig componentconfig.LeaderElectionConfiguration
 }
@@ -44,8 +42,7 @@ type GCPControllerManager struct {
 // GKECertificatesController with default parameters.
 func NewGCPControllerManager() *GCPControllerManager {
 	s := &GCPControllerManager{
-		ClusterSigningGKERetryBackoff: metav1.Duration{Duration: 500 * time.Millisecond},
-		GCEConfigPath:                 "/etc/gce.conf",
+		GCEConfigPath: "/etc/gce.conf",
 		LeaderElectionConfig: componentconfig.LeaderElectionConfiguration{
 			LeaderElect:   true,
 			LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
@@ -61,13 +58,7 @@ func NewGCPControllerManager() *GCPControllerManager {
 // specified FlagSet.
 func (s *GCPControllerManager) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-
 	fs.StringVar(&s.ClusterSigningGKEKubeconfig, "cluster-signing-gke-kubeconfig", s.ClusterSigningGKEKubeconfig, "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
-	fs.DurationVar(&s.ClusterSigningGKERetryBackoff.Duration, "cluster-signing-gke-retry-backoff", s.ClusterSigningGKERetryBackoff.Duration, "The initial backoff to use when retrying requests to GKE. Additional attempts will use exponential backoff.")
-
-	fs.StringVar(&s.ApproveAllKubeletCSRsForGroup, "insecure-experimental-approve-all-kubelet-csrs-for-group", s.ApproveAllKubeletCSRsForGroup, "The group for which the controller-manager will auto approve all CSRs for kubelet client certificates.")
-
 	fs.StringVar(&s.GCEConfigPath, "gce-config", s.GCEConfigPath, "Path to gce.conf.")
-
 	leaderelectionconfig.BindFlags(&s.LeaderElectionConfig, fs)
 }


### PR DESCRIPTION
Enables us to start individual controllers. This is required to start only the annotator in GCE.

@kawych 