### PR TITLE
Changes to support IPv6 addresses on nodes

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -94,6 +94,12 @@ var _ cloudprovider.Zones = (*Cloud)(nil)
 var _ cloudprovider.PVLabeler = (*Cloud)(nil)
 var _ cloudprovider.Clusters = (*Cloud)(nil)
 
+type StackType string
+
+const NetworkStackDualStack StackType = "IPV4_IPV6"
+const NetworkStackIPV4 StackType = "IPV4"
+const NetworkStackIPV6 StackType = "IPV6"
+
 // Cloud is an implementation of Interface, LoadBalancer and Instances for Google Compute Engine.
 type Cloud struct {
 	// ClusterID contains functionality for getting (and initializing) the ingress-uid. Call Cloud.Initialize()
@@ -167,6 +173,9 @@ type Cloud struct {
 	s *cloud.Service
 
 	metricsCollector loadbalancerMetricsCollector
+	// stackType indicates whether the cluster is a single stack IPv4, single
+	// stack IPv6 or a dual stack cluster
+	stackType StackType
 }
 
 // ConfigGlobal is the in memory representation of the gce.conf config data
@@ -181,6 +190,7 @@ type ConfigGlobal struct {
 	NetworkProjectID string `gcfg:"network-project-id"`
 	NetworkName      string `gcfg:"network-name"`
 	SubnetworkName   string `gcfg:"subnetwork-name"`
+	StackType        string `gcfg:"stack-type"`
 	// DEPRECATED: Do not rely on this value as it may be incorrect.
 	// SecondaryRangeName is the name of the secondary range to allocate IP
 	// aliases. The secondary range must be present on the subnetwork the
@@ -236,6 +246,7 @@ type CloudConfig struct {
 	TokenSource        oauth2.TokenSource
 	UseMetadataServer  bool
 	AlphaFeatureGate   *AlphaFeatureGate
+	StackType          string
 }
 
 func init() {
@@ -393,6 +404,10 @@ func generateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 		cloudConfig.SecondaryRangeName = configFile.Global.SecondaryRangeName
 	}
 
+	if configFile != nil {
+		cloudConfig.StackType = configFile.Global.StackType
+	}
+
 	return cloudConfig, err
 }
 
@@ -525,6 +540,7 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		AlphaFeatureGate:         config.AlphaFeatureGate,
 		nodeZones:                map[string]sets.String{},
 		metricsCollector:         newLoadBalancerMetrics(),
+		stackType:                StackType(config.StackType),
 	}
 
 	gce.manager = &gceServiceManager{gce}

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"k8s.io/klog/v2"
@@ -45,6 +46,7 @@ import (
 const (
 	defaultZone                   = ""
 	networkInterfaceIP            = "instance/network-interfaces/%s/ip"
+	networkInterfaceIPV6          = "instance/network-interfaces/%s/ipv6s"
 	networkInterfaceAccessConfigs = "instance/network-interfaces/%s/access-configs"
 	networkInterfaceExternalIP    = "instance/network-interfaces/%s/access-configs/%s/external-ip"
 )
@@ -117,6 +119,27 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 				}
 				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
 
+				if g.stackType == NetworkStackDualStack {
+					// Both internal and external IPv6 addresses are written to this array
+					ipv6s, err := metadata.Get(fmt.Sprintf(networkInterfaceIPV6, nic))
+					if err != nil {
+						return nil, fmt.Errorf("couldn't get internal IPV6 addresses for node %v: %v", nodeName, err)
+					}
+					ipv6Arr := strings.Split(ipv6s, "/\n")
+					var internalIPV6 string
+					for _, ip := range ipv6Arr {
+						if ip == "" {
+							continue
+						}
+						internalIPV6 = ip
+						break
+					}
+					if internalIPV6 != "" {
+						nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPV6})
+					} else {
+						klog.Warningf("internal IPV6 range is empty for node %v", nodeName)
+					}
+				}
 				acs, err := metadata.Get(fmt.Sprintf(networkInterfaceAccessConfigs, nic))
 				if err != nil {
 					return nil, fmt.Errorf("couldn't get access configs: %v", err)
@@ -160,12 +183,12 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 		return nil, fmt.Errorf("couldn't get instance details: %v", err)
 	}
 
