### PR TITLE
Let CA file path be set via kube-env to enable Windows paths.

### DIFF
--- a/cmd/gke-exec-auth-plugin/request_test.go
+++ b/cmd/gke-exec-auth-plugin/request_test.go
@@ -10,12 +10,13 @@ import (
 
 func TestKubeEnvToConfig(t *testing.T) {
 	tests := []struct {
-		desc    string
-		kubeEnv string
-		wantErr bool
+		desc       string
+		kubeEnv    string
+		wantErr    bool
+		wantConfig *rest.Config
 	}{
 		{
-			desc: "success",
+			desc: "success default CA path",
 			kubeEnv: `FOO: bar
 TPM_BOOTSTRAP_CERT: ZmFrZV9jZXJ0Cg==
 TPM_BOOTSTRAP_KEY: ZmFrZV9rZXkK
@@ -23,6 +24,55 @@ BAZ: qux
 
   indented line
 KUBERNETES_MASTER_NAME: 1.2.3.4`,
+			wantConfig: &rest.Config{
+				Host: "https://1.2.3.4",
+				TLSClientConfig: rest.TLSClientConfig{
+					CertData: []byte("fake_cert\n"),
+					KeyData:  []byte("fake_key\n"),
+					CAFile:   defaultCAFilePath,
+				},
+				Timeout: 5 * time.Minute,
+			},
+		},
+		{
+			desc: "success override CA path Linux",
+			kubeEnv: `FOO: bar
+TPM_BOOTSTRAP_CERT: ZmFrZV9jZXJ0Cg==
+TPM_BOOTSTRAP_KEY: ZmFrZV9rZXkK
+BAZ: qux
+CA_FILE_PATH: /ca/file/path.crt
+
+  indented line
+KUBERNETES_MASTER_NAME: 1.2.3.4`,
+			wantConfig: &rest.Config{
+				Host: "https://1.2.3.4",
+				TLSClientConfig: rest.TLSClientConfig{
+					CertData: []byte("fake_cert\n"),
+					KeyData:  []byte("fake_key\n"),
+					CAFile:   "/ca/file/path.crt",
+				},
+				Timeout: 5 * time.Minute,
+			},
+		},
+		{
+			desc: "success override CA path Windows",
+			kubeEnv: `FOO: bar
+TPM_BOOTSTRAP_CERT: ZmFrZV9jZXJ0Cg==
+TPM_BOOTSTRAP_KEY: ZmFrZV9rZXkK
+BAZ: qux
+CA_FILE_PATH: C:\ca\file\path.crt
+
+  indented line
+KUBERNETES_MASTER_NAME: 1.2.3.4`,
+			wantConfig: &rest.Config{
+				Host: "https://1.2.3.4",
+				TLSClientConfig: rest.TLSClientConfig{
+					CertData: []byte("fake_cert\n"),
+					KeyData:  []byte("fake_key\n"),
+					CAFile:   `C:\ca\file\path.crt`,
+				},
+				Timeout: 5 * time.Minute,
+			},
 		},
 		{
 			desc: "no cert",
@@ -47,15 +97,6 @@ TPM_BOOTSTRAP_KEY: ZmFrZV9rZXkK`,
 			wantErr: true,
 		},
 	}
-	wantConfig := &rest.Config{
-		Host: "https://1.2.3.4",
-		TLSClientConfig: rest.TLSClientConfig{
-			CertData: []byte("fake_cert\n"),
-			KeyData:  []byte("fake_key\n"),
-			CAFile:   caFilePath,
-		},
-		Timeout: 5 * time.Minute,
-	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -66,8 +107,8 @@ TPM_BOOTSTRAP_KEY: ZmFrZV9rZXkK`,
 			case err != nil && !tt.wantErr:
 				t.Fatalf("got error %v, want nil", err)
 			case err == nil:
-				if !reflect.DeepEqual(got, wantConfig) {
-					t.Errorf("got config %+v\nwant config %+v", got, wantConfig)
+				if !reflect.DeepEqual(got, tt.wantConfig) {
+					t.Errorf("got config %+v\nwant config %+v", got, tt.wantConfig)
 				}
 			}
 		})


### PR DESCRIPTION
`caFilePath` is hard-coded to a Linux path. This PR lets this path be overridden by a kube-env key, which will then be set by shielded Windows kubernetes nodes ([k/k changes in progress](https://github.com/kubernetes/kubernetes/compare/master...pjh:gce-shielded-windows?expand=1)). `gke-exec-auth-plugin.exe` then runs correctly.

This change is a noop for existing plugin users. The chosen kube-env key for specifying the path is [not used anywhere in k/k](https://github.com/kubernetes/kubernetes/search?q=%22CA_FILE_PATH%22&unscoped_q=%22CA_FILE_PATH%22).

There are alternative mechanisms we could use for setting this path for Windows: making it a flag, or making it constant with different Windows vs. Linux values at build time. This path is already only used `kubeEnvToConfig()` though so controlling it with a kube-env key seems reasonable and appropriately flexible.