### PR TITLE
Use cluster's location when fetching from GKE API

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ git_repository(
 
 git_repository(
     name = "io_k8s_repo_infra",
-    commit = "9ddd2bf9f38fdcb24709aaa84561de19f0a75cab",
+    commit = "df02ded38f9506e5bbcbf21702034b4fef815f2f",
     remote = "https://github.com/kubernetes/repo-infra.git",
 )
 

--- a/cmd/gcp-controller-manager/app/BUILD
+++ b/cmd/gcp-controller-manager/app/BUILD
@@ -86,6 +86,7 @@ go_test(
         "//vendor/github.com/google/go-tpm/tpm2:go_default_library",
         "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
+        "//vendor/google.golang.org/api/container/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -96,6 +97,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/apis/certificates/v1beta1:go_default_library",
     ],
 )

--- a/cmd/gcp-controller-manager/app/options.go
+++ b/cmd/gcp-controller-manager/app/options.go
@@ -102,6 +102,7 @@ func (s *GCPControllerManager) isEnabled(name string) bool {
 type GCPConfig struct {
 	ClusterName             string
 	ProjectID               string
+	Location                string
 	Zones                   []string
 	TPMEndorsementCACache   *caCache
 	Compute                 *compute.Service
@@ -167,12 +168,12 @@ func loadGCPConfig(s *GCPControllerManager) (GCPConfig, error) {
 	}
 
 	// Get cluster zone from metadata server.
-	zone, err := metadata.Zone()
+	a.Location, err = metadata.Get("instance/attributes/cluster-location")
 	if err != nil {
 		return a, err
 	}
 	// Extract region name from zone.
-	region, err := getRegionFromZone(zone)
+	region, err := getRegionFromZone(a.Location)
 	if err != nil {
 		return a, err
 	}
@@ -191,7 +192,7 @@ func loadGCPConfig(s *GCPControllerManager) (GCPConfig, error) {
 		return a, fmt.Errorf("can't find zones for region %q", region)
 	}
 	// Put master's zone first.
-	sort.Slice(a.Zones, func(i, j int) bool { return a.Zones[i] == zone })
+	sort.Slice(a.Zones, func(i, j int) bool { return a.Zones[i] == a.Location })
 
 	a.ClusterName, err = metadata.Get("instance/attributes/cluster-name")
 	if err != nil {


### PR DESCRIPTION
Instances are not guaranteed to be in cluster master's zone:
- in regional clusters
- in regional NodePools

Also handle the case of regional NodePools when checking Node
membership.

Add tests to cover some common cases.

This fix only applies to vTPM attestation validator.