-	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(instanceObj.Name), instanceObj.Zone))
+	instance, err := g.c.AlphaInstances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(instanceObj.Name), instanceObj.Zone))
 	if err != nil {
-		return []v1.NodeAddress{}, fmt.Errorf("error while querying for instance: %v", err)
+		return nil, fmt.Errorf("error while querying for instance: %v", err)
 	}
 
-	return nodeAddressesFromInstance(instance)
+	return g.nodeAddressesFromInstance(instance)
 }
 
 // NodeAddressesByProviderID will not be called from the node that is requesting this ID.
@@ -179,12 +202,12 @@ func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 		return []v1.NodeAddress{}, err
 	}
 
-	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.AlphaInstances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
 	if err != nil {
 		return []v1.NodeAddress{}, fmt.Errorf("error while querying for providerID %q: %v", providerID, err)
 	}
 
-	return nodeAddressesFromInstance(instance)
+	return g.nodeAddressesFromInstance(instance)
 }
 
 // instanceByProviderID returns the cloudprovider instance of the node
@@ -216,7 +239,7 @@ func (g *Cloud) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, erro
 	return false, cloudprovider.NotImplemented
 }
 
-func nodeAddressesFromInstance(instance *compute.Instance) ([]v1.NodeAddress, error) {
+func (g *Cloud) nodeAddressesFromInstance(instance *computealpha.Instance) ([]v1.NodeAddress, error) {
 	if len(instance.NetworkInterfaces) < 1 {
 		return nil, fmt.Errorf("could not find network interfaces for instanceID %q", instance.Id)
 	}
@@ -227,9 +250,25 @@ func nodeAddressesFromInstance(instance *compute.Instance) ([]v1.NodeAddress, er
 		for _, config := range nic.AccessConfigs {
 			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: config.NatIP})
 		}
+		if g.stackType == NetworkStackDualStack {
+			ipv6Addr := getIPV6AddressFromInterface(nic)
+			if ipv6Addr != "" {
+				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: ipv6Addr})
+			}
+		}
 	}
 
 	return nodeAddresses, nil
+}
+
+func getIPV6AddressFromInterface(nic *computealpha.NetworkInterface) string {
+	ipv6Addr := nic.Ipv6Address
+	if ipv6Addr == "" && nic.Ipv6AccessType == "EXTERNAL" {
+		for _, r := range nic.Ipv6AccessConfigs {
+			ipv6Addr = r.ExternalIpv6
+		}
+	}
+	return ipv6Addr
 }
 
 // InstanceTypeByProviderID returns the cloudprovider instance type of the node
@@ -298,12 +337,12 @@ func (g *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 		return nil, err
 	}
 
-	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.AlphaInstances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
 	if err != nil {
 		return nil, fmt.Errorf("error while querying for providerID %q: %v", providerID, err)
 	}
 
-	addresses, err := nodeAddressesFromInstance(instance)
+	addresses, err := g.nodeAddressesFromInstance(instance)
 	if err != nil {
 		return nil, err
 	}
@@ -502,8 +541,8 @@ func (g *Cloud) AliasRangesByProviderID(providerID string) (cidrs []string, err 
 		return nil, err
 	}
 
-	var res *computebeta.Instance
-	res, err = g.c.BetaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	var res *computealpha.Instance
+	res, err = g.c.AlphaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
 	if err != nil {
 		return
 	}
