### PR TITLE
Update gcp auth provider config

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -3201,6 +3201,7 @@ providers:
     - "*.gcr.io"
     - "*.pkg.dev"
     args:
+    - get-credentials
     - --v=3
     defaultCacheDuration: 1m
 EOF


### PR DESCRIPTION


get-credentials needs to be passed in args to make gcp-auth-provider working