### PR TITLE
Make node annotator failure retry correctly follow queue rate limiter

### DIFF
--- a/cmd/gcp-controller-manager/node_syncer.go
+++ b/cmd/gcp-controller-manager/node_syncer.go
@@ -33,7 +33,6 @@ import (
 const (
 	nodeSyncerControlLoopName = "node-syncer"
 	nodeSyncerQueueName       = "node-syncer-queue"
-	nodeSyncerQueueRetryLimit = 5
 	nodeSyncerResyncPeriod    = 30 * time.Minute
 )
 
@@ -121,10 +120,6 @@ func (ns *nodeSyncer) processNext() bool {
 
 	err := ns.process(key.(string))
 	if err != nil {
-		if ns.queue.NumRequeues(key) > nodeSyncerQueueRetryLimit {
-			klog.Errorf("Stop retrying %q in queue; last error: %v", key, err)
-			return true
-		}
 		klog.Warningf("Requeuing %q due to %v", key, err)
 		ns.queue.AddRateLimited(key)
 		return true


### PR DESCRIPTION
Current node annotator requeues node sync action on failure constantly without exponential backoff.
Modify the behavior to correctly follow the exponential backoff and impose retry limit for failures.