### PR TITLE
Fix missing sha reference in cluster-up.

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -126,9 +126,9 @@ function validate-hash {
   local -r file="$1"
   local -r expected="$2"
 
-  actual=$(sha1sum ${file} | awk '{ print $1 }') || true
+  actual=$(shasum -a512 ${file} | awk '{ print $1 }') || true
   if [[ "${actual}" != "${expected}" ]]; then
-    echo "== ${file} corrupted, sha1 ${actual} doesn't match expected ${expected} =="
+    echo "== ${file} corrupted, sha512 ${actual} doesn't match expected ${expected} =="
     return 1
   fi
 }
@@ -146,7 +146,7 @@ function valid-storage-scope {
 
 # Retry a download until we get it. Takes a hash and a set of URLs.
 #
-# $1 is the sha1 of the URL. Can be "" if the sha1 is unknown.
+# $1 is the sha512 of the URL. Can be "" if the sha512 is unknown.
 # $2+ are the URLs to download.
 function download-or-bust {
   local -r hash="$1"
@@ -168,7 +168,7 @@ function download-or-bust {
         echo "== Hash validation of ${url} failed. Retrying. =="
       else
         if [[ -n "${hash}" ]]; then
-          echo "== Downloaded ${url} (SHA1 = ${hash}) =="
+          echo "== Downloaded ${url} (SHA512 = ${hash}) =="
         else
           echo "== Downloaded ${url} =="
         fi
@@ -334,9 +334,9 @@ function install-kube-manifests {
   if [ -n "${KUBE_MANIFESTS_TAR_HASH:-}" ]; then
     local -r manifests_tar_hash="${KUBE_MANIFESTS_TAR_HASH}"
   else
-    echo "Downloading k8s manifests sha1 (not found in env)"
-    download-or-bust "" "${manifests_tar_urls[@]/.tar.gz/.tar.gz.sha1}"
-    local -r manifests_tar_hash=$(cat "${manifests_tar}.sha1")
+    echo "Downloading k8s manifests sha512 (not found in env)"
+    download-or-bust "" "${manifests_tar_urls[@]/.tar.gz/.tar.gz.sha512}"
+    local -r manifests_tar_hash=$(cat "${manifests_tar}.sha512")
   fi
 
   if is-preloaded "${manifests_tar}" "${manifests_tar_hash}"; then
@@ -363,7 +363,7 @@ function install-kube-manifests {
   cp "${dst_dir}/kubernetes/gci-trusty/health-monitor.sh" "${KUBE_BIN}/health-monitor.sh"
 
   rm -f "${KUBE_HOME}/${manifests_tar}"
-  rm -f "${KUBE_HOME}/${manifests_tar}.sha1"
+  rm -f "${KUBE_HOME}/${manifests_tar}.sha512"
 }
 
 # A helper function for loading a docker image. It keeps trying up to 5 times.
@@ -532,9 +532,9 @@ function install-kube-binary-config {
   if [[ -n "${SERVER_BINARY_TAR_HASH:-}" ]]; then
     local -r server_binary_tar_hash="${SERVER_BINARY_TAR_HASH}"
   else
-    echo "Downloading binary release sha1 (not found in env)"
-    download-or-bust "" "${server_binary_tar_urls[@]/.tar.gz/.tar.gz.sha1}"
-    local -r server_binary_tar_hash=$(cat "${server_binary_tar}.sha1")
+    echo "Downloading binary release sha512 (not found in env)"
+    download-or-bust "" "${server_binary_tar_urls[@]/.tar.gz/.tar.gz.sha512}"
+    local -r server_binary_tar_hash=$(cat "${server_binary_tar}.sha512")
   fi
 
   if is-preloaded "${server_binary_tar}" "${server_binary_tar_hash}"; then
@@ -596,7 +596,7 @@ function install-kube-binary-config {
   # Clean up.
   rm -rf "${KUBE_HOME}/kubernetes"
   rm -f "${KUBE_HOME}/${server_binary_tar}"
-  rm -f "${KUBE_HOME}/${server_binary_tar}.sha1"
+  rm -f "${KUBE_HOME}/${server_binary_tar}.sha512"
 }
 
 ######### Main Function ##########

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -240,9 +240,9 @@ function copy-to-staging() {
   fi
 
   #echo "${hash}" > "${tar}.sha1"
-  gsutil -m -q -h "Cache-Control:private, max-age=0" cp "${tar}" "${tar}.sha1" "${staging_path}"
+  gsutil -m -q -h "Cache-Control:private, max-age=0" cp "${tar}" "${tar}.sha512" "${staging_path}"
   gsutil -m acl ch -g all:R "${gs_url}" "${gs_url}.sha1" >/dev/null 2>&1
-  echo "+++ ${basename_tar} uploaded (sha1 = ${hash})"
+  echo "+++ ${basename_tar} uploaded (sha512 = ${hash})"
 }
 
 
@@ -315,13 +315,13 @@ function upload-tars() {
     DOCKER_REGISTRY_MIRROR_URL="https://mirror.gcr.io"
   fi
 
-  SERVER_BINARY_TAR_HASH=$(sha1sum-file "${SERVER_BINARY_TAR}")
+  SERVER_BINARY_TAR_HASH=$(sha512sum-file "${SERVER_BINARY_TAR}")
 
   if [[ -n "${NODE_BINARY_TAR:-}" ]]; then
     NODE_BINARY_TAR_HASH=$(sha1sum-file "${NODE_BINARY_TAR}")
   fi
   if [[ -n "${KUBE_MANIFESTS_TAR:-}" ]]; then
-    KUBE_MANIFESTS_TAR_HASH=$(sha1sum-file "${KUBE_MANIFESTS_TAR}")
+    KUBE_MANIFESTS_TAR_HASH=$(sha512sum-file "${KUBE_MANIFESTS_TAR}")
   fi
 
   local server_binary_tar_urls=()
@@ -531,8 +531,8 @@ function tars_from_version() {
     echo "Version doesn't match regexp" >&2
     exit 1
   fi
-  if ! SERVER_BINARY_TAR_HASH=$(curl -Ss --fail "${SERVER_BINARY_TAR_URL}.sha1"); then
-    echo "Failure trying to curl release .sha1"
+  if ! SERVER_BINARY_TAR_HASH=$(curl -Ss --fail "${SERVER_BINARY_TAR_URL}.sha512"); then
+    echo "Failure trying to curl release .sha512"
   fi
 
   if ! curl -Ss --head "${SERVER_BINARY_TAR_URL}" >&/dev/null; then
@@ -1560,6 +1560,10 @@ function sha1sum-file() {
   else
     shasum -a1 "$1" | awk '{ print $1 }'
   fi
+}
+
+function sha512sum-file() {
+  shasum -a512 "$1" | awk '{ print $1 }'
 }
 
 # Create certificate pairs for the cluster.

--- a/release/BUILD
+++ b/release/BUILD
@@ -33,6 +33,30 @@ genrule(
     cmd = "mv $< $@",
 )
 
+genrule(
+    name = "gen_server_shasum",
+    srcs = [
+        ":kubernetes-server-linux-amd64.tar.gz",
+    ],
+    outs = [
+        ":kubernetes-server-linux-amd64.tar.gz.sha512",
+    ],
+    output_to_bindir = 1,
+    cmd = "shasum -a512 $< > $<.sha512",
+)
+
+genrule(
+    name = "gen_manifest_shasum",
+    srcs = [
+        ":kubernetes-manifests.tar.gz",
+    ],
+    outs = [
+        ":kubernetes-manifests.tar.gz.sha512",
+    ],
+    output_to_bindir = 1,
+    cmd = "shasum -a512 $< > $<.sha512",
+)
+
 pkg_tar(
     name = "kubernetes-manifests",
     extension = "tar.gz",
@@ -47,8 +71,8 @@ pkg_tar(
 release_filegroup(
     name = "release-tars",
     srcs = [
-        ":kubernetes-manifests.tar.gz",
-        ":kubernetes-server-linux-amd64.tar.gz",
+        ":kubernetes-manifests.tar.gz.sha512",
+        ":kubernetes-server-linux-amd64.tar.gz.sha512",
         "@io_k8s_release//:kubernetes-node-linux-amd64",
     ],
 )


### PR DESCRIPTION
Creates the missing sha files referenced in #145.
We now create sha512 for the generated tgz files.
Switched the relevant checks from sha1 to sha512.
This is *not* fixing the legacy/out of repo sha1 generation.
So NPD, node etc are still on sha1.