### PR TITLE
Revert "Include node-local-dns label in node_annotator.go"

### DIFF
--- a/cmd/gcp-controller-manager/node_annotator.go
+++ b/cmd/gcp-controller-manager/node_annotator.go
@@ -74,7 +74,6 @@ func newNodeAnnotator(client clientset.Interface, nodeInformer coreinformers.Nod
 		"beta.kubernetes.io/masq-agent-ds-ready",
 		"projectcalico.org/ds-ready",
 		"beta.kubernetes.io/metadata-proxy-ready",
-		"addon.gke.io/node-local-dns-ds-ready",
 	}
 
 	na := &nodeAnnotator{


### PR DESCRIPTION
Reverts kubernetes/cloud-provider-gcp#107

Looks like we don't actually want this in the ownedKubeLablels list. These labels are removed by the node annotator during node creation.