### PR TITLE
Bugfix for DNS validation doesn't work for Windows

### DIFF
--- a/cmd/gcp-controller-manager/csr_approver.go
+++ b/cmd/gcp-controller-manager/csr_approver.go
@@ -369,8 +369,9 @@ func validateNodeServerCert(ctx *controllerContext, csr *capi.CertificateSigning
 		}
 
 		for _, dns := range x509cr.DNSNames {
-			// DNSName should be as the format of [INSTANCE_NAME].c.[PROJECT_ID].internal when using the global DNS, and [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal when using zonal DNS.
-			if dns != fmt.Sprintf("%s.c.%s.internal", instanceName, ctx.gcpCfg.ProjectID) && dns != fmt.Sprintf("%s.%s.c.%s.internal", instanceName, z, ctx.gcpCfg.ProjectID) {
+			// Linux DNSName should be as the format of [INSTANCE_NAME].c.[PROJECT_ID].internal when using the global DNS, and [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal when using zonal DNS.
+			// Windows DNSName should be INSTANCE_NAME
+			if dns != instanceName && dns != fmt.Sprintf("%s.c.%s.internal", instanceName, ctx.gcpCfg.ProjectID) && dns != fmt.Sprintf("%s.%s.c.%s.internal", instanceName, z, ctx.gcpCfg.ProjectID) {
 				klog.Infof("deny CSR %q: DNSName in CSR (%q) doesn't match default DNS format on instance %q", csr.Name, dns, instanceName)
 				return false, nil
 			}

--- a/cmd/gcp-controller-manager/csr_approver_test.go
+++ b/cmd/gcp-controller-manager/csr_approver_test.go
@@ -396,7 +396,7 @@ func TestValidators(t *testing.T) {
 			c.gcpCfg.Zones = []string{"z1", "z0"}
 			b.requestor = "system:node:i0"
 			b.ips = []net.IP{net.ParseIP("1.2.3.4")}
-			b.dns = []string{"i0.z0.c.p0.internal", "i0.c.p0.internal"}
+			b.dns = []string{"i0.z0.c.p0.internal", "i0.c.p0.internal", "i0"}
 		}
 		cases := []func(*csrBuilder, *controllerContext){goodCase}
 		testValidator(t, "good", cases, fn, true, false)
@@ -436,12 +436,17 @@ func TestValidators(t *testing.T) {
 			// Not matching zonal DNS.
 			func(b *csrBuilder, c *controllerContext) {
 				goodCase(b, c)
-				b.dns = []string{"i1.z0.c.p1.internal", "i0.c.p0.internal"}
+				b.dns = []string{"i1.z0.c.p1.internal", "i0.c.p0.internal", "i0"}
 			},
 			// Not matching global DNS.
 			func(b *csrBuilder, c *controllerContext) {
 				goodCase(b, c)
-				b.dns = []string{"i0.z0.c.p0.internal", "i1.c.p1.internal"}
+				b.dns = []string{"i0.z0.c.p0.internal", "i1.c.p1.internal", "i0"}
+			},
+			// Not matching windows DNS.
+			func(b *csrBuilder, c *controllerContext) {
+				goodCase(b, c)
+				b.dns = []string{"i0.z0.c.p0.internal", "i0.c.p0.internal", "i1"}
 			},
 		}
 		testValidator(t, "bad", cases, fn, false, false)


### PR DESCRIPTION
With the following query:
```
resource.type="container"
resource.labels.cluster_name="staging2-xpn-windows-2021-02-26-1f192"
resource.labels.container_name="gcp-controller-manager"
```
The code failed with error message `deny CSR "csr-srd6l": DNSName in CSR ("gke-staging2-xpn-windows--test-win-np-dcf30bf7-22kw") doesn't match default DNS format on instance "gke-staging2-xpn-windows--test-win-np-dcf30bf7-22kw"`