@@ -511,6 +550,16 @@ func (g *Cloud) AliasRangesByProviderID(providerID string) (cidrs []string, err 
 	for _, networkInterface := range res.NetworkInterfaces {
 		for _, r := range networkInterface.AliasIpRanges {
 			cidrs = append(cidrs, r.IpCidrRange)
+		}
+		if g.stackType == NetworkStackDualStack {
+			ipv6Addr := getIPV6AddressFromInterface(networkInterface)
+			if ipv6Addr == "" {
+				return nil, fmt.Errorf("IPV6 address not found for %s", providerID)
+			}
+			// The podCIDR range is the first /112 subrange from the /96 assigned to
+			// the node
+			ipv6PodCIDR := fmt.Sprintf("%s/112", ipv6Addr)
+			cidrs = append(cidrs, ipv6PodCIDR)
 		}
 	}
 	return

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -22,13 +22,18 @@ package gce
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
+	alpha "google.golang.org/api/compute/v0.alpha"
+	ga "google.golang.org/api/compute/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 func TestInstanceExists(t *testing.T) {
@@ -65,6 +70,356 @@ func TestInstanceExists(t *testing.T) {
 			exist, err := gce.InstanceExists(context.TODO(), node)
 			assert.Equal(t, test.expectedErr, err, test.name)
 			assert.Equal(t, test.exist, exist, test.name)
+		})
+	}
+}
+
+func TestNodeAddresses(t *testing.T) {
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+
+	instanceMap := make(map[string]*ga.Instance)
+	alphaInstanceMap := make(map[string]*alpha.Instance)
+	// n1 is instance with internal IPv6 address
+	alphaInstance := &alpha.Instance{
+		Name: "n1",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				NetworkIP:   "10.1.1.1",
+				StackType:   "IPV4_IPV6",
+				Ipv6Address: "2001:2d00::0:1",
+			},
+		},
+	}
+	alphaInstanceMap["n1"] = alphaInstance
+	instance := &ga.Instance{
+		Name: "n1",
+		Zone: "us-central1-b",
+	}
+	instanceMap["n1"] = instance
+
+	// n2 is instance with external IPv6 address
+	alphaInstance = &alpha.Instance{
+		Name: "n2",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				NetworkIP:      "10.1.1.2",
+				StackType:      "IPV4_IPV6",
+				Ipv6AccessType: "EXTERNAL",
+				Ipv6AccessConfigs: []*alpha.AccessConfig{
+					{ExternalIpv6: "2001:1900::0:2"},
+				},
+				AccessConfigs: []*alpha.AccessConfig{
+					{NatIP: "20.1.1.2"},
+				},
+			},
+		},
+	}
+	alphaInstanceMap["n2"] = alphaInstance
+	instance = &ga.Instance{
+		Name: "n2",
+		Zone: "us-central1-b",
+	}
+	instanceMap["n2"] = instance
+
+	// n3 is instance not present in the alphaInstanceMap
+	instance = &ga.Instance{
+		Name: "n3",
+		Zone: "us-central1-b",
+	}
+	instanceMap["n3"] = instance
+
+	// n4 is instance with invalid network interfaces
+	alphaInstance = &alpha.Instance{
+		Name: "n4",
+		Zone: "us-central1-b",
+	}
+	alphaInstanceMap["n4"] = alphaInstance
+	instance = &ga.Instance{
+		Name: "n4",
+		Zone: "us-central1-b",
+	}
+	instanceMap["n4"] = instance
+
+	// n5 is a single stack instance
+	alphaInstance = &alpha.Instance{
+		Name: "n5",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				NetworkIP: "10.1.1.5",
+				StackType: "IPV4",
+				AccessConfigs: []*alpha.AccessConfig{
+					{NatIP: "20.1.1.5"},
+				},
+			},
+		},
+	}
+	alphaInstanceMap["n5"] = alphaInstance
+	instance = &ga.Instance{
+		Name: "n5",
+		Zone: "us-central1-b",
+	}
+	instanceMap["n5"] = instance
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+	mai := mockGCE.AlphaInstances().(*cloud.MockAlphaInstances)
+	mai.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockAlphaInstances) (bool, *alpha.Instance, error) {
+		ret, ok := alphaInstanceMap[key.Name]
+		if !ok {
+			return true, nil, fmt.Errorf("alpha instance not found")
+		}
+		return true, ret, nil
+	}
+	mi := mockGCE.Instances().(*cloud.MockInstances)
+	mi.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockInstances) (bool, *ga.Instance, error) {
+		ret, ok := instanceMap[key.Name]
+		if !ok {
+			return true, nil, fmt.Errorf("instance not found")
+		}
+		return true, ret, nil
+	}
+
+	testcases := []struct {
+		name      string
+		nodeName  string
+		dualStack bool
+		wantErr   string
+		wantAddrs []v1.NodeAddress
+	}{
+		{
+			name:     "internal single stack instance",
+			nodeName: "n1",
+			wantAddrs: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+			},
+		},
+		{
+			name:      "internal dual stack instance",
+			nodeName:  "n1",
+			dualStack: true,
+			wantAddrs: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "2001:2d00::0:1"},
+			},
+		},
+		{
+			name:     "instance not found",
+			nodeName: "x1",
+			wantErr:  "instance not found",
+		},
+		{
+			name:     "alpha instance not found",
+			nodeName: "n3",
+			wantErr:  "alpha instance not found",
+		},
+		{
+			name:     "external single stack instance",
+			nodeName: "n2",
+			wantAddrs: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.2"},
+				{Type: v1.NodeExternalIP, Address: "20.1.1.2"},
+			},
+		},
+		{
+			name:      "external dual stack instance",
+			nodeName:  "n2",
+			dualStack: true,
+			wantAddrs: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.2"},
+				{Type: v1.NodeExternalIP, Address: "20.1.1.2"},
+				{Type: v1.NodeInternalIP, Address: "2001:1900::0:2"},
+			},
+		},
+		{
+			name:     "network interface not found",
+			nodeName: "n4",
+			wantErr:  "could not find network interface",
+		},
+		{
+			name:      "single stack instance",
+			nodeName:  "n5",
+			dualStack: true,
+			wantAddrs: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.5"},
+				{Type: v1.NodeExternalIP, Address: "20.1.1.5"},
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.dualStack {
+				gce.stackType = NetworkStackDualStack
+			} else {
+				gce.stackType = NetworkStackIPV4
+			}
+			gotAddrs, err := gce.NodeAddresses(context.TODO(), types.NodeName(test.nodeName))
+			if err != nil && (test.wantErr == "" || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Errorf("gce.NodeAddresses. Want err: %v, got: %v", test.wantErr, err)
+				return
+			} else if err == nil && test.wantErr != "" {
+				t.Errorf("gce.NodeAddresses. Want err: %v, got: %v", test.wantErr, err)
+			}
+			assert.Equal(t, test.wantAddrs, gotAddrs)
+		})
+	}
+}
+
+func TestAliasRangesByProviderID(t *testing.T) {
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+
+	alphaInstanceMap := make(map[string]*alpha.Instance)
+	// n1 is instance with internal IPv6 address
+	alphaInstance := &alpha.Instance{
+		Name: "n1",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				AliasIpRanges: []*alpha.AliasIpRange{
+					{IpCidrRange: "10.11.1.0/24"},
+				},
+				NetworkIP:   "10.1.1.1",
+				StackType:   "IPV4_IPV6",
+				Ipv6Address: "2001:2d00::1:0:0",
+			},
+		},
+	}
+	alphaInstanceMap["n1"] = alphaInstance
+
+	// n2 is instance with external IPv6 address
+	alphaInstance = &alpha.Instance{
+		Name: "n2",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				AliasIpRanges: []*alpha.AliasIpRange{
+					{IpCidrRange: "10.11.2.0/24"},
+				},
+				NetworkIP:      "10.1.1.2",
+				StackType:      "IPV4_IPV6",
+				Ipv6AccessType: "EXTERNAL",
+				Ipv6AccessConfigs: []*alpha.AccessConfig{
+					{ExternalIpv6: "2001:1900::2:0:0"},
+				},
+				AccessConfigs: []*alpha.AccessConfig{
+					{NatIP: "20.1.1.2"},
+				},
+			},
+		},
+	}
+	alphaInstanceMap["n2"] = alphaInstance
+
+	// n4 is instance with invalid network interfaces
+	alphaInstance = &alpha.Instance{
+		Name: "n4",
+		Zone: "us-central1-b",
+	}
+	alphaInstanceMap["n4"] = alphaInstance
+
+	// n5 is a single stack instance
+	alphaInstance = &alpha.Instance{
+		Name: "n5",
+		Zone: "us-central1-b",
+		NetworkInterfaces: []*alpha.NetworkInterface{
+			{
+				AliasIpRanges: []*alpha.AliasIpRange{
+					{IpCidrRange: "10.11.5.0/24"},
+				},
+				NetworkIP: "10.1.1.5",
+				StackType: "IPV4",
+				AccessConfigs: []*alpha.AccessConfig{
+					{NatIP: "20.1.1.5"},
+				},
+			},
+		},
+	}
+	alphaInstanceMap["n5"] = alphaInstance
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+	mai := mockGCE.AlphaInstances().(*cloud.MockAlphaInstances)
+	mai.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockAlphaInstances) (bool, *alpha.Instance, error) {
+		ret, ok := alphaInstanceMap[key.Name]
+		if !ok {
+			return true, nil, fmt.Errorf("alpha instance not found")
+		}
+		return true, ret, nil
+	}
+
+	testcases := []struct {
+		name       string
+		providerId string
+		dualStack  bool
+		wantErr    string
+		wantCIDRs  []string
+	}{
+		{
+			name:       "internal single stack instance",
+			providerId: "gce://p1/us-central1-b/n1",
+			wantCIDRs: []string{
+				"10.11.1.0/24",
+			},
+		},
+		{
+			name:       "internal single stack instance",
+			providerId: "gce://p1/us-central1-b/n1",
+			dualStack:  true,
+			wantCIDRs: []string{
+				"10.11.1.0/24",
+				"2001:2d00::1:0:0/112",
+			},
+		},
+		{
+			name:       "instance not found",
+			providerId: "gce://p1/us-central1-b/x1",
+			wantErr:    "alpha instance not found",
+		},
+		{
+			name:       "external single stack instance",
+			providerId: "gce://p1/us-central1-b/n2",
+			wantCIDRs: []string{
+				"10.11.2.0/24",
+			},
+		},
+		{
+			name:       "internal single stack instance",
+			providerId: "gce://p1/us-central1-b/n2",
+			dualStack:  true,
+			wantCIDRs: []string{
+				"10.11.2.0/24",
+				"2001:1900::2:0:0/112",
+			},
+		},
+		{
+			name:       "network interface not found",
+			providerId: "gce://p1/us-central1-b/n4",
+			wantErr:    "",
+		},
+		{
+			name:       "single stack instance",
+			providerId: "gce://p1/us-central1-b/n5",
+			dualStack:  true,
+			wantErr:    "IPV6 address not found",
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			if test.dualStack {
+				gce.stackType = NetworkStackDualStack
+			} else {
+				gce.stackType = NetworkStackIPV4
+			}
+			gotCIDRs, err := gce.AliasRangesByProviderID(test.providerId)
+			if err != nil && (test.wantErr == "" || !strings.Contains(err.Error(), test.wantErr)) {
+				t.Errorf("gce.AliasRangesByProviderID. Want err: %v, got: %v", test.wantErr, err)
+			} else if err == nil && test.wantErr != "" {
+				t.Errorf("gce.AliasRangesByProviderID. Want err: %v, got: %v, gotCIDRs: %v", test.wantErr, err, gotCIDRs)
+			}
+			assert.Equal(t, test.wantCIDRs, gotCIDRs)
 		})
 	}
 }


### PR DESCRIPTION
These changes populate the Node object with the IPv6 address as well as the IPv6 podCIDR. This is done only for clusters with stackType as IPV4_IPV6. This patch handles both the internal and external IPv6 addresses.