### PR TITLE
Use node's (not cluster's) location in syncNode to support Direct-Path in regional clusters

### DIFF
--- a/cmd/gcp-controller-manager/loops.go
+++ b/cmd/gcp-controller-manager/loops.go
@@ -104,7 +104,7 @@ func loops() map[string]func(*controllerContext) error {
 				ctx.sharedInformers.Core().V1().Pods(),
 				ctx.verifiedSAs,
 				ctx.hmsSyncNodeURL,
-				ctx.gcpCfg.Location,
+				ctx.client,
 			)
 			if err != nil {
 				return err

--- a/cmd/gcp-controller-manager/node_syncer.go
+++ b/cmd/gcp-controller-manager/node_syncer.go
@@ -17,13 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/workqueue"
@@ -47,10 +50,10 @@ type nodeSyncer struct {
 	nodes       *nodeMap
 	verifiedSAs *saMap
 	hms         *hmsClient
-	location    string
+	zones       *nodeZones
 }
 
-func newNodeSyncer(informer coreinformers.PodInformer, sm *saMap, hmsSyncNodeURL, location string) (*nodeSyncer, error) {
+func newNodeSyncer(informer coreinformers.PodInformer, sm *saMap, hmsSyncNodeURL string, client clientset.Interface) (*nodeSyncer, error) {
 	hms, err := newHMSClient(hmsSyncNodeURL, &clientcmdapi.AuthProviderConfig{Name: "gcp"})
 	if err != nil {
 		return nil, err
@@ -64,7 +67,7 @@ func newNodeSyncer(informer coreinformers.PodInformer, sm *saMap, hmsSyncNodeURL
 		nodes:       newNodeMap(),
 		verifiedSAs: sm,
 		hms:         hms,
-		location:    location,
+		zones:       newNodeZones(client),
 	}
 	informer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc:    ns.onPodAdd,
@@ -193,7 +196,11 @@ func (ns *nodeSyncer) sync(node string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve GSA list for Node %q: %v", node, err)
 	}
-	return ns.hms.sync(node, ns.location, gsaList)
+	zone, err := ns.zones.zoneByNode(node)
+	if err != nil {
+		return fmt.Errorf("failed to find zone for node %q: %w", node, err)
+	}
+	return ns.hms.sync(node, zone, gsaList)
 }
 
 // podMap is a map of GSAs indexed by Pod keys.
@@ -251,4 +258,35 @@ func (nm *nodeMap) gsaEmailsByNode(node string) ([]gsaEmail, error) {
 		l = append(l, gsa)
 	}
 	return l, nil
+}
+
+type nodeZones struct {
+	sync.Mutex
+	m      map[string]string
+	client clientset.Interface
+}
+
+func newNodeZones(client clientset.Interface) *nodeZones {
+	return &nodeZones{
+		m:      make(map[string]string),
+		client: client,
+	}
+}
+
+func (nz *nodeZones) zoneByNode(nodeName string) (string, error) {
+	nz.Lock()
+	defer nz.Unlock()
+	if zone, ok := nz.m[nodeName]; ok {
+		return zone, nil
+	}
+	node, err := nz.client.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get node object: %w", err)
+	}
+	_, zone, _, err := parseNodeURL(node.Spec.ProviderID)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse node url: %w", err)
+	}
+	nz.m[nodeName] = zone
+	return zone, nil
 }

--- a/cmd/gcp-controller-manager/node_syncer_test.go
+++ b/cmd/gcp-controller-manager/node_syncer_test.go
@@ -25,6 +25,7 @@ import (
 
 	core "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -77,6 +78,14 @@ func TestNodeSync(t *testing.T) {
 	podKey1 := testNamespace + "/testPod1"
 	podKey2 := testNamespace + "/testPod2"
 	podKeyUnauthz := testNamespace + "/testPodUnauthz"
+	node := &core.Node{
+		ObjectMeta: meta.ObjectMeta{
+			Name: testNode,
+		},
+		Spec: core.NodeSpec{
+			ProviderID: fmt.Sprintf("gce://project/%s/instance", testLoc),
+		},
+	}
 
 	tests := []struct {
 		desc        string
@@ -154,11 +163,11 @@ func TestNodeSync(t *testing.T) {
 				nodes.add(testNode, pod, gsa)
 			}
 			ns := &nodeSyncer{
-				location:    testLoc,
 				indexer:     fakeIndexer{obj: tc.idxObj, err: tc.idxErr},
 				hms:         hmsClient,
 				verifiedSAs: &verifiedSAs,
 				nodes:       nodes,
+				zones:       newNodeZones(fake.NewSimpleClientset(node)),
 			}
 
 			podKey := tc.keyOverride


### PR DESCRIPTION
In a regional cluster, the cluster location is the region. syncNode is zonal, so that it will fail. Add nodeZones to get node's zone via k8s clientset and store the result in a map.