### PR TITLE
Updated rules_docker to latest to fix build error

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,9 +29,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "480daa8737bf4370c1a05bfced903827e75046fea3123bd8c81389923d968f55",
-    strip_prefix = "rules_docker-0.11.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.11.0.tar.gz"],
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+    strip_prefix = "rules_docker-0.14.4",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
 )
 
 load("@bazel_skylib//lib:versions.bzl", "versions")
@@ -66,6 +66,10 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
 
 container_pull(
     name = "distroless",


### PR DESCRIPTION
Fixes error encountered when running `bazel build //release:release-tars` on current master.

`
ERROR: /usr/local/google/home/dresser/.cache/bazel/_bazel_dresser/944c284ce0faecea697971732fd904d3/external/io_bazel_rules_docker/container/BUILD:85:11: no such package '@bazel_tools//third_party/py/gflags': BUILD file not found in directory 'third_party/py/gflags' of external repository @bazel_tools. Add a BUILD file to a directory to mark it as a package. and referenced by '@io_bazel_rules_docker//container:build_tar_lib'
`


Updates to latest version based on: https://github.com/bazelbuild/rules_docker#setup