### PR TITLE
replace gcr.io/gke-release to use the community registry for nvidia-gpu-device-plugin

### DIFF
--- a/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+++ b/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
         hostPath:
           path: /dev
       containers:
-      - image: "gcr.io/gke-release/nvidia-gpu-device-plugin@sha256:a75ec0caa9e3038bd9886b3f36641a624574ff34b064974de6ee45048de3372b"
+      - image: "k8s.gcr.io/nvidia-gpu-device-plugin@sha256:4b036e8844920336fa48f36edeb7d4398f426d6a934ba022848deed2edbf09aa"
         command: ["/usr/bin/nvidia-gpu-device-plugin", "-logtostderr"]
         name: nvidia-gpu-device-plugin
         resources:


### PR DESCRIPTION
As part of the efforts described in this Issue https://github.com/kubernetes/k8s.io/issues/1525

moving out from `gcr.io/gke-release` to `k8s.gcr.io` community registry


This image was changed to an equivalent in k/k per this PR https://github.com/kubernetes/kubernetes/pull/100294

Applying the same changes here.

/assign @spiffxp @bowei @BenTheElder