### PR TITLE
test: update pause-win image to the new one k8s.gcr.io/pause:3.4.1

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -51,7 +51,7 @@
 #  - Document functions using proper syntax:
 #    https://technet.microsoft.com/en-us/library/hh847834(v=wps.620).aspx
 
-$INFRA_CONTAINER = 'gcr.io/gke-release/pause-win:1.1.0'
+$INFRA_CONTAINER = 'k8s.gcr.io/pause:3.4.1'
 $GCE_METADATA_SERVER = "169.254.169.254"
 # The "management" interface is used by the kubelet and by Windows pods to talk
 # to the rest of the Kubernetes cluster *without NAT*. This interface does not

--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -358,7 +358,7 @@ spec:
     spec:
       containers:
       - name: pause-win
-        image: gcr.io/gke-release/pause-win:1.1.0
+        image: k8s.gcr.io/pause:3.4.1
       nodeSelector:
         kubernetes.io/os: windows
       tolerations:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

As part of the efforts described in this Issue: https://github.com/kubernetes/k8s.io/issues/1525 we are trying to move away from `gcp project gke-release`

Also the pause image was release with windows support as we can see in the merged or in k/k https://github.com/kubernetes/kubernetes/pull/98205

/assign @spiffxp @saad-ali

