### PR TITLE
Handle internal IPV6 addresses from gce nodes if cluster is dual stack

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -132,6 +132,7 @@ type Cloud struct {
 	unsafeSubnetworkURL string
 	// DEPRECATED: Do not rely on this value as it may be incorrect.
 	secondaryRangeName       string
+	stackType                string
 	networkProjectID         string
 	onXPN                    bool
 	nodeTags                 []string    // List of tags to use on firewall rules for load balancers
@@ -185,6 +186,7 @@ type ConfigGlobal struct {
 	// aliases. The secondary range must be present on the subnetwork the
 	// cluster is attached to.
 	SecondaryRangeName string   `gcfg:"secondary-range-name"`
+	StackType          string   `gcfg:"stack-type"`
 	NodeTags           []string `gcfg:"node-tags"`
 	NodeInstancePrefix string   `gcfg:"node-instance-prefix"`
 	Regional           bool     `gcfg:"regional"`
@@ -230,6 +232,7 @@ type CloudConfig struct {
 	SubnetworkURL        string
 	// DEPRECATED: Do not rely on this value as it may be incorrect.
 	SecondaryRangeName string
+	StackType          string
 	NodeTags           []string
 	NodeInstancePrefix string
 	TokenSource        oauth2.TokenSource
@@ -390,6 +393,7 @@ func generateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 
 	if configFile != nil {
 		cloudConfig.SecondaryRangeName = configFile.Global.SecondaryRangeName
+		cloudConfig.StackType = configFile.Global.StackType
 	}
 
 	return cloudConfig, err
@@ -517,6 +521,7 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		unsafeIsLegacyNetwork:    isLegacyNetwork,
 		unsafeSubnetworkURL:      subnetURL,
 		secondaryRangeName:       config.SecondaryRangeName,
+		stackType:                config.StackType,
 		nodeTags:                 config.NodeTags,
 		nodeInstancePrefix:       config.NodeInstancePrefix,
 		useMetadataServer:        config.UseMetadataServer,

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -118,12 +118,17 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
 
 				if g.stackType == "IPV4_IPV6" {
+					// Handling only the internal v6 address. External v6 addresses will be handled once vendor apis are updated.
 					internalIPV6, err := metadata.Get(fmt.Sprintf(networkInterfaceIPV6, nic))
 					if err != nil {
 						return nil, fmt.Errorf("couldn't get internal IPV6: %v", err)
 					}
 					internalIPV6 = strings.TrimSuffix(internalIPV6, "\n")
-					nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPV6})
+					if internalIPV6 != "" {
+						nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPV6})
+					} else {
+						klog.Warningf("internal IPV6 range is empty")
+					}
 				}
 
 				acs, err := metadata.Get(fmt.Sprintf(networkInterfaceAccessConfigs, nic))


### PR DESCRIPTION
Introducing stackType to get the information about cluster IP stack type.

If the cluster is dual stack (i.e. IPV4_IPV6), we will handle the internal IPV6 addresses.