### PR TITLE
gcp-controller-manager: Fix startup panic

### DIFF
--- a/cmd/gcp-controller-manager/BUILD
+++ b/cmd/gcp-controller-manager/BUILD
@@ -83,6 +83,7 @@ go_library(
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/component-base/config:go_default_library",
         "//vendor/k8s.io/component-base/config/options:go_default_library",
+        "//vendor/k8s.io/component-base/logs:go_default_library",
         "//vendor/k8s.io/component-base/version/verflag:go_default_library",
         "//vendor/k8s.io/controller-manager/pkg/clientbuilder:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/healthz"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/component-base/config/options"
+	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/controller-manager/pkg/clientbuilder"
 	"k8s.io/klog/v2"
@@ -76,8 +77,8 @@ var (
 )
 
 func main() {
-	klog.InitFlags(flag.CommandLine)
-	defer klog.Flush()
+	logs.InitLogs()
+
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	leConfig := &componentbaseconfig.LeaderElectionConfiguration{


### PR DESCRIPTION
The component-base package already calls klog.InitFlags in an init() function (whhhyyyyyyy???).  We were transitively including the offending package.  Make the dependency explicit, and remove our now-redundant call to InitFlag.