### PR TITLE
Remove invalid options from CCM manifest

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1921,9 +1921,6 @@ function start-cloud-controller-manager {
   elif [[ -n "${ALLOCATE_NODE_CIDRS:-}" ]]; then
     params+=" --allocate-node-cidrs=${ALLOCATE_NODE_CIDRS}"
   fi
-  if [[ -n "${TERMINATED_POD_GC_THRESHOLD:-}" ]]; then
-    params+=" --terminated-pod-gc-threshold=${TERMINATED_POD_GC_THRESHOLD}"
-  fi
   if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
     params+=" --cidr-allocator-type=${NODE_IPAM_MODE}"
     params+=" --configure-cloud-routes=false"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1928,9 +1928,6 @@ function start-cloud-controller-manager {
   if [[ -n "${FEATURE_GATES:-}" ]]; then
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
-  if [[ -n "${CLUSTER_SIGNING_DURATION:-}" ]]; then
-    params+=" --experimental-cluster-signing-duration=$CLUSTER_SIGNING_DURATION"
-  fi
   # Disable using HPA metrics REST clients if metrics-server isn't enabled,
   # or if we want to explicitly disable it by setting HPA_USE_REST_CLIENT.
   if [[ "${ENABLE_METRICS_SERVER:-}" != "true" ]] ||

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1928,12 +1928,6 @@ function start-cloud-controller-manager {
   if [[ -n "${FEATURE_GATES:-}" ]]; then
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
-  # Disable using HPA metrics REST clients if metrics-server isn't enabled,
-  # or if we want to explicitly disable it by setting HPA_USE_REST_CLIENT.
-  if [[ "${ENABLE_METRICS_SERVER:-}" != "true" ]] ||
-     [[ "${HPA_USE_REST_CLIENTS:-}" == "false" ]]; then
-    params+=" --horizontal-pod-autoscaler-use-rest-clients=false"
-  fi
   if [[ -n "${RUN_CONTROLLERS:-}" ]]; then
     params+=" --controllers=${RUN_CONTROLLERS}"
   fi


### PR DESCRIPTION
This PR removes the ability for `start-cloud-controller-manager` to add `--terminated-pod-gc-threshold`, `--experimental-cluster-signing-duration`, and `--horizontal-pod-autoscaler-use-rest-clients` as options for the CCM, since all three only apply to the KCM and will prevent the CCM from starting if passed.

The full list of supported options, as seen from `cloud-controller-manager --help`, can be seen [here](https://gist.github.com/DangerOnTheRanger/a3af8ebb420210db9ac9e6a56661da56).