### PR TITLE
do a readonly install of golint for tools/verify-golint.sh

### DIFF
--- a/tools/verify-golint.sh
+++ b/tools/verify-golint.sh
@@ -36,7 +36,7 @@ PATH="${GOBIN}:${PATH}"
 # Install golint
 echo 'installing golint'
 pushd "${KUBE_ROOT}/tools" >/dev/null
-  GO111MODULE=on go get -u golang.org/x/lint/golint
+  GO111MODULE=on go install -mod=readonly golang.org/x/lint/golint
 popd >/dev/null
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
https://github.com/kubernetes/cloud-provider-gcp/pull/216 just failed because `go get` was updating go.mod, which then causes the check that vendor/modules.txt fails: https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/cloud-provider-gcp/216/cloud-provider-gcp-verify-all/1391845103726759936/build-log.txt

I've fixed this by instead using `go install -mod readonly`