### PR TITLE
Add DNS csr verification for gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/csr_approver_test.go
+++ b/cmd/gcp-controller-manager/csr_approver_test.go
@@ -396,6 +396,7 @@ func TestValidators(t *testing.T) {
 			c.gcpCfg.Zones = []string{"z1", "z0"}
 			b.requestor = "system:node:i0"
 			b.ips = []net.IP{net.ParseIP("1.2.3.4")}
+			b.dns = []string{"i0.z0.c.p0.internal", "i0.c.p0.internal"}
 		}
 		cases := []func(*csrBuilder, *controllerContext){goodCase}
 		testValidator(t, "good", cases, fn, true, false)
@@ -431,6 +432,16 @@ func TestValidators(t *testing.T) {
 			func(b *csrBuilder, c *controllerContext) {
 				goodCase(b, c)
 				b.ips = []net.IP{net.ParseIP("1.2.3.5")}
+			},
+			// Not matching zonal DNS.
+			func(b *csrBuilder, c *controllerContext) {
+				goodCase(b, c)
+				b.dns = []string{"i1.z0.c.p1.internal", "i0.c.p0.internal"}
+			},
+			// Not matching global DNS.
+			func(b *csrBuilder, c *controllerContext) {
+				goodCase(b, c)
+				b.dns = []string{"i0.z0.c.p0.internal", "i1.c.p1.internal"}
 			},
 		}
 		testValidator(t, "bad", cases, fn, false, false)


### PR DESCRIPTION
The gcp-cloud-provider auto-approves CSR requests for serving certificates using logic at https://github.com/kubernetes/cloud-provider-gcp/blob/16a329f8c7133b72f4950aba624b6e3b3c24a66c/cmd/gcp-controller-manager/csr_approver.go#L347-L389

That approver verifies the IP address SANs in the CSR are actually associated with the node record in metadata. It does not verify DNS names in the CSR at all.

This would allow anyone with node credentials to request/obtain a serving certificate signed by the cluster CA valid for any DNS name, including DNS names associated with other nodes.

Because the kube-apiserver runs configured with --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname, and GCP nodes report InternalIP and ExternalIP addresses, the kube-apiserver will use IP info to connect to nodes, not DNS names.

It appears that the only DNS name the kubelet GCE cloud provider will request is the instance/hostname value:

https://github.com/kubernetes/kubernetes/blob/3895b1e4a0f8044540365a5a0a086cba0af77340/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go#L143-L151