### PR TITLE
cluster: Remove inactive members from OWNERS

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -3,8 +3,6 @@
 reviewers:
   - bowei
   - cjcullen
-  - gmarek
-  - jingax10
   - MaciekPytel
   - mtaufen
   - mwielgus
@@ -16,10 +14,11 @@ approvers:
   - bowei
   - cheftako
   - cjcullen
-  - gmarek
-  - jingax10
   - MaciekPytel
   - mtaufen
   - mwielgus
   - vishh
   - yujuhong
+emeritus_approvers:
+- gmarek
+- jingax10


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

Move gmarek and jingax10 to emeritus

/assign @cheftako 