### PR TITLE
merge_licenses.sh: Include own LICENSE

### DIFF
--- a/tools/merge_licenses.sh
+++ b/tools/merge_licenses.sh
@@ -5,15 +5,28 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-output_path=${BUILD_WORKING_DIRECTORY}/MERGED_LICENSES
+output_path="${BUILD_WORKING_DIRECTORY}"/MERGED_LICENSES
 # Truncate file.
 echo >"${output_path}"
 
-for path in $(find ${BUILD_WORKING_DIRECTORY}/vendor/ -name LICENSE); do
+cat <<EOF >>"${output_path}"
+------------------------------------------------------------
+License for github.com/kubernetes/cloud-provider-gcp
+------------------------------------------------------------
+EOF
+cat "${BUILD_WORKING_DIRECTORY}"/LICENSE >>"${output_path}"
+
+cat <<EOF >>"${output_path}"
+------------------------------------------------------------
+Licenses of vendored software below
+------------------------------------------------------------
+EOF
+
+for path in $(find "${BUILD_WORKING_DIRECTORY}"/vendor/ -name LICENSE); do
   >&2 echo "adding ${path}";
   # Trim working directory prefix from output.
   cat <<EOF >>"${output_path}"
------------------------------------------------------------
+------------------------------------------------------------
 ${path#"$BUILD_WORKING_DIRECTORY"}
 ------------------------------------------------------------
 EOF


### PR DESCRIPTION
This commit modifies merge_licenses.sh to include the top-level
LICENSE file for this repository, as well as the licenses of all
vendored libraries.