### PR TITLE
Add /healthz endpoint to gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/BUILD
+++ b/cmd/gcp-controller-manager/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//cmd/gcp-controller-manager:__subpackages__",
     ],
     deps = [
+        "//cmd/gcp-controller-manager/healthz:go_default_library",
         "//pkg/csrmetrics:go_default_library",
         "//pkg/nodeidentity:go_default_library",
         "//pkg/tpmattest:go_default_library",

--- a/cmd/gcp-controller-manager/healthz/BUILD
+++ b/cmd/gcp-controller-manager/healthz/BUILD
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["healthz.go"],
+    importpath = "k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/healthz",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/klog:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["healthz_test.go"],
+    embed = [":go_default_library"],
+)

--- a/cmd/gcp-controller-manager/healthz/healthz.go
+++ b/cmd/gcp-controller-manager/healthz/healthz.go
@@ -1,0 +1,49 @@
+package healthz
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"k8s.io/klog"
+)
+
+// Check reports the (un)healthiness of a single component.
+type Check func(context.Context) error
+
+// Handler is a http.Handler that performs a number of named checks and returns
+// their result on every request.
+// Note: populate Checks *before* accepting any requests to the Handler.
+type Handler struct {
+	// Timeout is passed to Check calls via the context. It limits how long
+	// Handler allows Checks to run for.
+	Timeout time.Duration
+	// Checks are named Check functions for Handler to call on each request.
+	// Checks are called sequentially, in random order.
+	Checks map[string]Check
+}
+
+// NewHandler initializes a new Handler.
+func NewHandler() *Handler {
+	return &Handler{
+		Timeout: time.Second,
+		Checks:  make(map[string]Check),
+	}
+}
+
+func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	ctx, cancel := context.WithTimeout(req.Context(), h.Timeout)
+	defer cancel()
+	var failed bool
+	for name, check := range h.Checks {
+		if err := check(ctx); err != nil {
+			failed = true
+			klog.Warningf("healthz check %q failed: %v", name, err)
+			http.Error(rw, fmt.Sprintf("%q: %v", name, err), http.StatusInternalServerError)
+		}
+	}
+	if !failed {
+		fmt.Fprintln(rw, "ok")
+	}
+}

--- a/cmd/gcp-controller-manager/healthz/healthz_test.go
+++ b/cmd/gcp-controller-manager/healthz/healthz_test.go
@@ -1,0 +1,86 @@
+package healthz
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	passingCheck := func(context.Context) error { return nil }
+	failingCheck := func(context.Context) error { return errors.New("failed") }
+	blockedCheck := func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	tests := []struct {
+		desc       string
+		checks     map[string]Check
+		wantStatus int
+	}{
+		{
+			desc:       "no checks",
+			wantStatus: http.StatusOK,
+		},
+		{
+			desc:       "one passing check",
+			wantStatus: http.StatusOK,
+			checks: map[string]Check{
+				"passing": passingCheck,
+			},
+		},
+		{
+			desc:       "multiple passing checks",
+			wantStatus: http.StatusOK,
+			checks: map[string]Check{
+				"passing 1": passingCheck,
+				"passing 2": passingCheck,
+				"passing 3": passingCheck,
+			},
+		},
+		{
+			desc:       "one failing check",
+			wantStatus: http.StatusInternalServerError,
+			checks: map[string]Check{
+				"failing": failingCheck,
+			},
+		},
+		{
+			desc:       "passing and failing checks",
+			wantStatus: http.StatusInternalServerError,
+			checks: map[string]Check{
+				"passing 1": passingCheck,
+				"failing":   failingCheck,
+				"passing 2": passingCheck,
+			},
+		},
+		{
+			desc:       "timeout",
+			wantStatus: http.StatusInternalServerError,
+			checks: map[string]Check{
+				"blocked": blockedCheck,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			h := NewHandler()
+			h.Checks = tt.checks
+
+			s := httptest.NewServer(h)
+			defer s.Close()
+
+			resp, err := http.Get(s.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tt.wantStatus {
+				t.Errorf("got status %q, want %q", http.StatusText(resp.StatusCode), http.StatusText(tt.wantStatus))
+			}
+		})
+	}
+}

