### PR TITLE
Fix CCM image.

### DIFF
--- a/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
+++ b/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
@@ -7,11 +7,27 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
   - create
   - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cloud-controller-manager
+  resources:
+  - leases
+  verbs:
+  - get
   - update
 - apiGroups:
   - ""

--- a/cluster/gce/gci/configure-kubeapiserver.sh
+++ b/cluster/gce/gci/configure-kubeapiserver.sh
@@ -69,7 +69,7 @@ function start-kube-apiserver {
   local params="${API_SERVER_TEST_LOG_LEVEL:-"--v=2"} ${APISERVER_TEST_ARGS:-} ${CLOUD_CONFIG_OPT}"
   params+=" --address=127.0.0.1"
   params+=" --allow-privileged=true"
-  params+=" --cloud-provider=gce"
+  params+=" --cloud-provider=external"
   params+=" --client-ca-file=${CA_CERT_BUNDLE_PATH}"
 
   # params is passed by reference, so no "$"

--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -24,11 +24,12 @@
         "cpu": "{{cpurequest}}"
       }
     },
-    "command": [
-                 "/bin/sh",
-                 "-c",
-                 "exec /usr/local/bin/cloud-controller-manager {{params}} 1>>/var/log/cloud-controller-manager.log 2>&1"
-               ],
+    "command": ["/cloud-controller-manager"],
+    "args": [
+      "--log-file=/var/log/cloud-controller-manager.log",
+      "--logtostderr=false",
+      {{params}}
+    ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/defs/container.bzl
+++ b/defs/container.bzl
@@ -17,6 +17,7 @@ def image(binary, visibility = ["//visibility:public"]):
     name = binary[1:]
     container_image(
         name = "image",
+        repository = "k8s.gcr.io",
         cmd = ["/" + name],
         files = [binary],
         stamp = True,

--- a/deploy/cloud-controller-manager.manifest
+++ b/deploy/cloud-controller-manager.manifest
@@ -14,6 +14,7 @@
   }
 },
 "spec":{
+"priorityClass": "system-node-critical",
 "hostNetwork": true,
 "containers":[
     {
@@ -24,11 +25,12 @@
         "cpu": "{{cpurequest}}"
       }
     },
-    "command": [
-                 "/bin/sh",
-                 "-c",
-                 "exec /usr/local/bin/cloud-controller-manager {{params}} 1>>/var/log/cloud-controller-manager.log 2>&1"
-               ],
+    "command": ["/cloud-controller-manager"],
+    "args": [
+      "--log-file=/var/log/cloud-controller-manager.log",
+      "--logtostderr=false",
+      {{params}}
+    ],
     {{container_env}}
     "livenessProbe": {
       "httpGet": {

--- a/deploy/cloud-node-controller-role.yaml
+++ b/deploy/cloud-node-controller-role.yaml
@@ -7,11 +7,27 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
   - create
   - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cloud-controller-manager
+  resources:
+  - leases
+  verbs:
+  - get
   - update
 - apiGroups:
   - ""

--- a/release/BUILD
+++ b/release/BUILD
@@ -30,7 +30,23 @@ genrule(
     srcs = ["//cmd/cloud-controller-manager:image.tar"],
     outs = ["cmd/cloud-controller-manager/cloud-controller-manager.tar"],
     output_to_bindir = 1,
-    cmd = "mv $< $@",
+    stamp = 1,
+    cmd = '''
+    {
+      mkdir archive
+      cd archive
+      tar tf ../$< > contents
+      tar xf ../$<
+      image_tag=`awk '/STABLE_IMAGE_TAG/ {print $$2}' ../bazel-out/stable-status.txt`
+      # Fix the image tag to not contain '+'
+      image_tag=`echo $$image_tag | sed 's/+/-/g'`
+      sed -i "s@:image\"@:$${image_tag}\"@g" manifest.json
+      sed -i "s@\"image\"@\"$${image_tag}\"@g" repositories
+      sed -i "s@k8s.gcr.io/cmd/cloud-controller-manager:@k8s.gcr.io/cloud-controller-manager:@g" manifest.json
+      sed -i "s@k8s.gcr.io/cmd/cloud-controller-manager@k8s.gcr.io/cloud-controller-manager@g" repositories
+      tar -c -T contents -f ../$@
+      cd ..
+    }''',
 )
 
 genrule(

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Version management helpers.  These functions help to set, save and load the
+# following variables:
+#
+#    KUBE_GIT_COMMIT - The git commit id corresponding to this
+#          source code.
+#    KUBE_GIT_TREE_STATE - "clean" indicates no changes since the git commit id
+#        "dirty" indicates source code changes after the git commit id
+#        "archive" indicates the tree was produced by 'git archive'
+#    KUBE_GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    KUBE_GIT_MAJOR - The major part of the version
+#    KUBE_GIT_MINOR - The minor component of the version
+
+# Grovels through git to set a set of env variables.
+#
+# If KUBE_GIT_VERSION_FILE, this function will load from that file instead of
+# querying git.
+get_version_vars() {
+  echo "Starting get_version_vars"
+  if [[ -n ${KUBE_GIT_VERSION_FILE-} ]]; then
+    echo "Exiting early"
+    load_version_vars "${KUBE_GIT_VERSION_FILE}"
+    return
+  fi
+
+  # If the kubernetes source was exported through git archive, then
+  # we likely don't have a git tree, but these magic values may be filled in.
+  # shellcheck disable=SC2016,SC2050
+  # Disabled as we're not expanding these at runtime, but rather expecting
+  # that another tool may have expanded these and rewritten the source (!)
+  if [[ '$Format:%%$' == "%" ]]; then
+    KUBE_GIT_COMMIT='$Format:%H$'
+    KUBE_GIT_TREE_STATE="archive"
+    # When a 'git archive' is exported, the '$Format:%D$' below will look
+    # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
+    # can be extracted from it.
+    if [[ '$Format:%D$' =~ tag:\ (v[^ ,]+) ]]; then
+     KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
+    fi
+  else
+    echo "Format failed, format = ?"
+    #echo "Format failed, format = '$Format:%%$'"
+  fi
+
+  local git=(git --work-tree "${KUBE_ROOT}")
+
+  if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then
+    if [[ -z ${KUBE_GIT_TREE_STATE-} ]]; then
+      # Check if the tree is dirty.  default to dirty
+      if git_status=$("${git[@]}" status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        KUBE_GIT_TREE_STATE="clean"
+      else
+        KUBE_GIT_TREE_STATE="dirty"
+      fi
+    else
+      echo "git tree state failed"
+    fi
+
+    # Use git describe to find the version based on tags.
+    #if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$(echo "v1.18.0-alpha+${KUBE_GIT_COMMIT}"); then
+      # This translates the "git describe" to an actual semver.org
+      # compatible semantic version that looks something like this:
+      #   v1.1.0-alpha.0.6+84c76d1142ea4d
+      #
+      # TODO: We continue calling this "git version" because so many
+      # downstream consumers are expecting it there.
+      #
+      # These regexes are painful enough in sed...
+      # We don't want to do them in pure shell, so disable SC2001
+      # shellcheck disable=SC2001
+      DASHES_IN_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/[^-]//g")
+      if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+        # shellcheck disable=SC2001
+        # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\+\2/")
+      elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+        # shellcheck disable=SC2001
+        # We have distance to base tag (v1.1.0-1-gCommitHash)
+        KUBE_GIT_VERSION=$(echo "${KUBE_GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/+\1/")
+      fi
+      if [[ "${KUBE_GIT_TREE_STATE}" == "dirty" ]]; then
+        # git describe --dirty only considers changes to existing files, but
+        # that is problematic since new untracked .go files affect the build,
+        # so use our idea of "dirty" from git status instead.
+        KUBE_GIT_VERSION+="-dirty"
+        echo "KUBE_GIT_VERSION set to ${KUBE_GIT_VERSION}"
+      fi
+
+
+      # Try to match the "git describe" output to a regex to try to extract
+      # the "major" and "minor" versions and whether this is the exact tagged
+      # version or whether the tree is between two tagged versions.
+      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+        KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
+        KUBE_GIT_MINOR=${BASH_REMATCH[2]}
+        if [[ -n "${BASH_REMATCH[4]}" ]]; then
+          KUBE_GIT_MINOR+="+"
+        fi
+      fi
+
+      # If KUBE_GIT_VERSION is not a valid Semantic Version, then refuse to build.
+      if ! [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "KUBE_GIT_VERSION should be a valid Semantic Version. Current value: ${KUBE_GIT_VERSION}"
+          echo "Please see more details here: https://semver.org"
+          exit 1
+      fi
+    else
+      echo "git version failed"
+      echo "KUBE_GIT_VERSION is ${KUBE_GIT_VERSION}"
+      echo "KUBE_GIT_COMMIT is ${KUBE_GIT_COMMIT}"
+    fi
+  else
+    echo "git failed"
+  fi
+}
+
+# Saves the environment flags to $1
+save_version_vars() {
+  local version_file=${1-}
+  [[ -n ${version_file} ]] || {
+    echo "!!! Internal error.  No file specified in save_version_vars"
+    return 1
+  }
+
+  cat <<EOF >"${version_file}"
+KUBE_GIT_COMMIT='${KUBE_GIT_COMMIT-}'
+KUBE_GIT_TREE_STATE='${KUBE_GIT_TREE_STATE-}'
+KUBE_GIT_VERSION='${KUBE_GIT_VERSION-}'
+KUBE_GIT_MAJOR='${KUBE_GIT_MAJOR-}'
+KUBE_GIT_MINOR='${KUBE_GIT_MINOR-}'
+EOF
+}
+
+# Loads up the version variables from file $1
+load_version_vars() {
+  local version_file=${1-}
+  [[ -n ${version_file} ]] || {
+    echo "!!! Internal error.  No file specified in load_version_vars"
+    return 1
+  }
+
+  source "${version_file}"
+}
+
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+# in order to set the Kubernetes based on the git tree status.
+# IMPORTANT: if you update any of these, also update the lists in
+# pkg/version/def.bzl and hack/print-workspace-status.sh.
+ldflags() {
+  get_version_vars
+
+  local -a ldflags
+  function add_ldflag() {
+    local key=${1}
+    local val=${2}
+    # If you update these, also update the list component-base/version/def.bzl.
+    ldflags+=(
+      "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}'"
+      "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/component-base/version.${key}=${val}'"
+    )
+  }
+
+  add_ldflag "buildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
+  if [[ -n ${KUBE_GIT_COMMIT-} ]]; then
+    add_ldflag "gitCommit" "${KUBE_GIT_COMMIT}"
+    add_ldflag "gitTreeState" "${KUBE_GIT_TREE_STATE}"
+  fi
+
+  if [[ -n ${KUBE_GIT_VERSION-} ]]; then
+    add_ldflag "gitVersion" "${KUBE_GIT_VERSION}"
+  fi
+
+  if [[ -n ${KUBE_GIT_MAJOR-} && -n ${KUBE_GIT_MINOR-} ]]; then
+    add_ldflag "gitMajor" "${KUBE_GIT_MAJOR}"
+    add_ldflag "gitMinor" "${KUBE_GIT_MINOR}"
+  fi
+
+  # The -ldflags parameter takes a single string, so join the output.
+  echo "${ldflags[*]-}"
+}

--- a/tools/workspace-status.sh
+++ b/tools/workspace-status.sh
@@ -20,11 +20,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+source "${KUBE_ROOT}/tools/version.sh"
+get_version_vars
+IMAGE_TAG=${KUBE_GIT_VERSION:-latest}
+
 # Prefix with STABLE_ so that these values are saved to stable-status.txt
 # instead of volatile-status.txt.
 # Stamped rules will be retriggered by changes to stable-status.txt, but not by
 # changes to volatile-status.txt.
-# IMPORTANT: the camelCase vars should match the lists in hack/lib/version.sh
+# IMPORTANT: the camelCase vars should match the lists in version.sh
 # and pkg/version/def.bzl.
 cat <<EOF
 STABLE_IMAGE_REGISTRY ${IMAGE_REGISTRY:-gcr.io}


### PR DESCRIPTION
CCM image was set to a blaize repository instead of k8s.gcr.io.
CCM image had unneeded path info in it.
CCM image was tag with 'image'.
Added a script to determine the 'dirty' tag for one off builds.
Assuming a hard coded base version for now.
However it is a 1 line change to pick up version from a git tag.
Fixed issue in manifest based on us using distroless base image.
Fixed config to actually write out the log file.
Fixed manifests to use external cloud provider when appropriate.