### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ approvers:
 - freehan
 - nicksardo
 - mrhohn
-- dnardo
 - mikedanese
 - calebamiles
+emeritus_approvers:
+- dnardo


### PR DESCRIPTION
As a part of kubernetes/org#2013, we are cleaning up inactive members from OWNERS who haven't been active
since the release of v1.11. This commit removes dnardo from OWNERS.

/assign @cheftako 
cc @dnardo 