### PR TITLE
Updated WORKSPACE file to point to an updated bazel_rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,8 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.3/rules_go-0.18.3.tar.gz"],
-    sha256 = "86ae934bd4c43b99893fc64be9d9fc684b81461581df7ea8fc291c816f5ee8c5",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.20.1/rules_go-v0.20.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.20.1/rules_go-v0.20.1.tar.gz",
+    ],
+    sha256 = "842ec0e6b4fbfdd3de6150b61af92901eeb73681fd4d185746644c338f51d4c0",
 )
 http_archive(
     name = "bazel_gazelle",
@@ -45,9 +48,7 @@ go_download_sdk(
     urls = ["https://storage.googleapis.com/go-boringcrypto/{}"],
 )
 
-go_register_toolchains(
-    go_version = "1.11.5",
-)
+go_register_toolchains()
 
 load(
     "@io_bazel_rules_docker//repositories:repositories.bzl",


### PR DESCRIPTION
The existing bazel_rules_go uses a bunch of deprecated bazel features that prevent building: 

Examples:
```
ERROR: /usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/BUILD.bazel:62:1: in go_context_data rule @io_bazel_rules_go//:go_context_data: 
Traceback (most recent call last):
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/BUILD.bazel", line 62
		go_context_data(name = 'go_context_data')
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/context.bzl", line 396, in _go_context_data_impl
		cc_common.configure_features(<3 more arguments>)
Incompatible flag --incompatible_require_ctx_in_configure_features has been flipped, and the mandatory parameter 'ctx' of cc_common.configure_features is missing. Please add 'ctx' as a named parameter. See https://github.com/bazelbuild/bazel/issues/7793 for details.

```
```
ERROR: /usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/rules/cgo.bzl:152:12: Traceback (most recent call last):
	File "/usr/local/google/home/samueldavidson/go/src/github.com/kubernetes/cloud-provider-gcp/vendor/golang.org/x/sys/unix/BUILD", line 3
		go_library(<6 more arguments>)
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/rules/wrappers.bzl", line 89, in go_library
		_cgo(name, kwargs)
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/rules/wrappers.bzl", line 84, in _cgo
		setup_cgo_library(**cgo_attrs)
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/rules/cgo.bzl", line 513, in setup_cgo_library
		_encode_cgo_mode(goos, goarch, <2 more arguments>)
	File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/external/io_bazel_rules_go/go/private/rules/cgo.bzl", line 152, in _encode_cgo_mode
		"_".join(<1 more arguments>)
sequence element must be a string (got 'bool'). See https://github.com/bazelbuild/bazel/issues/7802 for information about --incompatible_string_join_requires_strings.
```

Everything appears to work fine on my machine doing:
```bash
bazel test //...
```

Though I get a _sorta_ error saying `All tests passed but there were other errors during the build` in the context of:
```
ERROR: /usr/local/google/home/samueldavidson/go/src/github.com/kubernetes/cloud-provider-gcp/cmd/cloud-controller-manager/BUILD:26:1: JoinLayers cmd/cloud-controller-manager/image.tar failed (Exit 1) join_layers failed: error executing command 
  (cd /usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/sandbox/linux-sandbox/1959/execroot/io_k8s_cloud_provider_gcp && \
  exec env - \
  bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers '--output=bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image.tar' '--tags=bazel/cmd/cloud-controller-manager:image=@bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image.0.config' '--manifests=bazel/cmd/cloud-controller-manager:image=@bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image.0.manifest' '--layer=@bazel-out/k8-fastbuild/bin/external/distroless/image/000.tar.gz.nogz.sha256=@bazel-out/k8-fastbuild/bin/external/distroless/image/000.tar.gz.sha256=bazel-out/k8-fastbuild/bin/external/distroless/image/000.tar.gz.nogz=external/distroless/image/000.tar.gz' '--layer=@bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image-layer.tar.sha256=@bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image-layer.tar.gz.sha256=bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image-layer.tar=bazel-out/k8-fastbuild/bin/cmd/cloud-controller-manager/image-layer.tar.gz')
Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox
Traceback (most recent call last):
  File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/sandbox/linux-sandbox/1959/execroot/io_k8s_cloud_provider_gcp/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/io_bazel_rules_docker/container/join_layers.py", line 27, in <module>
    from containerregistry.client import docker_name
  File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/sandbox/linux-sandbox/1959/execroot/io_k8s_cloud_provider_gcp/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/containerregistry/client/__init__.py", line 23, in <module>
    from containerregistry.client import docker_creds_
  File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/sandbox/linux-sandbox/1959/execroot/io_k8s_cloud_provider_gcp/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/containerregistry/client/docker_creds_.py", line 31, in <module>
    import httplib2
  File "/usr/local/google/home/samueldavidson/.cache/bazel/_bazel_samueldavidson/525211c0f626bc4d49d10e8ee75edef3/sandbox/linux-sandbox/1959/execroot/io_k8s_cloud_provider_gcp/bazel-out/host/bin/external/io_bazel_rules_docker/container/join_layers.runfiles/httplib2/__init__.py", line 988
    raise socket.error, msg
                      ^
SyntaxError: invalid syntax
----------------
Note: The failure of target @io_bazel_rules_docker//container:join_layers (with exit code 1) may have been caused by the fact that it is running under Python 3 instead of Python 2. Examine the error to determine if that appears to be the problem. Since this target is built in the host configuration, the only way to change its version is to set --host_force_python=PY2, which affects the entire build.
```

But building with:
```bash
bazel test //... --host_force_python=PY2
```
Is 100% successful