### PR TITLE
Moved pantheon metrics to their own file and fixed various go-lint errors

### DIFF
--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -12,6 +12,7 @@ go_library(
         "gke_approver.go",
         "gke_signer.go",
         "loops.go",
+        "metrics.go",
         "node_annotater.go",
         "options.go",
     ],

--- a/cmd/gcp-controller-manager/app/controller.go
+++ b/cmd/gcp-controller-manager/app/controller.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiserverconfig "k8s.io/apiserver/pkg/apis/config"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Register GCP auth provider plugin.
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"

--- a/cmd/gcp-controller-manager/app/gke_approver_test.go
+++ b/cmd/gcp-controller-manager/app/gke_approver_test.go
@@ -39,7 +39,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	authorization "k8s.io/api/authorization/v1beta1"
 	capi "k8s.io/api/certificates/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -936,7 +936,7 @@ func TestShouldDeleteNode(t *testing.T) {
 				},
 			},
 			shouldDelete:   true,
-			getInstanceErr: instanceNotFound,
+			getInstanceErr: errInstanceNotFound,
 		},
 		{
 			desc: "error gettting instance",

--- a/cmd/gcp-controller-manager/app/gke_signer.go
+++ b/cmd/gcp-controller-manager/app/gke_signer.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
+	_ "k8s.io/kubernetes/pkg/apis/certificates/install" // Install certificates API group.
 	"k8s.io/kubernetes/pkg/controller/certificates"
 )
 
@@ -48,6 +48,7 @@ var (
 	}, []string{"status"})
 )
 
+// ClusterSigningGKERetryBackoff is the backoff between GKE cluster signing retries.
 const ClusterSigningGKERetryBackoff = 500 * time.Millisecond
 
 func init() {
@@ -125,14 +126,14 @@ func (s *gkeSigner) sign(csr *capi.CertificateSigningRequest) (*capi.Certificate
 		return nil, s.webhookError(csr, fmt.Errorf("received unsuccessful response code from webhook: %d", statusCode))
 	}
 
-	result_csr := &capi.CertificateSigningRequest{}
+	resultCSR := &capi.CertificateSigningRequest{}
 
-	if err := result.Into(result_csr); err != nil {
-		return nil, s.webhookError(result_csr, err)
+	if err := result.Into(resultCSR); err != nil {
+		return nil, s.webhookError(resultCSR, err)
 	}
 
 	// Keep the original CSR intact, and only update fields we expect to change.
-	csr.Status.Certificate = result_csr.Status.Certificate
+	csr.Status.Certificate = resultCSR.Status.Certificate
 	return csr, nil
 }
 

--- a/cmd/gcp-controller-manager/app/metrics.go
+++ b/cmd/gcp-controller-manager/app/metrics.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/gcp-controller-manager/app/metrics.go
+++ b/cmd/gcp-controller-manager/app/metrics.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	csrApprovalStatus = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "csr_approval_count",
+		Help: "Count of approved, denied and ignored CSRs",
+	}, []string{"status", "kind"})
+	csrApprovalLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "csr_approval_latencies",
+		Help: "Latency of CSR approver, in seconds",
+	}, []string{"status", "kind"})
+)
+
+func init() {
+	prometheus.MustRegister(csrApprovalStatus)
+	prometheus.MustRegister(csrApprovalLatency)
+}

--- a/cmd/gcp-controller-manager/app/node_annotater.go
+++ b/cmd/gcp-controller-manager/app/node_annotater.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/klog"
 )
 
+// InstanceIDAnnotationKey is the node annotation key where the external ID is written.
 const InstanceIDAnnotationKey = "container.googleapis.com/instance_id"
 
 var errNoMetadata = fmt.Errorf("instance did not have 'kube-labels' metadata")


### PR DESCRIPTION
Moved metrics from `gke_approver.go` to new `metrics.go`.

Fixed a bunch of go-lint errors. 

Cleanup in anticipation of plumbing additional metrics 