### PR TITLE
Fix startup and CSRs for regional clusters

### DIFF
--- a/cmd/gcp-controller-manager/app/gke_approver.go
+++ b/cmd/gcp-controller-manager/app/gke_approver.go
@@ -558,8 +558,9 @@ func clusterHasInstance(opts GCPConfig, instanceZone string, instanceID uint64) 
 	// Convert it to just "us-central1-c".
 	instanceZone = path.Base(instanceZone)
 
-	recordMetric := csrmetrics.OutboundRPCStartRecorder("container.ProjectsZonesClustersService.Get")
-	cluster, err := container.NewProjectsZonesClustersService(opts.Container).Get(opts.ProjectID, opts.Location, opts.ClusterName).Do()
+	clusterName := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", opts.ProjectID, opts.Location, opts.ClusterName)
+	recordMetric := csrmetrics.OutboundRPCStartRecorder("container.ProjectsLocationsClustersService.Get")
+	cluster, err := container.NewProjectsLocationsClustersService(opts.Container).Get(clusterName).Do()
 	if err != nil {
 		recordMetric(csrmetrics.OutboundRPCStatusError)
 		return false, fmt.Errorf("fetching cluster info: %v", err)

--- a/cmd/gcp-controller-manager/app/gke_approver_test.go
+++ b/cmd/gcp-controller-manager/app/gke_approver_test.go
@@ -877,7 +877,7 @@ func fakeGKEAPI(t *testing.T) (*http.Client, *httptest.Server) {
 	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		t.Logf("fakeGKEAPI request %q", req.URL.Path)
 		switch req.URL.Path {
-		case "/v1/projects/p0/zones/z0/clusters/c0":
+		case "/v1/projects/p0/locations/z0/clusters/c0":
 			json.NewEncoder(rw).Encode(container.Cluster{
 				Name: "c0",
 				NodePools: []*container.NodePool{
@@ -885,14 +885,14 @@ func fakeGKEAPI(t *testing.T) (*http.Client, *httptest.Server) {
 					{InstanceGroupUrls: []string{"https://www.googleapis.com/compute/v1/projects/2/zones/z0/instanceGroupManagers/ig0"}},
 				},
 			})
-		case "/v1/projects/p0/zones/z0/clusters/c1":
+		case "/v1/projects/p0/locations/z0/clusters/c1":
 			json.NewEncoder(rw).Encode(container.Cluster{
 				Name: "c1",
 				NodePools: []*container.NodePool{
 					{InstanceGroupUrls: []string{"https://www.googleapis.com/compute/v1/projects/2/zones/z0/instanceGroupManagers/ig1"}},
 				},
 			})
-		case "/v1/projects/p0/zones/z0/clusters/c2":
+		case "/v1/projects/p0/locations/z0/clusters/c2":
 			json.NewEncoder(rw).Encode(container.Cluster{
 				Name: "c2",
 				NodePools: []*container.NodePool{

--- a/cmd/gcp-controller-manager/app/options_test.go
+++ b/cmd/gcp-controller-manager/app/options_test.go
@@ -22,37 +22,44 @@ import (
 	"testing"
 )
 
-func TestGetRegionFromZone(t *testing.T) {
-	var testcases = []struct {
-		zone         string
+func TestGetRegionFromLocation(t *testing.T) {
+	testCases := []struct {
+		location     string
 		expectRegion string
 		shouldError  bool
 	}{
 		{
-			zone:         "us-central1-f",
+			location:     "us-central1-f",
 			expectRegion: "us-central1",
 		},
 		{
-			zone:         "us-central1-foobar",
+			location:     "us-central1-foobar",
 			expectRegion: "us-central1",
 		},
 		{
-			zone:        "invalid-input",
+			location:     "us-central1",
+			expectRegion: "us-central1",
+		},
+		{
+			location:    "invalid input",
+			shouldError: true,
+		},
+		{
+			location:    "",
 			shouldError: true,
 		},
 	}
 
-	for _, tc := range testcases {
-		region, err := getRegionFromZone(tc.zone)
+	for _, tc := range testCases {
+		region, err := getRegionFromLocation(tc.location)
 
 		hasError := err != nil
 		if hasError != tc.shouldError {
-			t.Errorf("Zone %s: expect error %v, got error %v", tc.zone, tc.shouldError, err)
-			continue
+			t.Errorf("getRegionFromLocation(%q): expect error %v, got error %q", tc.location, tc.shouldError, err)
 		}
 
-		if err == nil && tc.expectRegion != region {
-			t.Errorf("Zone %s: expect to get region %s, got region %s", tc.zone, tc.expectRegion, region)
+		if tc.expectRegion != region {
+			t.Errorf("getRegionFromLocation(%q): expect to get region %q, got region %q", tc.location, tc.expectRegion, region)
 		}
 	}
 }


### PR DESCRIPTION
Startup was failing because of option parsing code assuming cluster-location metadata being a zone.
CSR approval was failing because we were fetching cluster object from API by zone instead of location.