### PR TITLE
Allow override GCE Endpoint in gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/gcp_config.go
+++ b/cmd/gcp-controller-manager/gcp_config.go
@@ -59,7 +59,7 @@ func getRegionFromLocation(loc string) (string, error) {
 	}
 }
 
-func loadGCPConfig(gceConfigPath string) (gcpConfig, error) {
+func loadGCPConfig(gceConfigPath, gceAPIEndpointOverride string) (gcpConfig, error) {
 	a := gcpConfig{}
 
 	// Load gce.conf.
@@ -85,9 +85,15 @@ func loadGCPConfig(gceConfigPath string) (gcpConfig, error) {
 	if err != nil {
 		return a, fmt.Errorf("creating GCE API client: %v", err)
 	}
+	if gceAPIEndpointOverride != "" {
+		a.Compute.BasePath = gceAPIEndpointOverride
+	}
 	a.BetaCompute, err = betacompute.New(client)
 	if err != nil {
 		return a, fmt.Errorf("creating GCE Beta API client: %v", err)
+	}
+	if gceAPIEndpointOverride != "" {
+		a.BetaCompute.BasePath = strings.Replace(gceAPIEndpointOverride, "v1", "beta", -1)
 	}
 	a.Container, err = container.New(client)
 	if err != nil {

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -63,6 +63,7 @@ var (
 	controllers                        = pflag.StringSlice("controllers", []string{"*"}, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
 	csrApproverVerifyClusterMembership = pflag.Bool("csr-validate-cluster-membership", true, "Validate that VMs requesting CSRs belong to current GKE cluster.")
 	csrApproverAllowLegacyKubelet      = pflag.Bool("csr-allow-legacy-kubelet", true, "Allow legacy kubelet bootstrap flow.")
+	gceAPIEndpointOverride             = pflag.String("gce-api-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/projects/")
 )
 
 func main() {
@@ -85,6 +86,7 @@ func main() {
 	s := &controllerManager{
 		clusterSigningGKEKubeconfig:        *clusterSigningGKEKubeconfig,
 		gceConfigPath:                      *gceConfigPath,
+		gceAPIEndpointOverride:             *gceAPIEndpointOverride,
 		controllers:                        *controllers,
 		csrApproverVerifyClusterMembership: *csrApproverVerifyClusterMembership,
 		csrApproverAllowLegacyKubelet:      *csrApproverAllowLegacyKubelet,
@@ -99,7 +101,7 @@ func main() {
 	s.kubeconfig.QPS = 100
 	s.kubeconfig.Burst = 200
 
-	s.gcpConfig, err = loadGCPConfig(s.gceConfigPath)
+	s.gcpConfig, err = loadGCPConfig(s.gceConfigPath, s.gceAPIEndpointOverride)
 	if err != nil {
 		klog.Exitf("failed loading GCP config: %v", err)
 	}
@@ -120,6 +122,7 @@ type controllerManager struct {
 	// Fields initialized from flags.
 	clusterSigningGKEKubeconfig        string
 	gceConfigPath                      string
+	gceAPIEndpointOverride             string
 	controllers                        []string
 	csrApproverVerifyClusterMembership bool
 	csrApproverAllowLegacyKubelet      bool


### PR DESCRIPTION
Carrying over from https://github.com/kubernetes/kubernetes/blob/8765fa2e48974e005ad16e65cb5c3acf5acff17b/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L421-L429

Need this to access other zones, currently hitting
```
node_annotater.go:201] Sync [node-name] failed with: googleapi: Error 400: Invalid value for field 'zone': '****'. Unknown zone., invalid
```

/assign @awly 