### PR TITLE
Add a flag to disable legacy kubelet bootstrap

### DIFF
--- a/cmd/gcp-controller-manager/app/controller.go
+++ b/cmd/gcp-controller-manager/app/controller.go
@@ -103,9 +103,10 @@ func Run(s *GCPControllerManager) error {
 				recorder: eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{
 					Component: name,
 				}),
-				gcpCfg:                      gcpCfg,
-				clusterSigningGKEKubeconfig: s.ClusterSigningGKEKubeconfig,
-				done:                        ctx.Done(),
+				gcpCfg:                             gcpCfg,
+				clusterSigningGKEKubeconfig:        s.ClusterSigningGKEKubeconfig,
+				csrApproverVerifyClusterMembership: s.CSRApproverVerifyClusterMembership,
+				done:                               ctx.Done(),
 			}); err != nil {
 				klog.Fatalf("Failed to start %q: %v", name, err)
 			}

--- a/cmd/gcp-controller-manager/app/loops.go
+++ b/cmd/gcp-controller-manager/app/loops.go
@@ -26,12 +26,13 @@ import (
 )
 
 type controllerContext struct {
-	client                      clientset.Interface
-	sharedInformers             informers.SharedInformerFactory
-	recorder                    record.EventRecorder
-	gcpCfg                      GCPConfig
-	clusterSigningGKEKubeconfig string
-	done                        <-chan struct{}
+	client                             clientset.Interface
+	sharedInformers                    informers.SharedInformerFactory
+	recorder                           record.EventRecorder
+	gcpCfg                             GCPConfig
+	clusterSigningGKEKubeconfig        string
+	csrApproverVerifyClusterMembership bool
+	done                               <-chan struct{}
 }
 
 // loops returns all the control loops that the GCPControllerManager can start.
@@ -40,7 +41,7 @@ type controllerContext struct {
 func loops() map[string]func(*controllerContext) error {
 	return map[string]func(*controllerContext) error{
 		"certificate-approver": func(ctx *controllerContext) error {
-			approver := newGKEApprover(ctx.gcpCfg, ctx.client)
+			approver := newGKEApprover(ctx.gcpCfg, ctx.client, ctx.csrApproverVerifyClusterMembership)
 			approveController := certificates.NewCertificateController(
 				ctx.client,
 				ctx.sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),

--- a/cmd/gcp-controller-manager/app/options.go
+++ b/cmd/gcp-controller-manager/app/options.go
@@ -49,6 +49,7 @@ type GCPControllerManager struct {
 	GCEConfigPath                      string
 	Controllers                        []string
 	CSRApproverVerifyClusterMembership bool
+	CSRApproverAllowLegacyKubelet      bool
 
 	LeaderElectionConfig componentbaseconfig.LeaderElectionConfiguration
 }
@@ -60,6 +61,7 @@ func NewGCPControllerManager() *GCPControllerManager {
 		GCEConfigPath:                      "/etc/gce.conf",
 		Controllers:                        []string{"*"},
 		CSRApproverVerifyClusterMembership: true,
+		CSRApproverAllowLegacyKubelet:      true,
 		LeaderElectionConfig: componentbaseconfig.LeaderElectionConfiguration{
 			LeaderElect:   true,
 			LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
@@ -79,6 +81,7 @@ func (s *GCPControllerManager) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.GCEConfigPath, "gce-config", s.GCEConfigPath, "Path to gce.conf.")
 	fs.StringSliceVar(&s.Controllers, "controllers", s.Controllers, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
 	fs.BoolVar(&s.CSRApproverVerifyClusterMembership, "csr-validate-cluster-membership", s.CSRApproverVerifyClusterMembership, "Validate that VMs requesting CSRs belong to current GKE cluster.")
+	fs.BoolVar(&s.CSRApproverAllowLegacyKubelet, "csr-allow-legacy-kubelet", s.CSRApproverAllowLegacyKubelet, "Allow legacy kubelet bootstrap flow.")
 	leaderelectionconfig.BindFlags(&s.LeaderElectionConfig, fs)
 }
 


### PR DESCRIPTION
When TPM-backed bootstrap is enabled in cluster, prevent old bootstrap
flow to ensure only compliant nodes are allowed.