### PR TITLE
add an alt token source mode to the exec plugin

### DIFF
--- a/cmd/gke-exec-auth-plugin/BUILD
+++ b/cmd/gke-exec-auth-plugin/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "alt_token_source.go",
         "cache.go",
         "main.go",
         "request.go",
@@ -16,6 +17,9 @@ go_library(
         "//vendor/cloud.google.com/go/compute/metadata:go_default_library",
         "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
         "//vendor/github.com/google/go-tpm/tpmutil:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+        "//vendor/golang.org/x/oauth2/google:go_default_library",
+        "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/cmd/gke-exec-auth-plugin/alt_token_source.go
+++ b/cmd/gke-exec-auth-plugin/alt_token_source.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/googleapi"
+)
+
+// altTokenSource is the structure holding the data for the functionality needed to generates tokens
+type altTokenSource struct {
+	oauthClient *http.Client
+	tokenURL    string
+	tokenBody   string
+}
+
+// Token returns a token which may be used for authentication
+func (a *altTokenSource) Token() (*oauth2.Token, error) {
+	req, err := http.NewRequest("POST", a.tokenURL, strings.NewReader(a.tokenBody))
+	if err != nil {
+		return nil, err
+	}
+	res, err := a.oauthClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var tok struct {
+		AccessToken string    `json:"accessToken"`
+		ExpireTime  time.Time `json:"expireTime"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&tok); err != nil {
+		return nil, err
+	}
+	return &oauth2.Token{
+		AccessToken: tok.AccessToken,
+		Expiry:      tok.ExpireTime,
+	}, nil
+}
+
+// newAltTokenSource constructs a new alternate token source for generating tokens.
+func newAltTokenSource(tokenURL, tokenBody string) oauth2.TokenSource {
+	return &altTokenSource{
+		oauthClient: oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource("")),
+		tokenURL:    tokenURL,
+		tokenBody:   tokenBody,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,8 +95,8 @@ golang.org/x/net/idna
 golang.org/x/net/context
 # golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c
 golang.org/x/oauth2
-golang.org/x/oauth2/internal
 golang.org/x/oauth2/google
+golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20190124100055-b90733256f2e
@@ -119,12 +119,12 @@ google.golang.org/api/googleapi/internal/uritemplates
 google.golang.org/api/compute/v0.alpha
 google.golang.org/api/tpu/v1
 # google.golang.org/appengine v1.4.0
-google.golang.org/appengine/urlfetch
 google.golang.org/appengine
+google.golang.org/appengine/urlfetch
 google.golang.org/appengine/internal
-google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/internal/app_identity
 google.golang.org/appengine/internal/modules
+google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/datastore
 google.golang.org/appengine/internal/log


### PR DESCRIPTION
alt_token_source.go is copied and trimmed from the gce cloud provider
which cuts out 25M in binary size.