### PR TITLE
Moved lockfile from os's tmp to cache dir.

### DIFF
--- a/cmd/gke-exec-auth-plugin/main.go
+++ b/cmd/gke-exec-auth-plugin/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -74,7 +73,7 @@ func main() {
 	case modeTPM:
 		// Lock around certificate reading and CSRs. Prevents parallel
 		// invocations creating duplicate CSRs if there is no cert yet.
-		fileLock := flock.New(filepath.Join(os.TempDir(), flockName))
+		fileLock := flock.New(filepath.Join(*cacheDir, flockName))
 		if err = fileLock.Lock(); err != nil {
 			klog.Exit(err)
 		}

--- a/cmd/gke-exec-auth-plugin/main.go
+++ b/cmd/gke-exec-auth-plugin/main.go
@@ -22,7 +22,7 @@ const (
 	modeTPM      = "tpm"
 	modeVMID     = "vmid"
 	modeAltToken = "alt-token"
-	flockName    = "gke-exec-auth-plugin.lock"
+	flockName    = "kubelet-client.lock"
 )
 
 var (


### PR DESCRIPTION
Since the binaries will be run in their own containers `os.TempDir()` likely means different things on disk in each container so the lock will not work. Moved the lockfile dir to the cache dir which is a folder mounted/shared between containers.