### PR TITLE
Re-run gazelle and add gazelle-diff command for presubmit

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,3 +11,12 @@ gazelle(
     ],
     prefix = "k8s.io/cloud-provider-gcp",
 )
+
+gazelle(
+    name = "gazelle-diff",
+    extra_args = [
+        "-build_file_name=BUILD",
+        "-mode=diff",
+    ],
+    prefix = "k8s.io/cloud-provider-gcp",
+)

--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -79,6 +79,8 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/nodeidentity:go_default_library",
+        "//pkg/tpmattest:go_default_library",
+        "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",


### PR DESCRIPTION
The build wasn't actually broken.
This probably worked because test's dependencies are merged with package
dependencies when package name matches.

Clean it up and I'll add a presubmit check using gazelle-diff
separately. Existing presubmit will catch failing build/test.