### PR TITLE
pkg/csrapproval: fix setting required fields

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/BUILD
+++ b/cmd/gke-gcloud-auth-plugin/BUILD
@@ -14,16 +14,12 @@ go_binary(
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "main.go",
-    ],
+    srcs = ["main.go"],
     importpath = "k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin",
     deps = [
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1:go_default_library",
         "//vendor/k8s.io/component-base/version/verflag:go_default_library",
     ],

--- a/pkg/csrapproval/BUILD
+++ b/pkg/csrapproval/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//pkg/csrmetrics:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/certificates/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",

--- a/pkg/csrapproval/csrapproval.go
+++ b/pkg/csrapproval/csrapproval.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authorization "k8s.io/api/authorization/v1"
@@ -218,15 +219,18 @@ func (vc *Context) updateCSR(csr *capi.CertificateSigningRequest, approved bool,
 			Type:    capi.CertificateApproved,
 			Reason:  "AutoApproved",
 			Message: msg,
+			// sense of this condition is true, i.e, approved
+			Status: corev1.ConditionTrue,
 		})
 	} else {
 		csr.Status.Conditions = append(csr.Status.Conditions, capi.CertificateSigningRequestCondition{
 			Type:    capi.CertificateDenied,
 			Reason:  "AutoDenied",
 			Message: msg,
+			Status:  corev1.ConditionTrue,
 		})
 	}
-	_, err := vc.Client.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.TODO(), "", csr, metav1.UpdateOptions{})
+	_, err := vc.Client.CertificatesV1().CertificateSigningRequests().UpdateApproval(context.TODO(), csr.Name, csr, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("error updating approval status for csr: %v", err)
 	}


### PR DESCRIPTION
update-approval requires the csr name in a param,
and csr.Condition.Status must be set.