### PR TITLE
Create the bucket for tars based on $PROJECT

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -338,7 +338,7 @@ function upload-tars() {
     # Ensure the buckets are created
     if ! gsutil ls "${staging_bucket}" >/dev/null; then
       echo "Creating ${staging_bucket}"
-      gsutil mb -l "${region}" "${staging_bucket}"
+      gsutil mb -l "${region}" -p "${PROJECT}" "${staging_bucket}"
     fi
 
     local staging_path="${staging_bucket}/${INSTANCE_PREFIX}-devel"

--- a/test/boskos.sh
+++ b/test/boskos.sh
@@ -14,8 +14,8 @@ acquire_project() {
 
     if project=$(echo "${boskos_response}" | jq -r '.name'); then
         echo "Using GCP project: ${project}"
-        CLOUDSDK_CORE_PROJECT="${project}"
-        export CLOUDSDK_CORE_PROJECT
+        PROJECT="${project}"
+        export PROJECT
         heartbeat_project_forever &
         BOSKOS_HEARTBEAT_PID=$!
         export BOSKOS_HEARTBEAT_PID
@@ -27,12 +27,12 @@ acquire_project() {
 
 # release the project back to boskos
 release_project() {
-    curl -X POST "http://boskos/release?name=${CLOUDSDK_CORE_PROJECT}&owner=${JOB_NAME}&dest=dirty"
+    curl -X POST "http://boskos/release?name=${PROJECT}&owner=${JOB_NAME}&dest=dirty"
 }
 
 # send a heartbeat to boskos for the project
 heartbeat_project() {
-    curl -X POST "http://boskos/update?name=${CLOUDSDK_CORE_PROJECT}&state=busy&owner=${JOB_NAME}" > /dev/null 2>&1
+    curl -X POST "http://boskos/update?name=${PROJECT}&state=busy&owner=${JOB_NAME}" > /dev/null 2>&1
 }
 
 # heartbeat_project in an infinite loop


### PR DESCRIPTION
This did not cause issues in the past because the current e2e script sets `$CLOUDSDK_CORE_PROJECT` which the gcloud utils use. However, `$PROJECT` should be supported and preferred. Before this fix, if the user sets `$PROJECT` but has a different default project, the bucket gets created in the wrong project and the created VMs cannot read from that bucket due to permission issues.

Related to this issue, and included in this PR: the _only_ place (outside of the windows README) that `$CLOUDSDK_CORE_PROJECT` is even referenced is in the test/boskos.sh script. Updated to make it use `$PROJECT` as well to conform with the norm.

Tested by setting just `$PROJECT` and just `$CLOUDSDK_CORE_PROJECT`.