### PR TITLE
bump to go1.16

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,7 +45,7 @@ go_rules_dependencies()
 go_download_sdk(
     name = "go_sdk",
     sdks = {
-        "linux_amd64": ("go1.15.10b5.linux-amd64.tar.gz", "7533b0307fd995deb9ef68d67899582c336a3c62387d19d03d10202129e9fad3"),
+        "linux_amd64": ("go1.16.4b7.linux-amd64.tar.gz", "de60f0620f46b1872813f72646fdece76be94f43c1abe84b69033c26f823a31f"),
     },
     urls = ["https://storage.googleapis.com/go-boringcrypto/{}"],
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-gcp
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.75.0

--- a/providers/go.mod
+++ b/providers/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-gcp/providers
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go v0.65.0

--- a/tools/verify-golint.sh
+++ b/tools/verify-golint.sh
@@ -35,8 +35,8 @@ PATH="${GOBIN}:${PATH}"
 
 # Install golint
 echo 'installing golint'
-pushd "${KUBE_ROOT}/tools" >/dev/null
-  GO111MODULE=on go install -mod=readonly golang.org/x/lint/golint
+pushd $(mktemp -d) >/dev/null
+  GO111MODULE=on go get -u golang.org/x/lint/golint
 popd >/dev/null
 
 cd "${KUBE_ROOT}"


### PR DESCRIPTION
We should port this back to our release-1.21 branch after this merges.