### PR TITLE
Fix klog flag set

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -67,9 +67,9 @@ var (
 )
 
 func main() {
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	klog.InitFlags(flag.CommandLine)
 	defer klog.Flush()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	leConfig := &componentbaseconfig.LeaderElectionConfiguration{
 		LeaderElect:   true,


### PR DESCRIPTION
Adding flag.FlagSet to pflag.FlagSet should only be done after we add
everything to the stdlib FlagSet.
Any flags we add afterwards don't reflect in pflag's FlagSet.
This makes the process fail at startup when any klog-related flags are
passed in.