### PR TITLE
Set CacheKeyType on credential provider response

### DIFF
--- a/cmd/auth-provider-gcp/provider/provider.go
+++ b/cmd/auth-provider-gcp/provider/provider.go
@@ -96,5 +96,6 @@ func GetResponse(image string, provider credentialconfig.DockerConfigProvider) (
 	}
 	response.TypeMeta.Kind = apiKind
 	response.TypeMeta.APIVersion = apiVersion
+	response.CacheKeyType = credentialproviderapi.RegistryPluginCacheKeyType
 	return response, nil
 }

--- a/cmd/auth-provider-gcp/provider/provider_test.go
+++ b/cmd/auth-provider-gcp/provider/provider_test.go
@@ -34,6 +34,7 @@ const (
 	dummyToken       = "ya26.lots-of-indiscernible-garbage"
 	email            = "1234@project.gserviceaccount.com"
 	expectedUsername = "_token"
+	expectedCacheKey = credentialproviderapi.RegistryPluginCacheKeyType
 	dummyImage       = "k8s.gcr.io/pause"
 )
 
@@ -87,6 +88,9 @@ func TestContainerRegistry(t *testing.T) {
 	if hasURL(registryURL, response) == false {
 		t.Errorf("URL %s expected in response, not found (response: %s)", registryURL, response.Auth)
 	}
+	if expectedCacheKey != response.CacheKeyType {
+		t.Errorf("Expected %s as cache key (found %s instead)", expectedCacheKey, response.CacheKeyType)
+	}
 	for _, auth := range response.Auth {
 		if expectedUsername != auth.Username {
 			t.Errorf("Expected username %s not found (username: %s)", expectedUsername, auth.Username)
@@ -136,6 +140,9 @@ func TestConfigProvider(t *testing.T) {
 	response, err := GetResponse(dummyImage, provider)
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
+	}
+	if expectedCacheKey != response.CacheKeyType {
+		t.Errorf("Expected %s as cache key (found %s instead)", expectedCacheKey, response.CacheKeyType)
 	}
 	for _, auth := range response.Auth {
 		if username != auth.Username {
@@ -190,6 +197,9 @@ func TestConfigURLProvider(t *testing.T) {
 	response, err := GetResponse(dummyImage, provider)
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
+	}
+	if expectedCacheKey != response.CacheKeyType {
+		t.Errorf("Expected %s as cache key (found %s instead)", expectedCacheKey, response.CacheKeyType)
 	}
 	for _, auth := range response.Auth {
 		if username != auth.Username {

--- a/cmd/auth-provider-gcp/provider/provider_test.go
+++ b/cmd/auth-provider-gcp/provider/provider_test.go
@@ -34,7 +34,7 @@ const (
 	dummyToken       = "ya26.lots-of-indiscernible-garbage"
 	email            = "1234@project.gserviceaccount.com"
 	expectedUsername = "_token"
-	expectedCacheKey = credentialproviderapi.RegistryPluginCacheKeyType
+	expectedCacheKey = credentialproviderapi.ImagePluginCacheKeyType
 	dummyImage       = "k8s.gcr.io/pause"
 )
 


### PR DESCRIPTION
This PR fixes #226 by setting `response.CacheKeyType`  on the credential provider and checking for its presence/correctly set value in the unit test suite.