### PR TITLE
verify-kube-binaries uses relative path instead of fixed

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -515,7 +515,7 @@ function verify-kube-binaries() {
   # TODO: @cheftako Remove the hack to get a local kubectl from existing tars.
   # Need to get something which matches the local machine type.
   mkdir -p ${KUBE_ROOT}/cluster/bin
-  tar -xf bazel-bin/external/io_k8s_release/kubernetes-server-linux-amd64.tar ./kubernetes/server/bin/kubectl --to-stdout > ${KUBE_ROOT}/cluster/bin/kubectl
+  tar -xf ${KUBE_ROOT}/bazel-bin/external/io_k8s_release/kubernetes-server-linux-amd64.tar ./kubernetes/server/bin/kubectl --to-stdout > ${KUBE_ROOT}/cluster/bin/kubectl
   chmod +x ${KUBE_ROOT}/cluster/bin/kubectl
   if ! "${KUBE_ROOT}/cluster/kubectl.sh" version --client >&/dev/null; then
     echo "!!! kubectl(${KUBE_ROOT}/cluster/kubectl.sh) appears to be broken or missing"


### PR DESCRIPTION
Like the rest of the code in kube-up, verify-kube-binaries
should not look for binaries based on the current working
directory. Instead, it should use $KUBE_ROOT.