### PR TITLE
switch owners and reviewers for gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/OWNERS
+++ b/cmd/gcp-controller-manager/OWNERS
@@ -1,8 +1,6 @@
 approvers:
-- pipejakob
 - mikedanese
-- roberthbailey
+- awly
 reviewers:
-- pipejakob
 - mikedanese
-- roberthbailey
+- awly


### PR DESCRIPTION
/assign @awly 