### PR TITLE
Windows crossbuild support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ This command will build and publish
 IMAGE_REGISTRY=example.com IMAGE_REPO=my-repo IMAGE_TAG=v1 bazel run //cmd/gcp-controller-manager:publish
 ```
 
+# Cross-compiling
+
+Selecting the target platform is done with the `--platforms` option with `bazel`.
+This command builds release tarballs for Windows:
+
+```
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //release:release-tars
+```
+
+This command explicitly targets Linux as the target platform:
+
+```
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //release:release-tars
+```
+
+
 # Dependency management
 
 Dependencies are managed using [Go modules](https://github.com/golang/go/wiki/Modules) (`go mod` subcommands).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,8 +105,14 @@ fetch_kube_release(
         #"kubernetes-manifests.tar.gz": "38946246fb192d6e877d0d04a7b0645980b983b8b81ca2a259c50a035ced815b7",
         "kubernetes-manifests.tar.gz": "bf99bd768afdda829f617038b10aafff7f8cd07071bd0e8b585f118bfbff9df7",
         # we do not currently make modifications to these release tars below
+<<<<<<< HEAD
         #"kubernetes-node-linux-amd64.tar.gz": "7128a3c647c93181b7b52b668eb3030b8beee025b8b4614f14f159874e47dc34",
         "kubernetes-node-linux-amd64.tar.gz": "5baa2b45bdca2dd09d03b9e2a4fb17e105c47972b600f7c2dcbdbaec2a956ae1",
+=======
+        #"kubernetes-node-linux-amd64.tar.gz": "d32e568a78230ee25de25ca5ba0d9fc9b5b783d0e41fadb983f318b338a70357",
+        "kubernetes-node-linux-amd64.tar.gz": "7128a3c647c93181b7b52b668eb3030b8beee025b8b4614f14f159874e47dc34",
+        "kubernetes-node-windows-amd64.tar.gz": "3e2a0560a3af45add14290f4dddc6e5720b34851b49b3a7f1a4144f1e35a0dcb",
+>>>>>>> a71f515f (Add initial Windows crossbuild support.)
     },
     version = "v1.20.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,14 +105,9 @@ fetch_kube_release(
         #"kubernetes-manifests.tar.gz": "38946246fb192d6e877d0d04a7b0645980b983b8b81ca2a259c50a035ced815b7",
         "kubernetes-manifests.tar.gz": "bf99bd768afdda829f617038b10aafff7f8cd07071bd0e8b585f118bfbff9df7",
         # we do not currently make modifications to these release tars below
-<<<<<<< HEAD
         #"kubernetes-node-linux-amd64.tar.gz": "7128a3c647c93181b7b52b668eb3030b8beee025b8b4614f14f159874e47dc34",
         "kubernetes-node-linux-amd64.tar.gz": "5baa2b45bdca2dd09d03b9e2a4fb17e105c47972b600f7c2dcbdbaec2a956ae1",
-=======
-        #"kubernetes-node-linux-amd64.tar.gz": "d32e568a78230ee25de25ca5ba0d9fc9b5b783d0e41fadb983f318b338a70357",
-        "kubernetes-node-linux-amd64.tar.gz": "7128a3c647c93181b7b52b668eb3030b8beee025b8b4614f14f159874e47dc34",
         "kubernetes-node-windows-amd64.tar.gz": "3e2a0560a3af45add14290f4dddc6e5720b34851b49b3a7f1a4144f1e35a0dcb",
->>>>>>> a71f515f (Add initial Windows crossbuild support.)
     },
     version = "v1.20.0",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -107,7 +107,7 @@ fetch_kube_release(
         # we do not currently make modifications to these release tars below
         #"kubernetes-node-linux-amd64.tar.gz": "7128a3c647c93181b7b52b668eb3030b8beee025b8b4614f14f159874e47dc34",
         "kubernetes-node-linux-amd64.tar.gz": "5baa2b45bdca2dd09d03b9e2a4fb17e105c47972b600f7c2dcbdbaec2a956ae1",
-        "kubernetes-node-windows-amd64.tar.gz": "3e2a0560a3af45add14290f4dddc6e5720b34851b49b3a7f1a4144f1e35a0dcb",
+        "kubernetes-node-windows-amd64.tar.gz": "0756353944bb182984384f398df3586c14b7a6228d18cef27a294a3b69a4f4d1",
     },
     version = "v1.20.0",
 )

--- a/release/BUILD
+++ b/release/BUILD
@@ -27,6 +27,20 @@ pkg_tar(
     ],
 )
 
+pkg_tar(
+    name = "kubernetes-node-windows-amd64",
+    srcs = [
+        "//cmd/auth-provider-gcp",
+    ],
+    extension = "tar.gz",
+    remap_paths = {
+        "/auth-provider-gcp.exe": "kubernetes/node/bin/auth-provider-gcp.exe",
+    },
+    deps = [
+        "@io_k8s_release//:kubernetes-node-windows-amd64",
+    ],
+)
+
 genrule(
     name = "rename_ccm_image",
     srcs = ["//cmd/cloud-controller-manager:image.tar"],
@@ -75,6 +89,19 @@ genrule(
     cmd = "shasum -a512 $< > $<.sha512",
 )
 
+genrule(
+    name = "gen_windows_node_shasum",
+    srcs = [
+        ":kubernetes-node-windows-amd64.tar.gz",
+    ],
+    outs = [
+        ":kubernetes-node-windows-amd64.tar.gz.sha512",
+    ],
+    output_to_bindir = 1,
+    cmd = "shasum -a512 $< > $<.sha512",
+)
+
+
 pkg_tar(
     name = "kubernetes-manifests",
     extension = "tar.gz",
@@ -94,3 +121,11 @@ release_filegroup(
         "@io_k8s_release//:kubernetes-node-linux-amd64",
     ],
 )
+
+release_filegroup(
+    name = "release-tars-windows",
+    srcs = [
+        ":kubernetes-node-windows-amd64.tar.gz.sha512",
+         "@io_k8s_release//:kubernetes-node-windows-amd64",
+    ]
+) 

--- a/release/BUILD
+++ b/release/BUILD
@@ -116,24 +116,14 @@ pkg_tar(
 release_filegroup(
     name = "release-tars",
     conditioned_srcs = {
-         "@io_bazel_rules_go//go/platform:linux_amd64": [":release-tars-linux"],
-         "@io_bazel_rules_go//go/platform:windows_amd64": [":release-tars-windows"],
-        },
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            ":kubernetes-manifests.tar.gz.sha512",
+            ":kubernetes-server-linux-amd64.tar.gz.sha512",
+            "@io_k8s_release//:kubernetes-node-linux-amd64",
+        ],
+        "@io_bazel_rules_go//go/platform:windows_amd64": [
+            ":kubernetes-node-windows-amd64.tar.gz.sha512",
+            "@io_k8s_release//:kubernetes-node-windows-amd64",
+        ]
+    }
 )
-
-release_filegroup(
-    name = "release-tars-linux",
-    srcs = [
-        ":kubernetes-manifests.tar.gz.sha512",
-        ":kubernetes-server-linux-amd64.tar.gz.sha512",
-        "@io_k8s_release//:kubernetes-node-linux-amd64",
-    ],
-)
-
-release_filegroup(
-    name = "release-tars-windows",
-    srcs = [
-        ":kubernetes-node-windows-amd64.tar.gz.sha512",
-         "@io_k8s_release//:kubernetes-node-windows-amd64",
-    ]
-) 

--- a/release/BUILD
+++ b/release/BUILD
@@ -115,6 +115,14 @@ pkg_tar(
 
 release_filegroup(
     name = "release-tars",
+    conditioned_srcs = {
+         "@io_bazel_rules_go//go/platform:linux_amd64": [":release-tars-linux"],
+         "@io_bazel_rules_go//go/platform:windows_amd64": [":release-tars-windows"],
+        },
+)
+
+release_filegroup(
+    name = "release-tars-linux",
     srcs = [
         ":kubernetes-manifests.tar.gz.sha512",
         ":kubernetes-server-linux-amd64.tar.gz.sha512",


### PR DESCRIPTION
This PR is intended to add the ability to build Windows nodes while using the `--platforms=@io_bazel_rules_go//go/toolchain:windows_amd64` option in Bazel, e.g., `bazel build --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 //release:release-tars`. This PR does not handle deployment of Windows nodes, only building. 