### PR TITLE
Use at minimum n1-standard-2 in cluster/gce/config-common.sh

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -27,10 +27,7 @@ function get-num-nodes {
 #   NUM_NODES
 #   NUM_WINDOWS_NODES
 function get-master-size {
-  local suggested_master_size=1
-  if [[ "$(get-num-nodes)" -gt "5" ]]; then
-    suggested_master_size=2
-  fi
+  local suggested_master_size=2
   if [[ "$(get-num-nodes)" -gt "10" ]]; then
     suggested_master_size=4
   fi


### PR DESCRIPTION
This PR increases the minimum returned VM model from an `n1-standard-1` to `n1-standard-2`, as there are resource limit issues with the 1vCPU model with `kubetest2`.

* Resource usage with [`n1-standard-2`](https://github.com/kubernetes/cloud-provider-gcp/pull/216#issuecomment-837469430)
* Resource usage with [`n1-standard-1`](https://gist.github.com/DangerOnTheRanger/6ca3d0e16f901f595732d3fd952bf684)