### PR TITLE
Start the sharedInformers for cloud controller manager controllers

### DIFF
--- a/vendor/k8s.io/cloud-provider/app/controllermanager.go
+++ b/vendor/k8s.io/cloud-provider/app/controllermanager.go
@@ -294,6 +294,7 @@ func startControllers(cloud cloudprovider.Interface, ctx genericcontrollermanage
 	}
 
 	c.SharedInformers.Start(stopCh)
+	ctx.InformerFactory.Start(ctx.Stop)
 
 	select {}
 }


### PR DESCRIPTION
I am not sure if this is the right place to make this change. However, without this change, the nodeipam controller being merged in https://github.com/kubernetes/cloud-provider-gcp/pull/247 will hang in the WaitForNamedCacheSync function.