### PR TITLE
Don't set a timeout on informers in gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -97,14 +97,18 @@ func main() {
 		leaderElectionConfig:               *leConfig,
 	}
 	var err error
-	s.kubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	s.informerKubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		klog.Exitf("failed loading kubeconfig: %v", err)
 	}
 	// bump the QPS limits per controller up from defaults of 5 qps / 10 burst
-	s.kubeconfig.QPS = kubeconfigQPS
-	s.kubeconfig.Burst = kubeconfigBurst
-	s.kubeconfig.Timeout = kubeconfigTimeout
+	s.informerKubeconfig.QPS = kubeconfigQPS
+	s.informerKubeconfig.Burst = kubeconfigBurst
+	// kubeconfig for controllers is the same, plus it has a client timeout for
+	// API requests. Informers shouldn't have a timeout because that breaks
+	// watch requests.
+	s.controllerKubeconfig = restclient.CopyConfig(s.informerKubeconfig)
+	s.controllerKubeconfig.Timeout = kubeconfigTimeout
 
 	s.gcpConfig, err = loadGCPConfig(s.gceConfigPath, s.gceAPIEndpointOverride)
 	if err != nil {
@@ -134,8 +138,9 @@ type controllerManager struct {
 	leaderElectionConfig               componentbaseconfig.LeaderElectionConfiguration
 
 	// Fields initialized from other sources.
-	gcpConfig  gcpConfig
-	kubeconfig *restclient.Config
+	gcpConfig            gcpConfig
+	informerKubeconfig   *restclient.Config
+	controllerKubeconfig *restclient.Config
 }
 
 func (s *controllerManager) isEnabled(name string) bool {
@@ -158,15 +163,16 @@ func (s *controllerManager) isEnabled(name string) bool {
 func run(s *controllerManager) error {
 	ctx := context.Background()
 
-	clientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: s.kubeconfig}
-
-	informerClient := clientBuilder.ClientOrDie("gcp-controller-manager-shared-informer")
+	informerClientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: s.informerKubeconfig}
+	informerClient := informerClientBuilder.ClientOrDie("gcp-controller-manager-shared-informer")
 	sharedInformers := informers.NewSharedInformerFactory(informerClient, time.Duration(12)*time.Hour)
+
+	controllerClientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: s.controllerKubeconfig}
 
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(klog.Infof)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{
-		Interface: v1core.New(clientBuilder.ClientOrDie("gcp-controller-manager").CoreV1().RESTClient()).Events(""),
+		Interface: v1core.New(controllerClientBuilder.ClientOrDie("gcp-controller-manager").CoreV1().RESTClient()).Events(""),
 	})
 
 	run := func(ctx context.Context) {
@@ -175,7 +181,7 @@ func run(s *controllerManager) error {
 				continue
 			}
 			name = "gcp-" + name
-			loopClient, err := clientBuilder.Client(name)
+			loopClient, err := controllerClientBuilder.Client(name)
 			if err != nil {
 				klog.Fatalf("failed to start client for %q: %v", name, err)
 			}
@@ -199,7 +205,7 @@ func run(s *controllerManager) error {
 	}
 
 	if s.leaderElectionConfig.LeaderElect {
-		leaderElectionClient, err := clientset.NewForConfig(restclient.AddUserAgent(s.kubeconfig, "leader-election"))
+		leaderElectionClient, err := clientset.NewForConfig(restclient.AddUserAgent(s.informerKubeconfig, "leader-election"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
They do the long-running watch requests that get interrupted by timeouts
in kubeconfig.

/assign @mikedanese 