--- a/cmd/gcp-controller-manager/healthz/healthz_test.go
+++ b/cmd/gcp-controller-manager/healthz/healthz_test.go
@@ -48,6 +48,14 @@ func TestHandler(t *testing.T) {
 			},
 		},
 		{
+			desc:       "multiple failing checks",
+			wantStatus: http.StatusInternalServerError,
+			checks: map[string]Check{
+				"failing 1": failingCheck,
+				"failing 2": failingCheck,
+			},
+		},
+		{
 			desc:       "passing and failing checks",
 			wantStatus: http.StatusInternalServerError,
 			checks: map[string]Check{

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/healthz"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -61,6 +62,7 @@ const (
 
 var (
 	metricsPort                        = pflag.Int("metrics-port", 8089, "Port to expose Prometheus metrics on")
+	healthzPort                        = pflag.Int("healthz-port", 8089, "Port to expose /healthz endpoint on. Can be the same as --metrics-port.")
 	kubeconfig                         = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
 	clusterSigningGKEKubeconfig        = pflag.String("cluster-signing-gke-kubeconfig", "", "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
 	gceConfigPath                      = pflag.String("gce-config", "/etc/gce.conf", "Path to gce.conf.")
@@ -100,6 +102,7 @@ func main() {
 		leaderElectionConfig:               *leConfig,
 		hmsAuthorizeSAMappingURL:           *hmsAuthorizeSAMappingURL,
 		hmsSyncNodeURL:                     *hmsSyncNodeURL,
+		healthz:                            healthz.NewHandler(),
 	}
 	var err error
 	s.informerKubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
@@ -120,10 +123,27 @@ func main() {
 		klog.Exitf("failed loading GCP config: %v", err)
 	}
 
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+
+	healthzMux := http.NewServeMux()
+	// Allow healthz and metrics to serve from same port - share the
+	// multiplexor.
+	if *metricsPort == *healthzPort {
+		healthzMux = metricsMux
+	}
+	healthzMux.Handle("/healthz", s.healthz)
+
 	go func() {
-		http.Handle("/metrics", promhttp.Handler())
-		klog.Exit(http.ListenAndServe(fmt.Sprintf(":%d", *metricsPort), nil))
+		klog.Exit(http.ListenAndServe(fmt.Sprintf(":%d", *metricsPort), metricsMux))
 	}()
+	// Allow healthz and metrics to serve from different ports - start a second
+	// server for healthz.
+	if *healthzPort != *metricsPort {
+		go func() {
+			klog.Exit(http.ListenAndServe(fmt.Sprintf(":%d", *healthzPort), healthzMux))
+		}()
+	}
 
 	if err := run(s); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
@@ -148,6 +168,7 @@ type controllerManager struct {
 	gcpConfig            gcpConfig
 	informerKubeconfig   *restclient.Config
 	controllerKubeconfig *restclient.Config
+	healthz              *healthz.Handler
 }
 
 func (s *controllerManager) isEnabled(name string) bool {
@@ -173,6 +194,7 @@ func run(s *controllerManager) error {
 	informerClientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: s.informerKubeconfig}
 	informerClient := informerClientBuilder.ClientOrDie("gcp-controller-manager-shared-informer")
 	sharedInformers := informers.NewSharedInformerFactory(informerClient, time.Duration(12)*time.Hour)
+	s.healthz.Checks["shared informers"] = informersCheck(sharedInformers)
 
 	controllerClientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: s.controllerKubeconfig}
 
@@ -194,7 +216,7 @@ func run(s *controllerManager) error {
 			if err != nil {
 				klog.Fatalf("failed to start client for %q: %v", name, err)
 			}
-			if loop(&controllerContext{
+			if err := loop(&controllerContext{
 				client:          loopClient,
 				sharedInformers: sharedInformers,
 				recorder: eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{
@@ -238,8 +260,9 @@ func run(s *controllerManager) error {
 		if err != nil {
 			return err
 		}
+		s.healthz.Checks["leader election"] = leaderElectorCheck(leaderElector)
 		leaderElector.Run(ctx)
-		panic("unreachable")
+		return fmt.Errorf("should never reach this point")
 	}
 
 	startControllers(ctx)
@@ -271,4 +294,30 @@ func makeLeaderElectionConfig(config componentbaseconfig.LeaderElectionConfigura
 		RenewDeadline: config.RenewDeadline.Duration,
 		RetryPeriod:   config.RetryPeriod.Duration,
 	}, nil
+}
+
+func informersCheck(s informers.SharedInformerFactory) healthz.Check {
+	return func(ctx context.Context) error {
+		res := s.WaitForCacheSync(ctx.Done())
+		var notSynced []string
+		for t, ok := range res {
+			if !ok {
+				notSynced = append(notSynced, t.String())
+			}
+		}
+		if len(notSynced) > 0 {
+			return fmt.Errorf("cache not synced for watchers: %q", notSynced)
+		}
+		return nil
+	}
+}
+
+func leaderElectorCheck(le *leaderelection.LeaderElector) healthz.Check {
+	return func(_ context.Context) error {
+		// 10s is lease expiry threshold, not a timeout for le.Check.
+		if err := le.Check(10 * time.Second); err != nil {
+			return fmt.Errorf("leader election unhealthy: %v", err)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
Behind the scenes it checks whether informer caches are synced and
whether leader lease hasn't expired after election.