### PR TITLE
[WIP] LKG support

### DIFF
--- a/test/lkg-postsubmit.sh
+++ b/test/lkg-postsubmit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+CLOUD_PROVIDER_LKG_FILE="$(git rev-parse --show-toplevel)/PROVIDER_LKG_INFO"
+CLOUD_PROVIDER_LKG_HASH=$(git rev-parse --short HEAD)
+echo $CLOUD_PROVIDER_LKG_HASH > $CLOUD_PROVIDER_LKG_FILE
+git add $CLOUD_PROVIDER_LKG_FILE
+git commit -m "Update cloud-provider-gcp LKG version to $CLOUD_PROVIDER_LKG_HASH"

--- a/test/lkg-postsubmit.sh
+++ b/test/lkg-postsubmit.sh
@@ -10,3 +10,7 @@ NEWEST_LKG_BRANCH=$(git for-each-ref --sort=committerdate refs/heads/ --format='
 git checkout master
 git merge $NEWEST_LKG_BRANCH
 git push origin master
+
+git for-each-ref --sort=committerdate refs/heads/ --format='%(refname:short)' | grep $KUBERNETES_LKG_PATTERN | tail -n +1 | while read -r $OLD_LKG_BRANCH ; do
+    git push -d origin $OLD_LKG_BRANCH
+done

--- a/test/lkg-postsubmit.sh
+++ b/test/lkg-postsubmit.sh
@@ -5,8 +5,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-CLOUD_PROVIDER_LKG_FILE="$(git rev-parse --show-toplevel)/PROVIDER_LKG_INFO"
-CLOUD_PROVIDER_LKG_HASH=$(git rev-parse --short HEAD)
-echo $CLOUD_PROVIDER_LKG_HASH > $CLOUD_PROVIDER_LKG_FILE
-git add $CLOUD_PROVIDER_LKG_FILE
-git commit -m "Update cloud-provider-gcp LKG version to $CLOUD_PROVIDER_LKG_HASH"
+KUBERNETES_LKG_PATTERN="k8s-lkg-update-*"
+NEWEST_LKG_BRANCH=$(git for-each-ref --sort=committerdate refs/heads/ --format='%(refname:short)' | grep $KUBERNETES_LKG_PATTERN | head -n1)
+git checkout master
+git merge $NEWEST_LKG_BRANCH
+git push origin master

--- a/test/lkg.sh
+++ b/test/lkg.sh
@@ -6,15 +6,15 @@ set -o pipefail
 set -o xtrace
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-KUBETEST2_OPTIONS="gce -v 2 --repo-root=$REPO_ROOT --gcp-project=$(gcloud config get-value project) --build --up --down --test=ginkgo -- --test-package-version=v1.21.0 --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'"
-if [[ -z "${KUBERNETES_REPO_DIR:-}" ]]; then
-    KUBERNETES_REPO_DIR="$HOME/kubernetes"
-else
-    KUBERNETES_REPO_DIR="${KUBERNETES_REPO_DIR}"
-fi
-
+KUBETEST2_OPTIONS="gce -v 2 --repo-root=$REPO_ROOT --gcp-project=$(gcloud config get-value project) --build --up --down --test=ginkgo -- --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'"
+KUBERNETES_REPO_ROOT="$REPO_ROOT/kubernetes-latest"
+KUBERNETES_REPO_DIR="$KUBERNETES_REPO_ROOT/kubernetes"
 cd $REPO_ROOT
+mkdir -p $KUBERNETES_REPO_ROOT
+cd $KUBERNETES_REPO_ROOT
+git clone git@github.com:kubernetes/kubernetes.git
 # prevent bazel from downloading the node/server tarballs so we can manually copy over the ones we want
+cd $REPO_ROOT
 patch defs/repo_rules.bzl << EOF
 diff --git defs/repo_rules.bzl defs/repo_rules.bzl
 index 74ac09d9..00d78b24 100644
@@ -33,9 +33,8 @@ index 74ac09d9..00d78b24 100644
              paths.basename(archive).split(".")[0],
              archive,
 EOF
-cd $OLDPWD
 
-cd $KUBERNETES_REPO_DIR && make quick-release && cd $OLDPWD
+cd $KUBERNETES_REPO_DIR && make quick-release && cd $REPO_ROOT
 BAZEL_CACHE_DIR=$(bazel info output_base)/external/io_k8s_release/
 # hack to get around bazel cleaning out the cache directory - intentionally run a build that will fail and be partially-cached
 set +e
@@ -47,3 +46,13 @@ do
 done
 
 kubetest2 $KUBETEST2_OPTIONS
+
+KUBERNETES_LKG_FILE="$(git rev-parse --show-toplevel)/KUBERNETES_LKG_INFO"
+cd $KUBERNETES_REPO_DIR
+KUBERNETES_LKG_HASH=$(git rev-parse --short HEAD)
+cd $REPO_ROOT
+echo $KUBERNETES_LKG_HASH > $KUBERNETES_LKG_FILE
+LKG_BRANCH="k8s-lkg-update-$KUBERNETES_LKG_HASH"
+git checkout -b $LKG_BRANCH
+git commit -m "Update kubernetes LKG version to $KUBERNETES_LKG_HASH"
+git push origin $LKG_BRANCH

--- a/test/lkg.sh
+++ b/test/lkg.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+KUBETEST2_OPTIONS="gce -v 2 --repo-root=$REPO_ROOT --gcp-project=$(gcloud config get-value project) --build --up --down --test=ginkgo -- --test-package-version=v1.21.0 --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'"
+if [[ -z "${KUBERNETES_REPO_DIR:-}" ]]; then
+    KUBERNETES_REPO_DIR="$HOME/kubernetes"
+else
+    KUBERNETES_REPO_DIR="${KUBERNETES_REPO_DIR}"
+fi
+
+cd $REPO_ROOT
+# prevent bazel from downloading the node/server tarballs so we can manually copy over the ones we want
+patch defs/repo_rules.bzl << EOF
+diff --git defs/repo_rules.bzl defs/repo_rules.bzl
+index 74ac09d9..00d78b24 100644
+--- defs/repo_rules.bzl
++++ defs/repo_rules.bzl
+@@ -19,11 +19,6 @@ def _archive_url(folder, version, archive):
+ def _fetch_kube_release(ctx):
+     build_file_contents = BUILD_PRELUDE
+     for archive in ctx.attr.archives:
+-        ctx.download(
+-            url = _archive_url(ctx.attr.folder, ctx.attr.version, archive),
+-            output = archive,
+-            sha256 = ctx.attr.archives[archive],
+-        )
+         build_file_contents += BUILD_TAR_TEMPLATE.format(
+             paths.basename(archive).split(".")[0],
+             archive,
+EOF
+cd $OLDPWD
+
+cd $KUBERNETES_REPO_DIR && make quick-release && cd $OLDPWD
+BAZEL_CACHE_DIR=$(bazel info output_base)/external/io_k8s_release/
+# hack to get around bazel cleaning out the cache directory - intentionally run a build that will fail and be partially-cached
+set +e
+bazel build //release:release-tars
+set -e
+for KUBE_TARBALL in kubernetes-server-linux-amd64.tar.gz kubernetes-node-linux-amd64.tar.gz kubernetes-manifests.tar.gz
+do
+    cp $KUBERNETES_REPO_DIR/_output/release-tars/$KUBE_TARBALL $BAZEL_CACHE_DIR
+done
+
+kubetest2 $KUBETEST2_OPTIONS


### PR DESCRIPTION
This PR adds support for LKG (Last Known Good) testing to this repository. This is intended to keep track of the most recent commit of k/k that is known to test successfully with cloud-provider-gcp - in the case of a regression, finding out the code that introduced the regression should hopefully be much more simple compared to a single version upgrade once every few months.

LKG testing is supported by adding a `KUBERNETES_LKG_INFO` file that is updated by Prow to hold the commit of the most recent k/k commit that passed the E2E test suite when used with cloud-provider-gcp. If a cloud-provider-gcp PR works successfully with the latest k/k commit, that file will be updated with that commit's hash.
