### PR TITLE
ensure Node matches metadata before approving CSRs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,14 +24,14 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "481ab09ce5fb40b57cfa962d211510b47accdd05a8168723da47307ca15d4725",
-    strip_prefix = "rules_docker-452878d665648ada0aaf816931611fdd9c683a97",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/452878d665648ada0aaf816931611fdd9c683a97.tar.gz"],
+    sha256 = "29d109605e0d6f9c892584f07275b8c9260803bf0c6fcb7de2623b2bedc910bd",
+    strip_prefix = "rules_docker-0.5.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.5.1.tar.gz"],
 )
 
 load("@bazel_skylib//:lib.bzl", "versions")
 
-versions.check(minimum_bazel_version = "0.10.0")
+versions.check(minimum_bazel_version = "0.20.0")
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_download_sdk")
 

--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/cmd/gcp-controller-manager/app/gke_approver_test.go
+++ b/cmd/gcp-controller-manager/app/gke_approver_test.go
@@ -39,8 +39,11 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	authorization "k8s.io/api/authorization/v1beta1"
 	capi "k8s.io/api/certificates/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/testing"
 	"k8s.io/cloud-provider-gcp/pkg/nodeidentity"
@@ -125,12 +128,13 @@ func TestHandle(t *testing.T) {
 		}
 	}
 	cases := []struct {
-		desc          string
-		allowed       bool
-		recognized    bool
-		err           bool
-		validate      validateFunc
-		verifyActions func(*testing.T, []testclient.Action)
+		desc           string
+		allowed        bool
+		recognized     bool
+		err            bool
+		validate       validateFunc
+		verifyActions  func(*testing.T, []testclient.Action)
+		preApproveHook preApproveHookFunc
 	}{
 		{
 			desc:       "not recognized not allowed",
@@ -168,6 +172,30 @@ func TestHandle(t *testing.T) {
 			recognized:    true,
 			allowed:       true,
 			verifyActions: verifyCreateAndUpdate,
+		},
+		{
+			desc:          "recognized, allowed and passed preApproveHook",
+			recognized:    true,
+			allowed:       true,
+			verifyActions: verifyCreateAndUpdate,
+			preApproveHook: func(_ GCPConfig, _ *capi.CertificateSigningRequest, _ *x509.CertificateRequest, _ string, _ clientset.Interface) error {
+				return nil
+			},
+		},
+		{
+			desc:       "recognized, allowed but failed preApproveHook",
+			recognized: true,
+			allowed:    true,
+			verifyActions: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 1 {
+					t.Fatalf("expected 1 call but got: %#v", as)
+				}
+				_ = as[0].(testclient.CreateActionImpl)
+			},
+			preApproveHook: func(_ GCPConfig, _ *capi.CertificateSigningRequest, _ *x509.CertificateRequest, _ string, _ clientset.Interface) error {
+				return fmt.Errorf("preApproveHook failed")
+			},
+			err: true,
 		},
 		{
 			desc:       "recognized, allowed and validated",
@@ -238,18 +266,18 @@ func TestHandle(t *testing.T) {
 					},
 				}, nil
 			})
-			approver := gkeApprover{
-				client: client,
-				validators: []csrValidator{
-					{
-						approveMsg: "tester",
-						permission: authorization.ResourceAttributes{Group: "foo", Resource: "bar", Subresource: "baz"},
-						recognize: func(opts GCPConfig, csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
-							return c.recognized
-						},
-						validate: c.validate,
-					},
+			validator := csrValidator{
+				approveMsg: "tester",
+				permission: authorization.ResourceAttributes{Group: "foo", Resource: "bar", Subresource: "baz"},
+				recognize: func(opts GCPConfig, csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+					return c.recognized
 				},
+				validate:       c.validate,
+				preApproveHook: c.preApproveHook,
+			}
+			approver := gkeApprover{
+				client:     client,
+				validators: []csrValidator{validator},
 			}
 			csr := makeTestCSR(t)
 			if err := approver.handle(csr); err != nil && !c.err {
@@ -809,4 +837,142 @@ func makeAttestationDataAndSignature(t *testing.T, csrKey *ecdsa.PrivateKey, aik
 	}
 
 	return attestData, sig
+}
+
+func TestShouldDeleteNode(t *testing.T) {
+	testErr := fmt.Errorf("intended error")
+	cases := []struct {
+		desc           string
+		node           *v1.Node
+		instance       *compute.Instance
+		shouldDelete   bool
+		getInstanceErr error
+		expectedErr    error
+	}{
+		{
+			desc: "instance with 1 alias range and matches podCIDR",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			instance: &compute.Instance{
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						AliasIpRanges: []*compute.AliasIpRange{
+							{
+								IpCidrRange: "10.0.0.1/24",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "instance with 1 alias range doesn't match podCIDR",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			instance: &compute.Instance{
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						AliasIpRanges: []*compute.AliasIpRange{
+							{
+								IpCidrRange: "10.0.0.2/24",
+							},
+						},
+					},
+				},
+			},
+			shouldDelete: true,
+		},
+		{
+			desc: "instance with 2 alias range and 1 matches podCIDR",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			instance: &compute.Instance{
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						AliasIpRanges: []*compute.AliasIpRange{
+							{
+								IpCidrRange: "10.0.0.2/24",
+							},
+							{
+								IpCidrRange: "10.0.0.1/24",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "instance with 0 alias range",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			instance: &compute.Instance{},
+		},
+		{
+			desc: "node with empty podCIDR",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+			},
+		},
+		{
+			desc: "instance not found",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			shouldDelete:   true,
+			getInstanceErr: instanceNotFound,
+		},
+		{
+			desc: "error gettting instance",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node-test",
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "10.0.0.1/24",
+				},
+			},
+			getInstanceErr: testErr,
+			expectedErr:    testErr,
+		},
+	}
+	for _, c := range cases {
+		fakeGetInstance := func(_ GCPConfig, _ string) (*compute.Instance, error) {
+			return c.instance, c.getInstanceErr
+		}
+		shouldDelete, err := shouldDeleteNode(GCPConfig{}, c.node, fakeGetInstance)
+		if err != c.expectedErr || shouldDelete != c.shouldDelete {
+			t.Errorf("%s: shouldDeleteNode=(%v, %v), want (%v, %v)", c.desc, shouldDelete, err, c.shouldDelete, c.expectedErr)
+		}
+	}
 }


### PR DESCRIPTION
Before approving a client certificate request from a node, ensure any existing Node API object still matches information from metadata, and isn't a vestigial Node object that should be deleted before giving the new one API credentials

Best reviewed split without whitespace: https://github.com/kubernetes/cloud-provider-gcp/pull/63/files?utf8=%E2%9C%93&diff=split&w=1