### PR TITLE
Remove self client cert approver

### DIFF
--- a/cmd/gcp-controller-manager/app/gke_approver.go
+++ b/cmd/gcp-controller-manager/app/gke_approver.go
@@ -202,13 +202,6 @@ var validators = []csrValidator{
 		approveMsg:    "Auto approving kubelet client certificate with TPM attestation after SubjectAccessReview.",
 	},
 	{
-		name:          "self kubelet client certificate SubjectAccessReview",
-		authFlowLabel: "kubelet_client_self",
-		recognize:     isSelfNodeClientCert,
-		permission:    authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient"},
-		approveMsg:    "Auto approving self kubelet client certificate after SubjectAccessReview.",
-	},
-	{
 		name:          "kubelet client certificate SubjectAccessReview",
 		authFlowLabel: "kubelet_client_legacy",
 		recognize:     isLegacyNodeClientCert,
@@ -304,13 +297,6 @@ func isLegacyNodeClientCert(opts GCPConfig, csr *capi.CertificateSigningRequest,
 		return false
 	}
 	return csr.Spec.Username == legacyKubeletUsername
-}
-
-func isSelfNodeClientCert(opts GCPConfig, csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
-	if !isNodeClientCert(opts, csr, x509cr) {
-		return false
-	}
-	return csr.Spec.Username == x509cr.Subject.CommonName
 }
 
 func isNodeServerCert(opts GCPConfig, csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {

--- a/cmd/gcp-controller-manager/app/gke_approver_test.go
+++ b/cmd/gcp-controller-manager/app/gke_approver_test.go
@@ -287,20 +287,6 @@ func TestValidators(t *testing.T) {
 		}
 		testValidator(t, "bad", badCases, isLegacyNodeClientCert, false)
 	})
-	t.Run("isSelfNodeClientCert", func(t *testing.T) {
-		goodCase := func(b *csrBuilder, _ *GCPConfig) {}
-		goodCases := []func(*csrBuilder, *GCPConfig){goodCase}
-		testValidator(t, "good", goodCases, isSelfNodeClientCert, true)
-
-		badCases := []func(*csrBuilder, *GCPConfig){
-			func(b *csrBuilder, _ *GCPConfig) { b.requestor = "mike" },
-			func(b *csrBuilder, _ *GCPConfig) { b.orgs = nil },
-			func(b *csrBuilder, _ *GCPConfig) { b.orgs = []string{"system:master"} },
-			func(b *csrBuilder, _ *GCPConfig) { b.usages = kubeletServerUsages },
-			func(b *csrBuilder, _ *GCPConfig) { b.cn = "system:node:bar" },
-		}
-		testValidator(t, "bad", badCases, isSelfNodeClientCert, false)
-	})
 	t.Run("isNodeServerClient", func(t *testing.T) {
 		goodCase := func(b *csrBuilder, _ *GCPConfig) { b.usages = kubeletServerUsages }
 		goodCases := []func(*csrBuilder, *GCPConfig){goodCase}


### PR DESCRIPTION
Cert rotation is not enabled in GKE and we will use a TPM-attested
bootstrap for rotation in the future.