### PR TITLE
Disabled dynamic linking of gke-exec-auth-plugin binary.

### DIFF
--- a/cmd/gke-exec-auth-plugin/BUILD
+++ b/cmd/gke-exec-auth-plugin/BUILD
@@ -39,6 +39,7 @@ go_library(
 
 go_binary(
     name = "gke-exec-auth-plugin",
+    pure = "on",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
By default the binary dynamically links to libraries such as `glibc`. This would prevent `gke-exec-auth-plugin` from running in containers where this library is not present.

The build rule `pure = "on"` builds the binary with complete static linking of required libraries.