### PR TITLE
Enable node pool check

### DIFF
--- a/cmd/gcp-controller-manager/app/gke_approver_test.go
+++ b/cmd/gcp-controller-manager/app/gke_approver_test.go
@@ -299,7 +299,12 @@ func TestValidators(t *testing.T) {
 		fn := func(opts GCPConfig, csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
 			client, srv := fakeGCPAPI(t)
 			defer srv.Close()
-			err := validateNodeServerCertInner(client, opts, csr, x509cr)
+			cs, err := compute.New(client)
+			if err != nil {
+				t.Fatalf("creating GCE API client: %v", err)
+			}
+			opts.Compute = cs
+			err = validateNodeServerCertInner(opts, csr, x509cr)
 			if err != nil {
 				t.Logf("validateNodeServerCertInner: %v", err)
 			}

--- a/cmd/gcp-controller-manager/app/loops.go
+++ b/cmd/gcp-controller-manager/app/loops.go
@@ -17,21 +17,11 @@ limitations under the License.
 package app
 
 import (
-	"context"
-	"crypto/x509"
-	"fmt"
 	"sort"
-	"strings"
 
-	"cloud.google.com/go/compute/metadata"
-	"golang.org/x/oauth2"
-	compute "google.golang.org/api/compute/v1"
-	gcfg "gopkg.in/gcfg.v1"
-	warnings "gopkg.in/warnings.v0"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/controller/certificates"
 )
 
@@ -42,79 +32,6 @@ type controllerContext struct {
 	gcpCfg                      GCPConfig
 	clusterSigningGKEKubeconfig string
 	done                        <-chan struct{}
-}
-type GCPConfig struct {
-	ClusterName           string
-	ProjectID             string
-	Zones                 []string
-	TokenSource           oauth2.TokenSource
-	TPMEndorsementCACache *caCache
-}
-
-func loadGCPConfig(s *GCPControllerManager) (GCPConfig, error) {
-	var cfg GCPConfig
-
-	// Load gce.conf.
-	gceConfig := struct {
-		Global struct {
-			ProjectID string `gcfg:"project-id"`
-			TokenURL  string `gcfg:"token-url"`
-			TokenBody string `gcfg:"token-body"`
-		}
-	}{}
-	// ReadFileInfo will return warnings for extra fields in gce.conf we don't
-	// care about. Wrap with FatalOnly to discard those.
-	if err := warnings.FatalOnly(gcfg.ReadFileInto(&gceConfig, s.GCEConfigPath)); err != nil {
-		return cfg, err
-	}
-	cfg.ProjectID = gceConfig.Global.ProjectID
-	// Get the token source for GCE API.
-	cfg.TokenSource = gce.NewAltTokenSource(gceConfig.Global.TokenURL, gceConfig.Global.TokenBody)
-
-	// Get cluster zone from metadata server.
-	zone, err := metadata.Zone()
-	if err != nil {
-		return cfg, err
-	}
-	// Extract region name from zone.
-	if len(zone) < 2 {
-		return cfg, fmt.Errorf("invalid master zone: %q", zone)
-	}
-	region := zone[:len(zone)-2]
-	// Load all zones in the same region.
-	client := oauth2.NewClient(context.Background(), cfg.TokenSource)
-	cs, err := compute.New(client)
-	if err != nil {
-		return cfg, fmt.Errorf("creating GCE API client: %v", err)
-	}
-	allZones, err := compute.NewZonesService(cs).List(cfg.ProjectID).Do()
-	if err != nil {
-		return cfg, err
-	}
-	for _, z := range allZones.Items {
-		if strings.HasPrefix(z.Name, region) {
-			cfg.Zones = append(cfg.Zones, z.Name)
-		}
-	}
-	if len(cfg.Zones) == 0 {
-		return cfg, fmt.Errorf("can't find zones for region %q", region)
-	}
-	// Put master's zone first.
-	sort.Slice(cfg.Zones, func(i, j int) bool { return cfg.Zones[i] == zone })
-
-	cfg.ClusterName, err = metadata.Get("instance/attributes/cluster-name")
-	if err != nil {
-		return cfg, err
-	}
-
-	cfg.TPMEndorsementCACache = &caCache{
-		rootCertURL: rootCertURL,
-		interPrefix: intermediateCAPrefix,
-		certs:       make(map[string]*x509.Certificate),
-		crls:        make(map[string]*cachedCRL),
-	}
-
-	return cfg, nil
 }
 
 // loops returns all the control loops that the GCPControllerManager can start.
@@ -150,7 +67,7 @@ func loops() map[string]func(*controllerContext) error {
 			nodeAnnotateController, err := newNodeAnnotator(
 				ctx.client,
 				ctx.sharedInformers.Core().V1().Nodes(),
-				ctx.gcpCfg.TokenSource,
+				ctx.gcpCfg.Compute,
 			)
 			if err != nil {
 				return err

--- a/cmd/gcp-controller-manager/app/node_annotater.go
+++ b/cmd/gcp-controller-manager/app/node_annotater.go
@@ -17,7 +17,6 @@ limitations under the License.
 package app
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -35,7 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/golang/glog"
-	"golang.org/x/oauth2"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -51,13 +49,7 @@ type nodeAnnotator struct {
 	getInstance func(nodeURL string) (*compute.Instance, error)
 }
 
-func newNodeAnnotator(client clientset.Interface, nodeInformer coreinformers.NodeInformer, gts oauth2.TokenSource) (*nodeAnnotator, error) {
-
-	oclient := oauth2.NewClient(context.Background(), gts)
-	cs, err := compute.New(oclient)
-	if err != nil {
-		return nil, fmt.Errorf("creating GCE API client: %v", err)
-	}
+func newNodeAnnotator(client clientset.Interface, nodeInformer coreinformers.NodeInformer, cs *compute.Service) (*nodeAnnotator, error) {
 	gce := compute.NewInstancesService(cs)
 
 	na := &nodeAnnotator{

--- a/cmd/gcp-controller-manager/app/options.go
+++ b/cmd/gcp-controller-manager/app/options.go
@@ -19,23 +19,34 @@ limitations under the License.
 package app
 
 import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"sort"
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"cloud.google.com/go/compute/metadata"
 	"github.com/spf13/pflag"
+	"golang.org/x/oauth2"
+	compute "google.golang.org/api/compute/v1"
+	container "google.golang.org/api/container/v1"
+	gcfg "gopkg.in/gcfg.v1"
+	warnings "gopkg.in/warnings.v0"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	"k8s.io/kubernetes/pkg/client/leaderelectionconfig"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 )
 
 // GCPControllerManager is the main context object for the package.
 type GCPControllerManager struct {
-	Kubeconfig                  string
-	ClusterSigningGKEKubeconfig string
-	GCEConfigPath               string
-	Controllers                 []string
+	Kubeconfig                         string
+	ClusterSigningGKEKubeconfig        string
+	GCEConfigPath                      string
+	Controllers                        []string
+	CSRApproverVerifyClusterMembership bool
 
 	LeaderElectionConfig componentconfig.LeaderElectionConfiguration
 }
@@ -44,8 +55,9 @@ type GCPControllerManager struct {
 // GKECertificatesController with default parameters.
 func NewGCPControllerManager() *GCPControllerManager {
 	s := &GCPControllerManager{
-		GCEConfigPath: "/etc/gce.conf",
-		Controllers:   []string{"*"},
+		GCEConfigPath:                      "/etc/gce.conf",
+		Controllers:                        []string{"*"},
+		CSRApproverVerifyClusterMembership: true,
 		LeaderElectionConfig: componentconfig.LeaderElectionConfiguration{
 			LeaderElect:   true,
 			LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
@@ -64,6 +76,7 @@ func (s *GCPControllerManager) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ClusterSigningGKEKubeconfig, "cluster-signing-gke-kubeconfig", s.ClusterSigningGKEKubeconfig, "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
 	fs.StringVar(&s.GCEConfigPath, "gce-config", s.GCEConfigPath, "Path to gce.conf.")
 	fs.StringSliceVar(&s.Controllers, "controllers", s.Controllers, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
+	fs.BoolVar(&s.CSRApproverVerifyClusterMembership, "csr-validate-cluster-membership", s.CSRApproverVerifyClusterMembership, "Validate that VMs requesting CSRs belong to current GKE cluster.")
 	leaderelectionconfig.BindFlags(&s.LeaderElectionConfig, fs)
 }
 
@@ -81,4 +94,100 @@ func (s *GCPControllerManager) isEnabled(name string) bool {
 		}
 	}
 	return star
+}
+
+// GCPConfig groups GCP-specific configuration for all controllers.
+type GCPConfig struct {
+	ClusterName             string
+	ProjectID               string
+	Zones                   []string
+	TPMEndorsementCACache   *caCache
+	Compute                 *compute.Service
+	Container               *container.Service
+	VerifyClusterMembership bool
+}
+
+func loadGCPConfig(s *GCPControllerManager) (GCPConfig, error) {
+	a := GCPConfig{VerifyClusterMembership: s.CSRApproverVerifyClusterMembership}
+
+	// Load gce.conf.
+	gceConfig := struct {
+		Global struct {
+			ProjectID string `gcfg:"project-id"`
+			TokenURL  string `gcfg:"token-url"`
+			TokenBody string `gcfg:"token-body"`
+		}
+	}{}
+	// ReadFileInfo will return warnings for extra fields in gce.conf we don't
+	// care about. Wrap with FatalOnly to discard those.
+	if err := warnings.FatalOnly(gcfg.ReadFileInto(&gceConfig, s.GCEConfigPath)); err != nil {
+		return a, err
+	}
+	a.ProjectID = gceConfig.Global.ProjectID
+
+	// Get the token source for GCE and GKE APIs.
+	tokenSource := gce.NewAltTokenSource(gceConfig.Global.TokenURL, gceConfig.Global.TokenBody)
+	client := oauth2.NewClient(context.Background(), tokenSource)
+	var err error
+	a.Compute, err = compute.New(client)
+	if err != nil {
+		return a, fmt.Errorf("creating GCE API client: %v", err)
+	}
+	a.Container, err = container.New(client)
+	if err != nil {
+		return a, fmt.Errorf("creating GCE API client: %v", err)
+	}
+
+	// Overwrite GKE API endpoint in case we're not running in prod.
+	gkeAPIEndpoint, err := metadata.Get("instance/attributes/gke-api-endpoint")
+	if err != nil {
+		if _, ok := err.(metadata.NotDefinedError); ok {
+			gkeAPIEndpoint = ""
+		} else {
+			return a, err
+		}
+	}
+	if gkeAPIEndpoint != "" {
+		a.Container.BasePath = gkeAPIEndpoint
+	}
+
+	// Get cluster zone from metadata server.
+	zone, err := metadata.Zone()
+	if err != nil {
+		return a, err
+	}
+	// Extract region name from zone.
+	if len(zone) < 2 {
+		return a, fmt.Errorf("invalid master zone: %q", zone)
+	}
+	region := zone[:len(zone)-2]
+	// Load all zones in the same region.
+	allZones, err := compute.NewZonesService(a.Compute).List(a.ProjectID).Do()
+	if err != nil {
+		return a, err
+	}
+	for _, z := range allZones.Items {
+		if strings.HasPrefix(z.Name, region) {
+			a.Zones = append(a.Zones, z.Name)
+		}
+	}
+	if len(a.Zones) == 0 {
+		return a, fmt.Errorf("can't find zones for region %q", region)
+	}
+	// Put master's zone first.
+	sort.Slice(a.Zones, func(i, j int) bool { return a.Zones[i] == zone })
+
+	a.ClusterName, err = metadata.Get("instance/attributes/cluster-name")
+	if err != nil {
+		return a, err
+	}
+
+	a.TPMEndorsementCACache = &caCache{
+		rootCertURL: rootCertURL,
+		interPrefix: intermediateCAPrefix,
+		certs:       make(map[string]*x509.Certificate),
+		crls:        make(map[string]*cachedCRL),
+	}
+
+	return a, nil
 }


### PR DESCRIPTION
Fix a few bugs found along:

- CN check didn't trim `system:node:` prefix correctly
- `Zone` in VM identity in AIK was full URL instead of just name
- VM identity in AIK failed to parse because asn1 doesn't understand uint64
- exec plugin would create new CSR on each failed run