### PR TITLE
Ignore meaningless failures when setting bucket ACLs during kube-up.sh

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -241,7 +241,7 @@ function copy-to-staging() {
 
   #echo "${hash}" > "${tar}.sha1"
   gsutil -m -q -h "Cache-Control:private, max-age=0" cp "${tar}" "${tar}.sha512" "${staging_path}"
-  gsutil -m acl ch -g all:R "${gs_url}" "${gs_url}.sha512" >/dev/null 2>&1
+  gsutil -m acl ch -g all:R "${gs_url}" "${gs_url}.sha512" >/dev/null 2>&1 || true
   echo "+++ ${basename_tar} uploaded (sha512 = ${hash})"
 }
 


### PR DESCRIPTION
In a fresh GCP project, kube-up.sh will fail on two runs before succeeding. This is because it copies two files to staging during its run. When the file 1 is copied to the bucket, we hit this ACL-setting line which fails for weird bucket permission errors. The next run, kube-up discovers that file 1 is already in the bucket and doesn't call copy-to-staging, proceeding instead to copying file 2 to staging. The same error occurs. On the third run, both files are determined to be in the bucket and available and so the script proceeds without incident and completes a successful run. With this addition of || true, multiple runs are not necessary (it stops -e from killing the process).

**I would like to weigh this fix against removing the ACL change entirely, as it doesn't seem to be necessary. A run on a fresh project without the line also succeeds without incident.**

This issue occurred during the development and testing of: https://github.com/kubernetes/test-infra/pull/17964