### PR TITLE
Update numerous toolchain components.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,14 +5,17 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz"],
+    sha256 = "078f2a9569fa9ed846e60805fb5fb167d6f6c4ece48e6d409bf5fb2154eaf0d8",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.0/rules_go-v0.20.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.0/rules_go-v0.20.0.tar.gz",
+    ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
+    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz"],
 )
 
 skylib_version = "0.8.0"
@@ -26,9 +29,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+    sha256 = "480daa8737bf4370c1a05bfced903827e75046fea3123bd8c81389923d968f55",
+    strip_prefix = "rules_docker-0.11.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.11.0.tar.gz"],
 )
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
@@ -42,14 +45,12 @@ go_rules_dependencies()
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "linux_amd64": ("go1.11.5b4.linux-amd64.tar.gz", "9b5b2972b452da9ba6bba65bab18fb9e8fbda31b5c489275710e5429d76f568c"),
+        "linux_amd64": ("go1.13.1b4.linux-amd64.tar.gz", "70be1bae05feb67d0560f39767e80707343d96554c5a611fbb93b04ce5913693"),
     },
     urls = ["https://storage.googleapis.com/go-boringcrypto/{}"],
 )
 
-go_register_toolchains(
-    go_version = "1.11.5",
-)
+go_register_toolchains()
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",
@@ -61,6 +62,10 @@ load(
 )
 
 container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
 
 container_pull(
     name = "distroless",


### PR DESCRIPTION
These changes fix a build error currently at HEAD and are also needed to prepare for building gke-exec-auth-plugin for Windows.

Updates:
  - go toolchain to 1.13
  - rules_go to v0.20.0
  - gazelle to v0.19.0
  - rules_docker to v0.11.0

io_bazel_rules_go needs updating for bazelbuild/rules_go#2118 (bazelbuild/rules_go#1240).

bazel_gazelle and go_sdk need updating for compatibility with vendor/ targets that will be updated.

rules_docker needs updating to eliminate failures when running `bazel build ...` at HEAD. The corresponding update to the go toolchain is needed to completely eliminate the failures. For some more details see this [gist](https://gist.github.com/pjh/3e409e8d73dad63782b333c6535696de).

With these changes and a `gcloud auth login`, running `bazel build ...` to build the entire repository succeeds.

NOTES FOR REVIEWERS:
  - When updating rules_docker I had to add a new call to `container_deps()` as suggested [here](https://github.com/bazelbuild/rules_docker/issues/1176#issuecomment-538494233). There may be additional recommended changes as described in the [rules_docker Setup doc](https://github.com/bazelbuild/rules_docker#setup), but I did not review that carefully.
  - I did not test these changes other than by building the entire repository - please advise if I should run any manual testing.