### PR TITLE
Include node-local-dns label in node_annotator.go

### DIFF
--- a/cmd/gcp-controller-manager/node_annotator.go
+++ b/cmd/gcp-controller-manager/node_annotator.go
@@ -74,6 +74,7 @@ func newNodeAnnotator(client clientset.Interface, nodeInformer coreinformers.Nod
 		"beta.kubernetes.io/masq-agent-ds-ready",
 		"projectcalico.org/ds-ready",
 		"beta.kubernetes.io/metadata-proxy-ready",
+		"addon.gke.io/node-local-dns-ds-ready",
 	}
 
 	na := &nodeAnnotator{


### PR DESCRIPTION
The label "addon.gke.io/node-local-dns-ds-ready" is used to select nodes that can run the node-local-dns daemonset.