### PR TITLE
Fix typos: direcly -> directly

### DIFF
--- a/cmd/gke-exec-auth-plugin/request.go
+++ b/cmd/gke-exec-auth-plugin/request.go
@@ -135,7 +135,7 @@ func processCSR(client certificates.CertificateSigningRequestInterface, privateK
 }
 
 // This digest should include all the relevant pieces of the CSR we care about.
-// We can't direcly hash the serialized CSR because of random padding that we
+// We can't directly hash the serialized CSR because of random padding that we
 // regenerate every loop and we include usages which are not contained in the
 // CSR. This needs to be kept up to date as we add new fields to the node
 // certificates and with ensureCompatible.


### PR DESCRIPTION
Signed-off-by: mooncake <xcoder@tenxcloud.com>

Fix typos: direcly -> directly