### PR TITLE
OWNERS: move nicksardo to emeritus_approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,9 @@ approvers:
 - jingxu97
 - bowei
 - freehan
-- nicksardo
 - mrhohn
 - mikedanese
 - calebamiles
 emeritus_approvers:
 - dnardo
+- nicksardo


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves nicksardo to
emeritus_approvers section.

cc @nicksardo @mrbobbytables 

/kind cleanup
/assign @cheftako 

