### PR TITLE
CSR Approver/Signer: Only handle CSRs meant for the default signer

### DIFF
--- a/cmd/gcp-controller-manager/csr_approver.go
+++ b/cmd/gcp-controller-manager/csr_approver.go
@@ -38,6 +38,7 @@ import (
 
 	authorization "k8s.io/api/authorization/v1beta1"
 	capi "k8s.io/api/certificates/v1beta1"
+	certsv1b1 "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -312,6 +313,9 @@ func isNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Certific
 	if !isNodeCert(csr, x509cr) {
 		return false
 	}
+	if csr.Spec.SignerName == nil || *csr.Spec.SignerName != certsv1b1.KubeAPIServerClientKubeletSignerName {
+		return false
+	}
 	if len(x509cr.DNSNames) > 0 || len(x509cr.IPAddresses) > 0 {
 		return false
 	}
@@ -327,6 +331,9 @@ func isLegacyNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Ce
 
 func isNodeServerCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
 	if !isNodeCert(csr, x509cr) {
+		return false
+	}
+	if csr.Spec.SignerName == nil || *csr.Spec.SignerName != certsv1b1.KubeletServingSignerName {
 		return false
 	}
 	if !hasExactUsages(csr, kubeletServerUsages) {


### PR DESCRIPTION
CSR signer names, a mechanism for having multiple CSR signers coexisting in the same cluster, have landed in Kubernetes 1.18.  To let auxiliary approvers and signers coexist with the default signer, it needs to be updated to only handle CSRs that are addressed to it.

This commit:

  * Updates the approver to only act on CSRs addressed to `kubernetes.io/kube-apiserver-client-kubelet` and `kubernetes.io/kubelet-serving`.

  * Updates the signer to only act on CSRs addressed to `kubernetes.io/kube-apiserver-client`, `kubernetes.io/kube-apiserver-client-kubelet`, `kubernetes.io/kubelet-serving`, and `kubernetes.io/legacy-unknown`.

This should preserve all existing usecases, including that of people manually approving CSRs with kubectl and then having them be signed by the default signer.