### PR TITLE
Update go-tpm version to v0.3.2 that supports arm64

### DIFF
--- a/cmd/gcp-controller-manager/node_csr_approver_test.go
+++ b/cmd/gcp-controller-manager/node_csr_approver_test.go
@@ -1012,7 +1012,11 @@ func makeAttestationDataAndSignature(t *testing.T, csrKey *ecdsa.PrivateKey, aik
 	// Hash algorithm here must match tpmPub.NameAlg.
 	tpmPubDigest := sha256.Sum256(tpmPubRaw)
 	attestData, err := tpm2.AttestationData{
-		Type: tpm2.TagAttestCertify,
+		// In go-tpm v0.3.0 validation was added to check that the magic value
+		// is always 0xff544347
+		// See https://github.com/google/go-tpm/pull/136 for details.
+		Magic: 0xff544347,
+		Type:  tpm2.TagAttestCertify,
 		AttestedCertifyInfo: &tpm2.CertifyInfo{
 			Name: tpm2.Name{
 				Digest: &tpm2.HashValue{

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gofrs/flock v0.7.1
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.5.5
-	github.com/google/go-tpm v0.2.0
+	github.com/google/go-tpm v0.3.2
 	github.com/google/uuid v1.1.4 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -590,7 +590,11 @@ github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwG
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.2.0 h1:3Z5ZjNRQ0CsUj3yWXtbbx4Vfb/sQapdSeZJvuaKuQzc=
 github.com/google/go-tpm v0.2.0/go.mod h1:gTv8GNuqS7CI+tQWrpt5BMMaD5W3G+dZULQLhhAKT5c=
+github.com/google/go-tpm v0.3.0/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
+github.com/google/go-tpm v0.3.2 h1:3iQQ2dlEf+1no7CLlfLPYzxhQy7j2G/emBqU5okydaw=
+github.com/google/go-tpm v0.3.2/go.mod h1:j71sMBTfp3X5jPHz852ZOfQMUOf65Gb/Th8pRmp7fvg=
 github.com/google/go-tpm-tools v0.0.0-20190906225433-1614c142f845/go.mod h1:AVfHadzbdzHo54inR2x1v640jdi1YSi3NauM2DUsxk0=
+github.com/google/go-tpm-tools v0.2.0/go.mod h1:npUd03rQ60lxN7tzeBJreG38RvWwme2N1reF/eeiBk4=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -1377,6 +1381,7 @@ golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1443,6 +1448,7 @@ golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/apis/firewall/BUILD
+++ b/pkg/apis/firewall/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["register.go"],
+    importpath = "k8s.io/cloud-provider-gcp/pkg/apis/firewall",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/google/go-tpm/tpm2/constants.go
+++ b/vendor/github.com/google/go-tpm/tpm2/constants.go
@@ -15,15 +15,31 @@
 package tpm2
 
 import (
+	"crypto"
 	"crypto/elliptic"
-	"crypto/sha1"
-	"crypto/sha256"
-	"crypto/sha512"
 	"fmt"
-	"hash"
+	"strings"
+
+	// Register the relevant hash implementations to prevent a runtime failure.
+	_ "crypto/sha1"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 
 	"github.com/google/go-tpm/tpmutil"
 )
+
+var hashInfo = []struct {
+	alg  Algorithm
+	hash crypto.Hash
+}{
+	{AlgSHA1, crypto.SHA1},
+	{AlgSHA256, crypto.SHA256},
+	{AlgSHA384, crypto.SHA384},
+	{AlgSHA512, crypto.SHA512},
+	{AlgSHA3_256, crypto.SHA3_256},
+	{AlgSHA3_384, crypto.SHA3_384},
+	{AlgSHA3_512, crypto.SHA3_512},
+}
 
 // MAX_DIGEST_BUFFER is the maximum size of []byte request or response fields.
 // Typically used for chunking of big blobs of data (such as for hashing or
@@ -32,6 +48,16 @@ const maxDigestBuffer = 1024
 
 // Algorithm represents a TPM_ALG_ID value.
 type Algorithm uint16
+
+// HashToAlgorithm looks up the TPM2 algorithm corresponding to the provided crypto.Hash
+func HashToAlgorithm(hash crypto.Hash) (Algorithm, error) {
+	for _, info := range hashInfo {
+		if info.hash == hash {
+			return info.alg, nil
+		}
+	}
+	return AlgUnknown, fmt.Errorf("go hash algorithm #%d has no TPM2 algorithm", hash)
+}
 
 // IsNull returns true if a is AlgNull or zero (unset).
 func (a Algorithm) IsNull() bool {
@@ -48,15 +74,18 @@ func (a Algorithm) UsesHash() bool {
 	return a == AlgOAEP
 }
 
-// HashConstructor returns a function that can be used to make a
-// hash.Hash using the specified algorithm. An error is returned
-// if the algorithm is not a hash algorithm.
-func (a Algorithm) HashConstructor() (func() hash.Hash, error) {
-	c, ok := hashConstructors[a]
-	if !ok {
-		return nil, fmt.Errorf("algorithm not supported: 0x%x", a)
+// Hash returns a crypto.Hash based on the given TPM_ALG_ID.
+// An error is returned if the given algorithm is not a hash algorithm or is not available.
+func (a Algorithm) Hash() (crypto.Hash, error) {
+	for _, info := range hashInfo {
+		if info.alg == a {
+			if !info.hash.Available() {
+				return crypto.Hash(0), fmt.Errorf("go hash algorithm #%d not available", info.hash)
+			}
+			return info.hash, nil
+		}
 	}
-	return c, nil
+	return crypto.Hash(0), fmt.Errorf("hash algorithm not supported: 0x%x", a)
 }
 
 // Supported Algorithms.
@@ -82,6 +111,9 @@ const (
 	AlgKDF2      Algorithm = 0x0021
 	AlgECC       Algorithm = 0x0023
 	AlgSymCipher Algorithm = 0x0025
+	AlgSHA3_256  Algorithm = 0x0027
+	AlgSHA3_384  Algorithm = 0x0028
+	AlgSHA3_512  Algorithm = 0x0029
 	AlgCTR       Algorithm = 0x0040
 	AlgOFB       Algorithm = 0x0041
 	AlgCBC       Algorithm = 0x0042
@@ -140,6 +172,7 @@ type KeyProp uint32
 // Key properties.
 const (
 	FlagFixedTPM            KeyProp = 0x00000002
+	FlagStClear             KeyProp = 0x00000004
 	FlagFixedParent         KeyProp = 0x00000010
 	FlagSensitiveDataOrigin KeyProp = 0x00000020
 	FlagUserWithAuth        KeyProp = 0x00000040
@@ -156,12 +189,12 @@ const (
 		FlagFixedParent | FlagSensitiveDataOrigin | FlagUserWithAuth
 )
 
-// TPMProp represents the index of a TPM property in a call to GetCapability().
+// TPMProp represents a Property Tag (TPM_PT) used with calls to GetCapability(CapabilityTPMProperties).
 type TPMProp uint32
 
-// TPM Capability Properties, see TPM 2.0 Spec, Rev 1.38, Table 23
+// TPM Capability Properties, see TPM 2.0 Spec, Rev 1.38, Table 23.
+// Fixed TPM Properties (PT_FIXED)
 const (
-	// Fixed TPM Properties (PT_FIXED)
 	FamilyIndicator TPMProp = 0x100 + iota
 	SpecLevel
 	SpecRevision
@@ -209,7 +242,36 @@ const (
 	NVMaxBufferSize
 	TPMModes
 	CapabilityMaxBufferSize
+)
 
+// Variable TPM Properties (PT_VAR)
+const (
+	TPMAPermanent TPMProp = 0x200 + iota
+	TPMAStartupClear
+	HRNVIndex
+	HRLoaded
+	HRLoadedAvail
+	HRActive
+	HRActiveAvail
+	HRTransientAvail
+	CurrentPersistent
+	AvailPersistent
+	NVCounters
+	NVCountersAvail
+	AlgorithmSet
+	LoadedCurves
+	LockoutCounter
+	MaxAuthFail
+	LockoutInterval
+	LockoutRecovery
+	NVWriteRecovery
+	AuditCounter0
+	AuditCounter1
+)
+
+// Allowed ranges of different kinds of Handles (TPM_HANDLE)
+// These constants have type TPMProp for backwards compatibility.
+const (
 	PCRFirst           TPMProp = 0x00000000
 	HMACSessionFirst   TPMProp = 0x02000000
 	LoadedSessionFirst TPMProp = 0x02000000
@@ -306,78 +368,68 @@ var toGoCurve = map[EllipticCurve]elliptic.Curve{
 
 // Supported TPM operations.
 const (
-	cmdEvictControl       tpmutil.Command = 0x00000120
-	cmdUndefineSpace      tpmutil.Command = 0x00000122
-	cmdDefineSpace        tpmutil.Command = 0x0000012A
-	cmdCreatePrimary      tpmutil.Command = 0x00000131
-	cmdIncrementNVCounter tpmutil.Command = 0x00000134
-	cmdWriteNV            tpmutil.Command = 0x00000137
-	cmdPCREvent           tpmutil.Command = 0x0000013C
-	cmdStartup            tpmutil.Command = 0x00000144
-	cmdShutdown           tpmutil.Command = 0x00000145
-	cmdActivateCredential tpmutil.Command = 0x00000147
-	cmdCertify            tpmutil.Command = 0x00000148
-	cmdCertifyCreation    tpmutil.Command = 0x0000014A
-	cmdReadNV             tpmutil.Command = 0x0000014E
-	// CmdPolicySecret is a command code for TPM2_PolicySecret.
-	// It's exported for computing of default AuthPolicy value.
-	CmdPolicySecret     tpmutil.Command = 0x00000151
-	cmdCreate           tpmutil.Command = 0x00000153
-	cmdLoad             tpmutil.Command = 0x00000157
-	cmdQuote            tpmutil.Command = 0x00000158
-	cmdRSADecrypt       tpmutil.Command = 0x00000159
-	cmdSign             tpmutil.Command = 0x0000015D
-	cmdUnseal           tpmutil.Command = 0x0000015E
-	cmdContextLoad      tpmutil.Command = 0x00000161
-	cmdContextSave      tpmutil.Command = 0x00000162
-	cmdEncryptDecrypt   tpmutil.Command = 0x00000164
-	cmdFlushContext     tpmutil.Command = 0x00000165
-	cmdLoadExternal     tpmutil.Command = 0x00000167
-	cmdMakeCredential   tpmutil.Command = 0x00000168
-	cmdReadPublicNV     tpmutil.Command = 0x00000169
-	cmdReadPublic       tpmutil.Command = 0x00000173
-	cmdRSAEncrypt       tpmutil.Command = 0x00000174
-	cmdStartAuthSession tpmutil.Command = 0x00000176
-	cmdGetCapability    tpmutil.Command = 0x0000017A
-	cmdGetRandom        tpmutil.Command = 0x0000017B
-	cmdHash             tpmutil.Command = 0x0000017D
-	cmdPCRRead          tpmutil.Command = 0x0000017E
-	// CmdPolicyPCR is the command code for TPM2_PolicyPCR.
-	// It's exported for computing AuthPolicy values for PCR-based sessions.
-	CmdPolicyPCR       tpmutil.Command = 0x0000017F
-	cmdReadClock       tpmutil.Command = 0x00000181
-	cmdPCRExtend       tpmutil.Command = 0x00000182
-	cmdPolicyGetDigest tpmutil.Command = 0x00000189
-	cmdPolicyPassword  tpmutil.Command = 0x0000018C
-	cmdEncryptDecrypt2 tpmutil.Command = 0x00000193
+	CmdNVUndefineSpaceSpecial     tpmutil.Command = 0x0000011F
+	CmdEvictControl               tpmutil.Command = 0x00000120
+	CmdUndefineSpace              tpmutil.Command = 0x00000122
+	CmdClear                      tpmutil.Command = 0x00000126
+	CmdHierarchyChangeAuth        tpmutil.Command = 0x00000129
+	CmdDefineSpace                tpmutil.Command = 0x0000012A
+	CmdCreatePrimary              tpmutil.Command = 0x00000131
+	CmdIncrementNVCounter         tpmutil.Command = 0x00000134
+	CmdWriteNV                    tpmutil.Command = 0x00000137
+	CmdWriteLockNV                tpmutil.Command = 0x00000138
+	CmdDictionaryAttackLockReset  tpmutil.Command = 0x00000139
+	CmdDictionaryAttackParameters tpmutil.Command = 0x0000013A
+	CmdPCREvent                   tpmutil.Command = 0x0000013C
+	CmdSequenceComplete           tpmutil.Command = 0x0000013E
+	CmdStartup                    tpmutil.Command = 0x00000144
+	CmdShutdown                   tpmutil.Command = 0x00000145
+	CmdActivateCredential         tpmutil.Command = 0x00000147
+	CmdCertify                    tpmutil.Command = 0x00000148
+	CmdCertifyCreation            tpmutil.Command = 0x0000014A
+	CmdReadNV                     tpmutil.Command = 0x0000014E
+	CmdReadLockNV                 tpmutil.Command = 0x0000014F
+	CmdPolicySecret               tpmutil.Command = 0x00000151
+	CmdCreate                     tpmutil.Command = 0x00000153
+	CmdECDHZGen                   tpmutil.Command = 0x00000154
+	CmdImport                     tpmutil.Command = 0x00000156
+	CmdLoad                       tpmutil.Command = 0x00000157
+	CmdQuote                      tpmutil.Command = 0x00000158
+	CmdRSADecrypt                 tpmutil.Command = 0x00000159
+	CmdSequenceUpdate             tpmutil.Command = 0x0000015C
+	CmdSign                       tpmutil.Command = 0x0000015D
+	CmdUnseal                     tpmutil.Command = 0x0000015E
+	CmdContextLoad                tpmutil.Command = 0x00000161
+	CmdContextSave                tpmutil.Command = 0x00000162
+	CmdECDHKeyGen                 tpmutil.Command = 0x00000163
+	CmdEncryptDecrypt             tpmutil.Command = 0x00000164
+	CmdFlushContext               tpmutil.Command = 0x00000165
+	CmdLoadExternal               tpmutil.Command = 0x00000167
+	CmdMakeCredential             tpmutil.Command = 0x00000168
+	CmdReadPublicNV               tpmutil.Command = 0x00000169
+	CmdPolicyCommandCode          tpmutil.Command = 0x0000016C
+	CmdPolicyOr                   tpmutil.Command = 0x00000171
+	CmdReadPublic                 tpmutil.Command = 0x00000173
+	CmdRSAEncrypt                 tpmutil.Command = 0x00000174
+	CmdStartAuthSession           tpmutil.Command = 0x00000176
+	CmdGetCapability              tpmutil.Command = 0x0000017A
+	CmdGetRandom                  tpmutil.Command = 0x0000017B
+	CmdHash                       tpmutil.Command = 0x0000017D
+	CmdPCRRead                    tpmutil.Command = 0x0000017E
+	CmdPolicyPCR                  tpmutil.Command = 0x0000017F
+	CmdReadClock                  tpmutil.Command = 0x00000181
+	CmdPCRExtend                  tpmutil.Command = 0x00000182
+	CmdEventSequenceComplete      tpmutil.Command = 0x00000185
+	CmdHashSequenceStart          tpmutil.Command = 0x00000186
+	CmdPolicyGetDigest            tpmutil.Command = 0x00000189
+	CmdPolicyPassword             tpmutil.Command = 0x0000018C
+	CmdEncryptDecrypt2            tpmutil.Command = 0x00000193
 )
 
 // Regular TPM 2.0 devices use 24-bit mask (3 bytes) for PCR selection.
 const sizeOfPCRSelect = 3
 
-// digestSize returns the size of a digest for hashing algorithm alg, or 0 if
-// it's not recognized.
-func digestSize(alg Algorithm) int {
-	switch alg {
-	case AlgSHA1:
-		return sha1.Size
-	case AlgSHA256:
-		return sha256.Size
-	case AlgSHA512:
-		return sha512.Size
-	default:
-		return 0
-	}
-}
-
 const defaultRSAExponent = 1<<16 + 1
-
-var hashConstructors = map[Algorithm]func() hash.Hash{
-	AlgSHA1:   sha1.New,
-	AlgSHA256: sha256.New,
-	AlgSHA384: sha512.New384,
-	AlgSHA512: sha512.New,
-}
 
 // NVAttr is a bitmask used in Attributes field of NV indexes. Individual
 // flags should be OR-ed to form a full mask.
@@ -407,3 +459,42 @@ const (
 	AttrPlatformCreate NVAttr = 0x40000000
 	AttrReadSTClear    NVAttr = 0x80000000
 )
+
+var permMap = map[NVAttr]string{
+	AttrPPWrite:        "PPWrite",
+	AttrOwnerWrite:     "OwnerWrite",
+	AttrAuthWrite:      "AuthWrite",
+	AttrPolicyWrite:    "PolicyWrite",
+	AttrPolicyDelete:   "PolicyDelete",
+	AttrWriteLocked:    "WriteLocked",
+	AttrWriteAll:       "WriteAll",
+	AttrWriteDefine:    "WriteDefine",
+	AttrWriteSTClear:   "WriteSTClear",
+	AttrGlobalLock:     "GlobalLock",
+	AttrPPRead:         "PPRead",
+	AttrOwnerRead:      "OwnerRead",
+	AttrAuthRead:       "AuthRead",
+	AttrPolicyRead:     "PolicyRead",
+	AttrNoDA:           "No Do",
+	AttrOrderly:        "Oderly",
+	AttrClearSTClear:   "ClearSTClear",
+	AttrReadLocked:     "ReadLocked",
+	AttrWritten:        "Writte",
+	AttrPlatformCreate: "PlatformCreate",
+	AttrReadSTClear:    "ReadSTClear",
+}
+
+// String returns a textual representation of the set of NVAttr
+func (p NVAttr) String() string {
+	var retString strings.Builder
+	for iterator, item := range permMap {
+		if (p & iterator) != 0 {
+			retString.WriteString(item + " + ")
+		}
+	}
+	if retString.String() == "" {
+		return "Permission/s not found"
+	}
+	return strings.TrimSuffix(retString.String(), " + ")
+
+}

--- a/vendor/github.com/google/go-tpm/tpm2/kdf.go
+++ b/vendor/github.com/google/go-tpm/tpm2/kdf.go
@@ -16,55 +16,74 @@ package tpm2
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
 	"hash"
 )
 
 // KDFa implements TPM 2.0's default key derivation function, as defined in
 // section 11.4.9.2 of the TPM revision 2 specification part 1.
 // See: https://trustedcomputinggroup.org/resource/tpm-library-specification/
-// The key & label parameters must not be zero length, but contextU &
-// contextV may be.
-// Only SHA1 & SHA256 hash algorithms are implemented at this time.
+// The key & label parameters must not be zero length.
+// The label parameter is a non-null-terminated string.
+// The contextU & contextV parameters are optional.
 func KDFa(hashAlg Algorithm, key []byte, label string, contextU, contextV []byte, bits int) ([]byte, error) {
-	var counter uint32
-	remaining := (bits + 7) / 8 // As per note at the bottom of page 44.
-	var out []byte
-
-	var mac hash.Hash
-	switch hashAlg {
-	case AlgSHA1:
-		mac = hmac.New(sha1.New, key)
-	case AlgSHA256:
-		mac = hmac.New(sha256.New, key)
-	default:
-		return nil, fmt.Errorf("hash algorithm 0x%x is not supported", hashAlg)
+	h, err := hashAlg.Hash()
+	if err != nil {
+		return nil, err
 	}
+	mac := hmac.New(h.New, key)
 
-	for remaining > 0 {
-		counter++
-		if err := binary.Write(mac, binary.BigEndian, counter); err != nil {
-			return nil, fmt.Errorf("pack counter: %v", err)
-		}
+	out := kdf(mac, bits, func() {
 		mac.Write([]byte(label))
 		mac.Write([]byte{0}) // Terminating null character for C-string.
 		mac.Write(contextU)
 		mac.Write(contextV)
-		if err := binary.Write(mac, binary.BigEndian, uint32(bits)); err != nil {
-			return nil, fmt.Errorf("pack bits: %v", err)
-		}
-
-		out = mac.Sum(out)
-		remaining -= mac.Size()
-		mac.Reset()
-	}
-
-	if len(out) > bits/8 {
-		out = out[:bits/8]
-	}
-
+		binary.Write(mac, binary.BigEndian, uint32(bits))
+	})
 	return out, nil
+}
+
+// KDFe implements TPM 2.0's ECDH key derivation function, as defined in
+// section 11.4.9.3 of the TPM revision 2 specification part 1.
+// See: https://trustedcomputinggroup.org/resource/tpm-library-specification/
+// The z parameter is the x coordinate of one parties private ECC key and the other parties public ECC key.
+// The use parameter is a non-null-terminated string.
+// The partyUInfo and partyVInfo are the x coordinates of the initiators and the responders ECC points respectively.
+func KDFe(hashAlg Algorithm, z []byte, use string, partyUInfo, partyVInfo []byte, bits int) ([]byte, error) {
+	createHash, err := hashAlg.Hash()
+	if err != nil {
+		return nil, err
+	}
+	h := createHash.New()
+
+	out := kdf(h, bits, func() {
+		h.Write(z)
+		h.Write([]byte(use))
+		h.Write([]byte{0}) // Terminating null character for C-string.
+		h.Write(partyUInfo)
+		h.Write(partyVInfo)
+	})
+	return out, nil
+}
+
+func kdf(h hash.Hash, bits int, update func()) []byte {
+	bytes := (bits + 7) / 8
+	out := []byte{}
+
+	for counter := 1; len(out) < bytes; counter++ {
+		h.Reset()
+		binary.Write(h, binary.BigEndian, uint32(counter))
+		update()
+
+		out = h.Sum(out)
+	}
+	// out's length is a multiple of hash size, so there will be excess bytes if bytes isn't a multiple of hash size.
+	out = out[:bytes]
+
+	// As mentioned in the KDFa and KDFe specs mentioned above,
+	// the unused bits of the most significant octet are masked off.
+	if maskBits := uint8(bits % 8); maskBits > 0 {
+		out[0] &= (1 << maskBits) - 1
+	}
+	return out
 }

--- a/vendor/github.com/google/go-tpm/tpm2/structures.go
+++ b/vendor/github.com/google/go-tpm/tpm2/structures.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -31,7 +32,7 @@ import (
 type NVPublic struct {
 	NVIndex    tpmutil.Handle
 	NameAlg    Algorithm
-	Attributes KeyProp
+	Attributes NVAttr
 	AuthPolicy tpmutil.U16Bytes
 	DataSize   uint16
 }
@@ -124,11 +125,11 @@ func (p Public) Name() (Name, error) {
 	if err != nil {
 		return Name{}, err
 	}
-	hash, err := p.NameAlg.HashConstructor()
+	hash, err := p.NameAlg.Hash()
 	if err != nil {
 		return Name{}, err
 	}
-	nameHash := hash()
+	nameHash := hash.New()
 	nameHash.Write(pubEncoded)
 	return Name{
 		Digest: &HashValue{
@@ -618,11 +619,6 @@ func (p Private) Encode() ([]byte, error) {
 	return tpmutil.Pack(p)
 }
 
-type tpmtSigScheme struct {
-	Scheme Algorithm
-	Hash   Algorithm
-}
-
 // AttestationData contains data attested by TPM commands (like Certify).
 type AttestationData struct {
 	Magic                uint32
@@ -645,6 +641,13 @@ func DecodeAttestationData(in []byte) (*AttestationData, error) {
 	if err := tpmutil.UnpackBuf(buf, &ad.Magic, &ad.Type); err != nil {
 		return nil, fmt.Errorf("decoding Magic/Type: %v", err)
 	}
+	// All attestation structures have the magic prefix
+	// TPMS_GENERATED_VALUE to symbolize they were created by
+	// the TPM when signed with an AK.
+	if ad.Magic != 0xff544347 {
+		return nil, fmt.Errorf("incorrect magic value: %x", ad.Magic)
+	}
+
 	n, err := DecodeName(buf)
 	if err != nil {
 		return nil, fmt.Errorf("decoding QualifiedSigner: %v", err)
@@ -958,11 +961,11 @@ func decodeHashValue(in *bytes.Buffer) (*HashValue, error) {
 	if err := tpmutil.UnpackBuf(in, &hv.Alg); err != nil {
 		return nil, fmt.Errorf("decoding Alg: %v", err)
 	}
-	hfn, ok := hashConstructors[hv.Alg]
-	if !ok {
-		return nil, fmt.Errorf("unsupported hash algorithm type 0x%x", hv.Alg)
+	hfn, err := hv.Alg.Hash()
+	if err != nil {
+		return nil, err
 	}
-	hv.Value = make(tpmutil.U16Bytes, hfn().Size())
+	hv.Value = make(tpmutil.U16Bytes, hfn.Size())
 	if _, err := in.Read(hv.Value); err != nil {
 		return nil, fmt.Errorf("decoding Value: %v", err)
 	}
@@ -1001,16 +1004,8 @@ type TaggedProperty struct {
 // information.
 type Ticket struct {
 	Type      tpmutil.Tag
-	Hierarchy uint32
+	Hierarchy tpmutil.Handle
 	Digest    tpmutil.U16Bytes
-}
-
-func decodeTicket(in *bytes.Buffer) (*Ticket, error) {
-	var t Ticket
-	if err := tpmutil.UnpackBuf(in, &t.Type, &t.Hierarchy, &t.Digest); err != nil {
-		return nil, fmt.Errorf("decoding Type, Hierarchy, Digest: %v", err)
-	}
-	return &t, nil
 }
 
 // AuthCommand represents a TPMS_AUTH_COMMAND. This structure encapsulates parameters
@@ -1020,4 +1015,49 @@ type AuthCommand struct {
 	Nonce      tpmutil.U16Bytes
 	Attributes SessionAttributes
 	Auth       tpmutil.U16Bytes
+}
+
+// TPMLDigest represents the TPML_Digest structure
+// It is used to convey a list of digest values.
+// This type is used in TPM2_PolicyOR() and in TPM2_PCR_Read()
+type TPMLDigest struct {
+	Digests []tpmutil.U16Bytes
+}
+
+// Encode converts the TPMLDigest structure into a byte slice
+func (list *TPMLDigest) Encode() ([]byte, error) {
+	res, err := tpmutil.Pack(uint32(len(list.Digests)))
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range list.Digests {
+		b, err := tpmutil.Pack(item)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, b...)
+
+	}
+	return res, nil
+}
+
+// DecodeTPMLDigest decodes a TPML_Digest part of a message.
+func DecodeTPMLDigest(buf []byte) (*TPMLDigest, error) {
+	in := bytes.NewBuffer(buf)
+	var tpmld TPMLDigest
+	var count uint32
+	if err := binary.Read(in, binary.BigEndian, &count); err != nil {
+		return nil, fmt.Errorf("decoding TPML_Digest: %v", err)
+	}
+	for in.Len() > 0 {
+		var hash tpmutil.U16Bytes
+		if err := hash.TPMUnmarshal(in); err != nil {
+			return nil, err
+		}
+		tpmld.Digests = append(tpmld.Digests, hash)
+	}
+	if count != uint32(len(tpmld.Digests)) {
+		return nil, fmt.Errorf("expected size and read size does not match")
+	}
+	return &tpmld, nil
 }

--- a/vendor/github.com/google/go-tpm/tpm2/tpm2.go
+++ b/vendor/github.com/google/go-tpm/tpm2/tpm2.go
@@ -26,7 +26,7 @@ import (
 
 // GetRandom gets random bytes from the TPM.
 func GetRandom(rw io.ReadWriter, size uint16) ([]byte, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdGetRandom, size)
+	resp, err := runCommand(rw, TagNoSessions, CmdGetRandom, size)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func GetRandom(rw io.ReadWriter, size uint16) ([]byte, error) {
 // the TPM. This must be called for any loaded handle to avoid out-of-memory
 // errors in TPM.
 func FlushContext(rw io.ReadWriter, handle tpmutil.Handle) error {
-	_, err := runCommand(rw, TagNoSessions, cmdFlushContext, handle)
+	_, err := runCommand(rw, TagNoSessions, CmdFlushContext, handle)
 	return err
 }
 
@@ -73,6 +73,9 @@ func encodeTPMLPCRSelection(sel ...PCRSelection) ([]byte, error) {
 
 		// s[i].PCRs parameter is indexes of PCRs, convert that to set bits.
 		for _, n := range s.PCRs {
+			if n >= 8*sizeOfPCRSelect {
+				return nil, fmt.Errorf("PCR index %d is out of range (exceeds maximum value %d)", n, 8*sizeOfPCRSelect-1)
+			}
 			byteNum := n / 8
 			bytePos := byte(1 << byte(n%8))
 			ts.PCRs[byteNum] |= bytePos
@@ -177,12 +180,14 @@ func decodeReadPCRs(in []byte) (map[int][]byte, error) {
 }
 
 // ReadPCRs reads PCR values from the TPM.
+// This is only a wrapper over TPM2_PCR_Read() call, thus can only return
+// at most 8 PCRs digests.
 func ReadPCRs(rw io.ReadWriter, sel PCRSelection) (map[int][]byte, error) {
-	cmd, err := encodeTPMLPCRSelection(sel)
+	Cmd, err := encodeTPMLPCRSelection(sel)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagNoSessions, cmdPCRRead, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagNoSessions, CmdPCRRead, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +212,7 @@ func decodeReadClock(in []byte) (uint64, uint64, error) {
 // Second return value is time in milliseconds since TPM reset (since Storage
 // Primary Seed is changed).
 func ReadClock(rw io.ReadWriter) (uint64, uint64, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdReadClock)
+	resp, err := runCommand(rw, TagNoSessions, CmdReadClock)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -297,7 +302,7 @@ func decodeGetCapability(in []byte) ([]interface{}, bool, error) {
 // moreData is true if the TPM indicated that more data is available. Follow
 // the spec for the capability in question on how to query for more data.
 func GetCapability(rw io.ReadWriter, capa Capability, count, property uint32) (vals []interface{}, moreData bool, err error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdGetCapability, capa, property, count)
+	resp, err := runCommand(rw, TagNoSessions, CmdGetCapability, capa, property, count)
 	if err != nil {
 		return nil, false, err
 	}
@@ -351,11 +356,11 @@ func encodePCREvent(pcr tpmutil.Handle, eventData []byte) ([]byte, error) {
 
 // PCREvent writes an update to the specified PCR.
 func PCREvent(rw io.ReadWriter, pcr tpmutil.Handle, eventData []byte) error {
-	cmd, err := encodePCREvent(pcr, eventData)
+	Cmd, err := encodePCREvent(pcr, eventData)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdPCREvent, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagSessions, CmdPCREvent, tpmutil.RawBytes(Cmd))
 	return err
 }
 
@@ -412,30 +417,21 @@ func encodeCreate(owner tpmutil.Handle, sel PCRSelection, auth AuthCommand, owne
 	)
 }
 
-func decodeCreatePrimary(in []byte) (handle tpmutil.Handle, public, creationData, creationHash tpmutil.U16Bytes, ticket *Ticket, creationName tpmutil.U16Bytes, err error) {
+func decodeCreatePrimary(in []byte) (handle tpmutil.Handle, public, creationData, creationHash tpmutil.U16Bytes, ticket Ticket, creationName tpmutil.U16Bytes, err error) {
 	var paramSize uint32
 
 	buf := bytes.NewBuffer(in)
 	// Handle and auth data.
 	if err := tpmutil.UnpackBuf(buf, &handle, &paramSize); err != nil {
-		return 0, nil, nil, nil, nil, nil, fmt.Errorf("decoding handle, paramSize: %v", err)
+		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding handle, paramSize: %v", err)
 	}
 
-	if err := tpmutil.UnpackBuf(buf, &public, &creationData, &creationHash); err != nil {
-		return 0, nil, nil, nil, nil, nil, fmt.Errorf("decoding public, creationData, creationHash: %v", err)
-	}
-
-	ticket, err = decodeTicket(buf)
-	if err != nil {
-		return 0, nil, nil, nil, nil, nil, fmt.Errorf("decoding ticket: %v", err)
-	}
-
-	if err := tpmutil.UnpackBuf(buf, &creationName); err != nil {
-		return 0, nil, nil, nil, nil, nil, fmt.Errorf("decoding creationName: %v", err)
+	if err := tpmutil.UnpackBuf(buf, &public, &creationData, &creationHash, &ticket, &creationName); err != nil {
+		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("decoding public, creationData, creationHash, ticket, creationName: %v", err)
 	}
 
 	if _, err := DecodeCreationData(creationData); err != nil {
-		return 0, nil, nil, nil, nil, nil, fmt.Errorf("parsing CreationData: %v", err)
+		return 0, nil, nil, nil, Ticket{}, nil, fmt.Errorf("parsing CreationData: %v", err)
 	}
 	return handle, public, creationData, creationHash, ticket, creationName, err
 }
@@ -464,15 +460,15 @@ func CreatePrimary(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, par
 // CreatePrimaryEx initializes the primary key in a given hierarchy.
 // This function differs from CreatePrimary in that all response elements
 // are returned, and they are returned in relatively raw form.
-func CreatePrimaryEx(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) (keyHandle tpmutil.Handle, public, creationData, creationHash []byte, ticket *Ticket, creationName []byte, err error) {
+func CreatePrimaryEx(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public) (keyHandle tpmutil.Handle, public, creationData, creationHash []byte, ticket Ticket, creationName []byte, err error) {
 	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentPassword)}
-	cmd, err := encodeCreate(owner, sel, auth, ownerPassword, nil /*inSensitive*/, pub)
+	Cmd, err := encodeCreate(owner, sel, auth, ownerPassword, nil /*inSensitive*/, pub)
 	if err != nil {
-		return 0, nil, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, Ticket{}, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdCreatePrimary, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCreatePrimary, tpmutil.RawBytes(Cmd))
 	if err != nil {
-		return 0, nil, nil, nil, nil, nil, err
+		return 0, nil, nil, nil, Ticket{}, nil, err
 	}
 
 	return decodeCreatePrimary(resp)
@@ -508,7 +504,7 @@ func decodeReadPublic(in []byte) (Public, []byte, []byte, error) {
 // ReadPublic reads the public part of the object under handle.
 // Returns the public data, name and qualified name.
 func ReadPublic(rw io.ReadWriter, handle tpmutil.Handle) (Public, []byte, []byte, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdReadPublic, handle)
+	resp, err := runCommand(rw, TagNoSessions, CmdReadPublic, handle)
 	if err != nil {
 		return Public{}, nil, nil, err
 	}
@@ -519,14 +515,12 @@ func ReadPublic(rw io.ReadWriter, handle tpmutil.Handle) (Public, []byte, []byte
 func decodeCreate(in []byte) (private, public, creationData, creationHash tpmutil.U16Bytes, creationTicket Ticket, err error) {
 	buf := bytes.NewBuffer(in)
 	var paramSize uint32
-	if err := tpmutil.UnpackBuf(buf, &paramSize, &private, &public, &creationData, &creationHash); err != nil {
-		return nil, nil, nil, nil, Ticket{}, fmt.Errorf("decoding Handle, Private, Public, CreationData, CreationHash: %v", err)
+	if err := tpmutil.UnpackBuf(buf, &paramSize, &private, &public, &creationData, &creationHash, &creationTicket); err != nil {
+		return nil, nil, nil, nil, Ticket{}, fmt.Errorf("decoding Handle, Private, Public, CreationData, CreationHash, CreationTicket: %v", err)
 	}
-	cr, err := decodeTicket(buf)
 	if err != nil {
 		return nil, nil, nil, nil, Ticket{}, fmt.Errorf("decoding CreationTicket: %v", err)
 	}
-	creationTicket = *cr
 	if _, err := DecodeCreationData(creationData); err != nil {
 		return nil, nil, nil, nil, Ticket{}, fmt.Errorf("decoding CreationData: %v", err)
 	}
@@ -538,7 +532,7 @@ func create(rw io.ReadWriter, parentHandle tpmutil.Handle, auth AuthCommand, obj
 	if err != nil {
 		return nil, nil, nil, nil, Ticket{}, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdCreate, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCreate, tpmutil.RawBytes(cmd))
 	if err != nil {
 		return nil, nil, nil, nil, Ticket{}, err
 	}
@@ -560,6 +554,13 @@ func CreateKeyUsingAuth(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection
 	return create(rw, owner, auth, ownerPassword, nil /*inSensitive*/, pub, sel)
 }
 
+// CreateKeyWithSensitive is very similar to CreateKey, except
+// that it can take in a piece of sensitive data.
+func CreateKeyWithSensitive(rw io.ReadWriter, owner tpmutil.Handle, sel PCRSelection, parentPassword, ownerPassword string, pub Public, sensitive []byte) (private, public, creationData, creationHash []byte, creationTicket Ticket, err error) {
+	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentPassword)}
+	return create(rw, owner, auth, ownerPassword, sensitive, pub, sel)
+}
+
 // Seal creates a data blob object that seals the sensitive data under a parent and with a
 // password and auth policy. Access to the parent must be available with a simple password.
 // Returns private and public portions of the created object.
@@ -576,6 +577,50 @@ func Seal(rw io.ReadWriter, parentHandle tpmutil.Handle, parentPassword, objectP
 		return nil, nil, err
 	}
 	return private, public, nil
+}
+
+func encodeImport(parentHandle tpmutil.Handle, auth AuthCommand, publicBlob, privateBlob, symSeed, encryptionKey tpmutil.U16Bytes, sym *SymScheme) ([]byte, error) {
+	ph, err := tpmutil.Pack(parentHandle)
+	if err != nil {
+		return nil, err
+	}
+	encodedAuth, err := encodeAuthArea(auth)
+	if err != nil {
+		return nil, err
+	}
+	data, err := tpmutil.Pack(encryptionKey, publicBlob, privateBlob, symSeed)
+	if err != nil {
+		return nil, err
+	}
+	encodedScheme, err := sym.encode()
+	if err != nil {
+		return nil, err
+	}
+
+	return concat(ph, encodedAuth, data, encodedScheme)
+}
+
+func decodeImport(resp []byte) ([]byte, error) {
+	var paramSize uint32
+	var outPrivate tpmutil.U16Bytes
+	_, err := tpmutil.Unpack(resp, &paramSize, &outPrivate)
+	return outPrivate, err
+}
+
+// Import allows a user to import a key created on a different computer
+// or in a different TPM. The publicBlob and privateBlob must always be
+// provided. symSeed should be non-nil iff an "outer wrapper" is used. Both of
+// encryptionKey and sym should be non-nil iff an "inner wrapper" is used.
+func Import(rw io.ReadWriter, parentHandle tpmutil.Handle, auth AuthCommand, publicBlob, privateBlob, symSeed, encryptionKey []byte, sym *SymScheme) ([]byte, error) {
+	Cmd, err := encodeImport(parentHandle, auth, publicBlob, privateBlob, symSeed, encryptionKey, sym)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdImport, tpmutil.RawBytes(Cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeImport(resp)
 }
 
 func encodeLoad(parentHandle tpmutil.Handle, auth AuthCommand, publicBlob, privateBlob tpmutil.U16Bytes) ([]byte, error) {
@@ -615,11 +660,11 @@ func Load(rw io.ReadWriter, parentHandle tpmutil.Handle, parentAuth string, publ
 // LoadUsingAuth loads public/private blobs into an object in the TPM using the
 // provided AuthCommand. Returns loaded object handle and its name.
 func LoadUsingAuth(rw io.ReadWriter, parentHandle tpmutil.Handle, auth AuthCommand, publicBlob, privateBlob []byte) (tpmutil.Handle, []byte, error) {
-	cmd, err := encodeLoad(parentHandle, auth, publicBlob, privateBlob)
+	Cmd, err := encodeLoad(parentHandle, auth, publicBlob, privateBlob)
 	if err != nil {
 		return 0, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdLoad, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdLoad, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -652,11 +697,11 @@ func decodeLoadExternal(in []byte) (tpmutil.Handle, []byte, error) {
 // LoadExternal loads a public (and optionally a private) key into an object in
 // the TPM. Returns loaded object handle and its name.
 func LoadExternal(rw io.ReadWriter, pub Public, private Private, hierarchy tpmutil.Handle) (tpmutil.Handle, []byte, error) {
-	cmd, err := encodeLoadExternal(pub, private, hierarchy)
+	Cmd, err := encodeLoadExternal(pub, private, hierarchy)
 	if err != nil {
 		return 0, nil, err
 	}
-	resp, err := runCommand(rw, TagNoSessions, cmdLoadExternal, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagNoSessions, CmdLoadExternal, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -669,7 +714,7 @@ func LoadExternal(rw io.ReadWriter, pub Public, private Private, hierarchy tpmut
 
 // PolicyPassword sets password authorization requirement on the object.
 func PolicyPassword(rw io.ReadWriter, handle tpmutil.Handle) error {
-	_, err := runCommand(rw, TagNoSessions, cmdPolicyPassword, handle)
+	_, err := runCommand(rw, TagNoSessions, CmdPolicyPassword, handle)
 	return err
 }
 
@@ -697,22 +742,21 @@ func decodePolicySecret(in []byte) (*Ticket, error) {
 	if err := tpmutil.UnpackBuf(buf, &paramSize, &timeout); err != nil {
 		return nil, fmt.Errorf("decoding timeout: %v", err)
 	}
-
-	ticket, err := decodeTicket(buf)
-	if err != nil {
+	var t Ticket
+	if err := tpmutil.UnpackBuf(buf, &t); err != nil {
 		return nil, fmt.Errorf("decoding ticket: %v", err)
 	}
-	return ticket, nil
+	return &t, nil
 }
 
 // PolicySecret sets a secret authorization requirement on the provided entity.
 // If expiry is non-zero, the authorization is valid for expiry seconds.
 func PolicySecret(rw io.ReadWriter, entityHandle tpmutil.Handle, entityAuth AuthCommand, policyHandle tpmutil.Handle, policyNonce, cpHash, policyRef []byte, expiry int32) (*Ticket, error) {
-	cmd, err := encodePolicySecret(entityHandle, entityAuth, policyHandle, policyNonce, cpHash, policyRef, expiry)
+	Cmd, err := encodePolicySecret(entityHandle, entityAuth, policyHandle, policyNonce, cpHash, policyRef, expiry)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, CmdPolicySecret, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdPolicySecret, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
@@ -737,18 +781,45 @@ func encodePolicyPCR(session tpmutil.Handle, expectedDigest tpmutil.U16Bytes, se
 }
 
 // PolicyPCR sets PCR state binding for authorization on a session.
+//
+// expectedDigest is optional. When specified, it's compared against the digest
+// of PCRs matched by sel.
+//
+// Note that expectedDigest must be a *digest* of the expected PCR value. You
+// must compute the digest manually. ReadPCR returns raw PCR values, not their
+// digests.
+// If you wish to select multiple PCRs, concatenate their values before
+// computing the digest. See "TPM 2.0 Part 1, Selecting Multiple PCR".
 func PolicyPCR(rw io.ReadWriter, session tpmutil.Handle, expectedDigest []byte, sel PCRSelection) error {
-	cmd, err := encodePolicyPCR(session, expectedDigest, sel)
+	Cmd, err := encodePolicyPCR(session, expectedDigest, sel)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagNoSessions, CmdPolicyPCR, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagNoSessions, CmdPolicyPCR, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+// PolicyOr compares PolicySession→Digest against the list of provided values.
+// If the current Session→Digest does not match any value in the list,
+// the TPM shall return TPM_RC_VALUE. Otherwise, the TPM will reset policySession→Digest
+// to a Zero Digest. Then policySession→Digest is extended by the concatenation of
+// TPM_CC_PolicyOR and the concatenation of all of the digests.
+func PolicyOr(rw io.ReadWriter, session tpmutil.Handle, digests TPMLDigest) error {
+	d, err := digests.Encode()
+	if err != nil {
+		return err
+	}
+	data, err := tpmutil.Pack(session, d)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagNoSessions, CmdPolicyOr, data)
 	return err
 }
 
 // PolicyGetDigest returns the current policyDigest of the session.
 func PolicyGetDigest(rw io.ReadWriter, handle tpmutil.Handle) ([]byte, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdPolicyGetDigest, handle)
+	resp, err := runCommand(rw, TagNoSessions, CmdPolicyGetDigest, handle)
 	if err != nil {
 		return nil, err
 	}
@@ -782,11 +853,11 @@ func decodeStartAuthSession(in []byte) (tpmutil.Handle, []byte, error) {
 // StartAuthSession initializes a session object.
 // Returns session handle and the initial nonce from the TPM.
 func StartAuthSession(rw io.ReadWriter, tpmKey, bindKey tpmutil.Handle, nonceCaller, secret []byte, se SessionType, sym, hashAlg Algorithm) (tpmutil.Handle, []byte, error) {
-	cmd, err := encodeStartAuthSession(tpmKey, bindKey, nonceCaller, secret, se, sym, hashAlg)
+	Cmd, err := encodeStartAuthSession(tpmKey, bindKey, nonceCaller, secret, se, sym, hashAlg)
 	if err != nil {
 		return 0, nil, err
 	}
-	resp, err := runCommand(rw, TagNoSessions, cmdStartAuthSession, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagNoSessions, CmdStartAuthSession, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return 0, nil, err
 	}
@@ -822,11 +893,11 @@ func Unseal(rw io.ReadWriter, itemHandle tpmutil.Handle, password string) ([]byt
 
 // UnsealWithSession returns the data for a loaded sealed object.
 func UnsealWithSession(rw io.ReadWriter, sessionHandle, itemHandle tpmutil.Handle, password string) ([]byte, error) {
-	cmd, err := encodeUnseal(sessionHandle, itemHandle, password)
+	Cmd, err := encodeUnseal(sessionHandle, itemHandle, password)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdUnseal, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdUnseal, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
@@ -853,29 +924,44 @@ func encodeQuote(signingHandle tpmutil.Handle, parentPassword, ownerPassword str
 	return concat(ha, auth, params, pcrs)
 }
 
-func decodeQuote(in []byte) ([]byte, *Signature, error) {
+func decodeQuote(in []byte) ([]byte, []byte, error) {
 	buf := bytes.NewBuffer(in)
 	var paramSize uint32
-	var attest tpmutil.U16Bytes
-	if err := tpmutil.UnpackBuf(buf, &paramSize, &attest); err != nil {
+	if err := tpmutil.UnpackBuf(buf, &paramSize); err != nil {
 		return nil, nil, err
 	}
-	sig, err := DecodeSignature(buf)
-	return attest, sig, err
+	buf.Truncate(int(paramSize))
+	var attest tpmutil.U16Bytes
+	if err := tpmutil.UnpackBuf(buf, &attest); err != nil {
+		return nil, nil, err
+	}
+	return attest, buf.Bytes(), nil
 }
 
 // Quote returns a quote of PCR values. A quote is a signature of the PCR
 // values, created using a signing TPM key.
 //
-// Returns attestation data and the signature.
-//
-// Note: currently only RSA signatures are supported.
+// Returns attestation data and the decoded signature.
 func Quote(rw io.ReadWriter, signingHandle tpmutil.Handle, parentPassword, ownerPassword string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, *Signature, error) {
-	cmd, err := encodeQuote(signingHandle, parentPassword, ownerPassword, toQuote, sel, sigAlg)
+	attest, sigRaw, err := QuoteRaw(rw, signingHandle, parentPassword, ownerPassword, toQuote, sel, sigAlg)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdQuote, tpmutil.RawBytes(cmd))
+	sig, err := DecodeSignature(bytes.NewBuffer(sigRaw))
+	if err != nil {
+		return nil, nil, err
+	}
+	return attest, sig, nil
+}
+
+// QuoteRaw is very similar to Quote, except that it will return
+// the raw signature in a byte array without decoding.
+func QuoteRaw(rw io.ReadWriter, signingHandle tpmutil.Handle, parentPassword, ownerPassword string, toQuote []byte, sel PCRSelection, sigAlg Algorithm) ([]byte, []byte, error) {
+	Cmd, err := encodeQuote(signingHandle, parentPassword, ownerPassword, toQuote, sel, sigAlg)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdQuote, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -925,11 +1011,11 @@ func ActivateCredentialUsingAuth(rw io.ReadWriter, auth []AuthCommand, activeHan
 		return nil, fmt.Errorf("len(auth) = %d, want 2", len(auth))
 	}
 
-	cmd, err := encodeActivateCredential(auth, activeHandle, keyHandle, credBlob, secret)
+	Cmd, err := encodeActivateCredential(auth, activeHandle, keyHandle, credBlob, secret)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdActivateCredential, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdActivateCredential, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
@@ -960,11 +1046,11 @@ func decodeMakeCredential(in []byte) ([]byte, []byte, error) {
 // MakeCredential creates an encrypted credential for use in MakeCredential.
 // Returns encrypted credential and wrapped secret used to encrypt it.
 func MakeCredential(rw io.ReadWriter, protectorHandle tpmutil.Handle, credential, activeName []byte) ([]byte, []byte, error) {
-	cmd, err := encodeMakeCredential(protectorHandle, credential, activeName)
+	Cmd, err := encodeMakeCredential(protectorHandle, credential, activeName)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagNoSessions, cmdMakeCredential, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagNoSessions, CmdMakeCredential, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -989,11 +1075,59 @@ func encodeEvictControl(ownerAuth string, owner, objectHandle, persistentHandle 
 
 // EvictControl toggles persistence of an object within the TPM.
 func EvictControl(rw io.ReadWriter, ownerAuth string, owner, objectHandle, persistentHandle tpmutil.Handle) error {
-	cmd, err := encodeEvictControl(ownerAuth, owner, objectHandle, persistentHandle)
+	Cmd, err := encodeEvictControl(ownerAuth, owner, objectHandle, persistentHandle)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdEvictControl, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagSessions, CmdEvictControl, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+func encodeClear(handle tpmutil.Handle, auth AuthCommand) ([]byte, error) {
+	ah, err := tpmutil.Pack(handle)
+	if err != nil {
+		return nil, err
+	}
+	encodedAuth, err := encodeAuthArea(auth)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ah, encodedAuth)
+}
+
+// Clear clears lockout, endorsement and owner hierarchy authorization values
+func Clear(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand) error {
+	Cmd, err := encodeClear(handle, auth)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdClear, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+func encodeHierarchyChangeAuth(handle tpmutil.Handle, auth AuthCommand, newAuth string) ([]byte, error) {
+	ah, err := tpmutil.Pack(handle)
+	if err != nil {
+		return nil, err
+	}
+	encodedAuth, err := encodeAuthArea(auth)
+	if err != nil {
+		return nil, err
+	}
+	param, err := tpmutil.Pack(tpmutil.U16Bytes(newAuth))
+	if err != nil {
+		return nil, err
+	}
+	return concat(ah, encodedAuth, param)
+}
+
+// HierarchyChangeAuth changes the authorization values for a hierarchy or for the lockout authority
+func HierarchyChangeAuth(rw io.ReadWriter, handle tpmutil.Handle, auth AuthCommand, newAuth string) error {
+	Cmd, err := encodeHierarchyChangeAuth(handle, auth, newAuth)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdHierarchyChangeAuth, tpmutil.RawBytes(Cmd))
 	return err
 }
 
@@ -1001,12 +1135,12 @@ func EvictControl(rw io.ReadWriter, ownerAuth string, owner, objectHandle, persi
 // context for storage outside of the TPM. The handle references context to
 // store.
 func ContextSave(rw io.ReadWriter, handle tpmutil.Handle) ([]byte, error) {
-	return runCommand(rw, TagNoSessions, cmdContextSave, handle)
+	return runCommand(rw, TagNoSessions, CmdContextSave, handle)
 }
 
 // ContextLoad reloads context data created by ContextSave.
 func ContextLoad(rw io.ReadWriter, saveArea []byte) (tpmutil.Handle, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdContextLoad, tpmutil.RawBytes(saveArea))
+	resp, err := runCommand(rw, TagNoSessions, CmdContextLoad, tpmutil.RawBytes(saveArea))
 	if err != nil {
 		return 0, err
 	}
@@ -1029,67 +1163,132 @@ func encodeIncrementNV(handle tpmutil.Handle, authString string) ([]byte, error)
 
 // NVIncrement increments a counter in NVRAM.
 func NVIncrement(rw io.ReadWriter, handle tpmutil.Handle, authString string) error {
-	cmd, err := encodeIncrementNV(handle, authString)
+	Cmd, err := encodeIncrementNV(handle, authString)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdIncrementNVCounter, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagSessions, CmdIncrementNVCounter, tpmutil.RawBytes(Cmd))
 	return err
-}
-
-func encodeUndefineSpace(ownerAuth string, owner, index tpmutil.Handle) ([]byte, error) {
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
-	if err != nil {
-		return nil, err
-	}
-	out, err := tpmutil.Pack(owner, index)
-	if err != nil {
-		return nil, err
-	}
-	return concat(out, auth)
 }
 
 // NVUndefineSpace removes an index from TPM's NV storage.
 func NVUndefineSpace(rw io.ReadWriter, ownerAuth string, owner, index tpmutil.Handle) error {
-	cmd, err := encodeUndefineSpace(ownerAuth, owner, index)
+	authArea := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)}
+	return NVUndefineSpaceEx(rw, owner, index, authArea)
+}
+
+// NVUndefineSpaceEx removes an index from NVRAM. Unlike, NVUndefineSpace(), custom command
+// authorization can be provided.
+func NVUndefineSpaceEx(rw io.ReadWriter, owner, index tpmutil.Handle, authArea AuthCommand) error {
+	out, err := tpmutil.Pack(owner, index)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdUndefineSpace, tpmutil.RawBytes(cmd))
+	auth, err := encodeAuthArea(authArea)
+	if err != nil {
+		return err
+	}
+	cmd, err := concat(out, auth)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdUndefineSpace, tpmutil.RawBytes(cmd))
 	return err
 }
 
-func encodeDefineSpace(owner, handle tpmutil.Handle, ownerAuth, authVal string, attributes NVAttr, policy tpmutil.U16Bytes, dataSize uint16) ([]byte, error) {
-	ha, err := tpmutil.Pack(owner)
+// NVUndefineSpaceSpecial This command allows removal of a platform-created NV Index that has TPMA_NV_POLICY_DELETE SET.
+// The policy to authorize NV index access needs to be created with PolicyCommandCode(rw, sessionHandle, CmdNVUndefineSpaceSpecial) function
+// nvAuthCmd takes the session handle for the policy and the AuthValue (which can be emptyAuth) for the authorization.
+// platformAuth takes either a sessionHandle for the platform policy or HandlePasswordSession and the platformAuth value for authorization.
+func NVUndefineSpaceSpecial(rw io.ReadWriter, nvIndex tpmutil.Handle, nvAuth, platformAuth AuthCommand) error {
+	authBytes, err := encodeAuthArea(nvAuth, platformAuth)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
+	auth, err := tpmutil.Pack(authBytes)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	publicInfo, err := tpmutil.Pack(handle, AlgSHA1, attributes, policy, dataSize)
-	if err != nil {
-		return nil, err
-	}
-	params, err := tpmutil.Pack(tpmutil.U16Bytes(authVal), tpmutil.U16Bytes(publicInfo))
-	if err != nil {
-		return nil, err
-	}
-	return concat(ha, auth, params)
+	_, err = runCommand(rw, TagSessions, CmdNVUndefineSpaceSpecial, nvIndex, HandlePlatform, tpmutil.RawBytes(auth))
+	return err
 }
 
 // NVDefineSpace creates an index in TPM's NV storage.
 func NVDefineSpace(rw io.ReadWriter, owner, handle tpmutil.Handle, ownerAuth, authString string, policy []byte, attributes NVAttr, dataSize uint16) error {
-	cmd, err := encodeDefineSpace(owner, handle, ownerAuth, authString, attributes, policy, dataSize)
+	nvPub := NVPublic{
+		NVIndex:    handle,
+		NameAlg:    AlgSHA1,
+		Attributes: attributes,
+		AuthPolicy: policy,
+		DataSize:   dataSize,
+	}
+	authArea := AuthCommand{
+		Session:    HandlePasswordSession,
+		Attributes: AttrContinueSession,
+		Auth:       []byte(ownerAuth),
+	}
+	return NVDefineSpaceEx(rw, owner, authString, nvPub, authArea)
+
+}
+
+// NVDefineSpaceEx accepts NVPublic structure and AuthCommand, allowing more flexibility.
+func NVDefineSpaceEx(rw io.ReadWriter, owner tpmutil.Handle, authVal string, pubInfo NVPublic, authArea AuthCommand) error {
+	ha, err := tpmutil.Pack(owner)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdDefineSpace, tpmutil.RawBytes(cmd))
+	auth, err := encodeAuthArea(authArea)
+	if err != nil {
+		return err
+	}
+	publicInfo, err := tpmutil.Pack(pubInfo)
+	if err != nil {
+		return err
+	}
+	params, err := tpmutil.Pack(tpmutil.U16Bytes(authVal), tpmutil.U16Bytes(publicInfo))
+	if err != nil {
+		return err
+	}
+	cmd, err := concat(ha, auth, params)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdDefineSpace, tpmutil.RawBytes(cmd))
 	return err
 }
 
-func encodeWriteNV(owner, handle tpmutil.Handle, authString string, data tpmutil.U16Bytes, offset uint16) ([]byte, error) {
+// NVWrite writes data into the TPM's NV storage.
+func NVWrite(rw io.ReadWriter, authHandle, nvIndex tpmutil.Handle, authString string, data tpmutil.U16Bytes, offset uint16) error {
+	auth := AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(authString)}
+	return NVWriteEx(rw, authHandle, nvIndex, auth, data, offset)
+}
+
+// NVWriteEx does the same as NVWrite with the exception of letting the user take care of the AuthCommand before calling the function.
+// This allows more flexibility and does not limit the AuthCommand to PasswordSession.
+func NVWriteEx(rw io.ReadWriter, authHandle, nvIndex tpmutil.Handle, authArea AuthCommand, data tpmutil.U16Bytes, offset uint16) error {
+	h, err := tpmutil.Pack(authHandle, nvIndex)
+	if err != nil {
+		return err
+	}
+	authEnc, err := encodeAuthArea(authArea)
+	if err != nil {
+		return err
+	}
+
+	d, err := tpmutil.Pack(data, offset)
+	if err != nil {
+		return err
+	}
+
+	b, err := concat(h, authEnc, d)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdWriteNV, tpmutil.RawBytes(b))
+	return err
+}
+
+func encodeLockNV(owner, handle tpmutil.Handle, authString string) ([]byte, error) {
 	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(authString)})
 	if err != nil {
 		return nil, err
@@ -1098,20 +1297,28 @@ func encodeWriteNV(owner, handle tpmutil.Handle, authString string, data tpmutil
 	if err != nil {
 		return nil, err
 	}
-	buf, err := tpmutil.Pack(data, offset)
-	if err != nil {
-		return nil, err
-	}
-	return concat(out, auth, buf)
+	return concat(out, auth)
 }
 
-// NVWrite writes data into the TPM's NV storage.
-func NVWrite(rw io.ReadWriter, owner, handle tpmutil.Handle, authString string, data tpmutil.U16Bytes, offset uint16) error {
-	cmd, err := encodeWriteNV(owner, handle, authString, data, offset)
+// NVWriteLock inhibits further writes on the given NV index if at least one of
+// the AttrWriteSTClear or AttrWriteDefine bits is set.
+//
+// AttrWriteSTClear causes the index to be locked until the TPM is restarted
+// (see the Startup function).
+//
+// AttrWriteDefine causes the index to be locked permanently if data has been
+// written to the index; otherwise the lock is removed on startup.
+//
+// NVWriteLock returns an error if neither bit is set.
+//
+// It is not an error to call NVWriteLock for an index that is already locked
+// for writing.
+func NVWriteLock(rw io.ReadWriter, owner, handle tpmutil.Handle, authString string) error {
+	Cmd, err := encodeLockNV(owner, handle, authString)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdWriteNV, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagSessions, CmdWriteLockNV, tpmutil.RawBytes(Cmd))
 	return err
 }
 
@@ -1128,7 +1335,7 @@ func decodeNVReadPublic(in []byte) (NVPublic, error) {
 // NVReadPublic reads the public data of an NV index.
 func NVReadPublic(rw io.ReadWriter, index tpmutil.Handle) (NVPublic, error) {
 	// Read public area to determine data size.
-	resp, err := runCommand(rw, TagNoSessions, cmdReadPublicNV, index)
+	resp, err := runCommand(rw, TagNoSessions, CmdReadPublicNV, index)
 	if err != nil {
 		return NVPublic{}, err
 	}
@@ -1202,11 +1409,11 @@ func NVReadEx(rw io.ReadWriter, index, authHandle tpmutil.Handle, password strin
 			readSize = int(pub.DataSize) - len(outBuff)
 		}
 
-		cmd, err := encodeNVRead(index, authHandle, password, uint16(len(outBuff)), uint16(readSize))
+		Cmd, err := encodeNVRead(index, authHandle, password, uint16(len(outBuff)), uint16(readSize))
 		if err != nil {
 			return nil, fmt.Errorf("building NV_Read command: %v", err)
 		}
-		resp, err := runCommand(rw, TagSessions, cmdReadNV, tpmutil.RawBytes(cmd))
+		resp, err := runCommand(rw, TagSessions, CmdReadNV, tpmutil.RawBytes(Cmd))
 		if err != nil {
 			return nil, fmt.Errorf("running NV_Read command (cursor=%d,size=%d): %v", len(outBuff), readSize, err)
 		}
@@ -1219,38 +1426,214 @@ func NVReadEx(rw io.ReadWriter, index, authHandle tpmutil.Handle, password strin
 	return outBuff, nil
 }
 
-// Hash computes a hash of data in buf using the TPM.
-func Hash(rw io.ReadWriter, alg Algorithm, buf tpmutil.U16Bytes) ([]byte, error) {
-	resp, err := runCommand(rw, TagNoSessions, cmdHash, buf, alg, HandleNull)
+// NVReadLock inhibits further reads of the given NV index if AttrReadSTClear
+// is set. After the TPM is restarted the index can be read again (see the
+// Startup function).
+//
+// NVReadLock returns an error if the AttrReadSTClear bit is not set.
+//
+// It is not an error to call NVReadLock for an index that is already locked
+// for reading.
+func NVReadLock(rw io.ReadWriter, owner, handle tpmutil.Handle, authString string) error {
+	Cmd, err := encodeLockNV(owner, handle, authString)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdReadLockNV, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+// decodeHash unpacks a successful response to TPM2_Hash, returning the computed digest and
+// validation ticket.
+func decodeHash(resp []byte) ([]byte, *Ticket, error) {
+	var digest tpmutil.U16Bytes
+	var validation Ticket
+
+	buf := bytes.NewBuffer(resp)
+	if err := tpmutil.UnpackBuf(buf, &digest, &validation); err != nil {
+		return nil, nil, err
+	}
+	return digest, &validation, nil
+}
+
+// Hash computes a hash of data in buf using TPM2_Hash, returning the computed
+// digest and validation ticket. The validation ticket serves as confirmation
+// from the TPM that the data in buf did not begin with TPM_GENERATED_VALUE.
+// NOTE: TPM2_Hash can only accept data up to MAX_DIGEST_BUFFER in size, which
+// is implementation-dependent, but guaranteed to be at least 1024 octets.
+func Hash(rw io.ReadWriter, alg Algorithm, buf tpmutil.U16Bytes, hierarchy tpmutil.Handle) (digest []byte, validation *Ticket, err error) {
+	resp, err := runCommand(rw, TagNoSessions, CmdHash, buf, alg, hierarchy)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeHash(resp)
+}
+
+// HashSequenceStart starts a hash or an event sequence. If hashAlg is an
+// implemented hash, then a hash sequence is started. If hashAlg is
+// TPM_ALG_NULL, then an event sequence is started.
+func HashSequenceStart(rw io.ReadWriter, sequenceAuth string, hashAlg Algorithm) (seqHandle tpmutil.Handle, err error) {
+	resp, err := runCommand(rw, TagNoSessions, CmdHashSequenceStart, tpmutil.U16Bytes(sequenceAuth), hashAlg)
+	if err != nil {
+		return 0, err
+	}
+	var handle tpmutil.Handle
+	_, err = tpmutil.Unpack(resp, &handle)
+	return handle, err
+}
+
+func encodeSequenceUpdate(sequenceAuth string, seqHandle tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+	ha, err := tpmutil.Pack(seqHandle)
 	if err != nil {
 		return nil, err
 	}
-
-	var digest tpmutil.U16Bytes
-	if _, err = tpmutil.Unpack(resp, &digest); err != nil {
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(sequenceAuth)})
+	if err != nil {
 		return nil, err
 	}
-	return digest, nil
+	params, err := tpmutil.Pack(buf)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// SequenceUpdate is used to add data to a hash or HMAC sequence.
+func SequenceUpdate(rw io.ReadWriter, sequenceAuth string, seqHandle tpmutil.Handle, buffer []byte) error {
+	cmd, err := encodeSequenceUpdate(sequenceAuth, seqHandle, buffer)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdSequenceUpdate, tpmutil.RawBytes(cmd))
+	return err
+}
+
+func decodeSequenceComplete(resp []byte) ([]byte, *Ticket, error) {
+	var digest tpmutil.U16Bytes
+	var validation Ticket
+	var paramSize uint32
+
+	if _, err := tpmutil.Unpack(resp, &paramSize, &digest, &validation); err != nil {
+		return nil, nil, err
+	}
+	return digest, &validation, nil
+}
+
+func encodeSequenceComplete(sequenceAuth string, seqHandle, hierarchy tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+	ha, err := tpmutil.Pack(seqHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(sequenceAuth)})
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(buf, hierarchy)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+// SequenceComplete adds the last part of data, if any, to a hash/HMAC sequence
+// and returns the result.
+func SequenceComplete(rw io.ReadWriter, sequenceAuth string, seqHandle, hierarchy tpmutil.Handle, buffer []byte) (digest []byte, validation *Ticket, err error) {
+	cmd, err := encodeSequenceComplete(sequenceAuth, seqHandle, hierarchy, buffer)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdSequenceComplete, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeSequenceComplete(resp)
+}
+
+func encodeEventSequenceComplete(auths []AuthCommand, pcrHandle, seqHandle tpmutil.Handle, buf tpmutil.U16Bytes) ([]byte, error) {
+	ha, err := tpmutil.Pack(pcrHandle, seqHandle)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodeAuthArea(auths...)
+	if err != nil {
+		return nil, err
+	}
+	params, err := tpmutil.Pack(buf)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, params)
+}
+
+func decodeEventSequenceComplete(resp []byte) ([]*HashValue, error) {
+	var paramSize uint32
+	var hashCount uint32
+	var err error
+
+	buf := bytes.NewBuffer(resp)
+	if err := tpmutil.UnpackBuf(buf, &paramSize, &hashCount); err != nil {
+		return nil, err
+	}
+
+	buf.Truncate(int(paramSize))
+	digests := make([]*HashValue, hashCount)
+	for i := uint32(0); i < hashCount; i++ {
+		if digests[i], err = decodeHashValue(buf); err != nil {
+			return nil, err
+		}
+	}
+
+	return digests, nil
+}
+
+// EventSequenceComplete adds the last part of data, if any, to an Event
+// Sequence and returns the result in a digest list. If pcrHandle references a
+// PCR and not AlgNull, then the returned digest list is processed in the same
+// manner as the digest list input parameter to PCRExtend() with the pcrHandle
+// in each bank extended with the associated digest value.
+func EventSequenceComplete(rw io.ReadWriter, pcrAuth, sequenceAuth string, pcrHandle, seqHandle tpmutil.Handle, buffer []byte) (digests []*HashValue, err error) {
+	auth := []AuthCommand{
+		{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(pcrAuth)},
+		{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(sequenceAuth)},
+	}
+	cmd, err := encodeEventSequenceComplete(auth, pcrHandle, seqHandle, buffer)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdEventSequenceComplete, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeEventSequenceComplete(resp)
 }
 
 // Startup initializes a TPM (usually done by the OS).
 func Startup(rw io.ReadWriter, typ StartupType) error {
-	_, err := runCommand(rw, TagNoSessions, cmdStartup, typ)
+	_, err := runCommand(rw, TagNoSessions, CmdStartup, typ)
 	return err
 }
 
 // Shutdown shuts down a TPM (usually done by the OS).
 func Shutdown(rw io.ReadWriter, typ StartupType) error {
-	_, err := runCommand(rw, TagNoSessions, cmdShutdown, typ)
+	_, err := runCommand(rw, TagNoSessions, CmdShutdown, typ)
 	return err
 }
 
-func encodeSign(key tpmutil.Handle, password string, digest tpmutil.U16Bytes, sigScheme *SigScheme) ([]byte, error) {
+// nullTicket is a hard-coded null ticket of type TPMT_TK_HASHCHECK.
+// It is for Sign commands that do not require the TPM to verify that the digest
+// is not from data that started with TPM_GENERATED_VALUE.
+var nullTicket = Ticket{
+	Type:      TagHashCheck,
+	Hierarchy: HandleNull,
+	Digest:    tpmutil.U16Bytes{},
+}
+
+func encodeSign(sessionHandle, key tpmutil.Handle, password string, digest tpmutil.U16Bytes, sigScheme *SigScheme, validation *Ticket) ([]byte, error) {
 	ha, err := tpmutil.Pack(key)
 	if err != nil {
 		return nil, err
 	}
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(password)})
+	auth, err := encodeAuthArea(AuthCommand{Session: sessionHandle, Attributes: AttrContinueSession, Auth: []byte(password)})
 	if err != nil {
 		return nil, err
 	}
@@ -1262,16 +1645,15 @@ func encodeSign(key tpmutil.Handle, password string, digest tpmutil.U16Bytes, si
 	if err != nil {
 		return nil, err
 	}
-	hc, err := tpmutil.Pack(TagHashCheck)
-	if err != nil {
-		return nil, err
+	if validation == nil {
+		validation = &nullTicket
 	}
-	params, err := tpmutil.Pack(HandleNull, tpmutil.U16Bytes(nil))
+	v, err := tpmutil.Pack(validation)
 	if err != nil {
 		return nil, err
 	}
 
-	return concat(ha, auth, d, s, hc, params)
+	return concat(ha, auth, d, s, v)
 }
 
 func decodeSign(buf []byte) (*Signature, error) {
@@ -1283,66 +1665,146 @@ func decodeSign(buf []byte) (*Signature, error) {
 	return DecodeSignature(in)
 }
 
-// Sign computes a signature for digest using a given loaded key. Signature
-// algorithm depends on the key type.
-func Sign(rw io.ReadWriter, key tpmutil.Handle, password string, digest []byte, sigScheme *SigScheme) (*Signature, error) {
-	cmd, err := encodeSign(key, password, digest, sigScheme)
+// SignWithSession computes a signature for digest using a given loaded key. Signature
+// algorithm depends on the key type. Used for keys with non-password authorization policies.
+// If 'key' references a Restricted Decryption key, 'validation' must be a valid hash verification
+// ticket from the TPM, which can be obtained by using Hash() to hash the data with the TPM.
+// If 'validation' is nil, a NULL ticket is passed to TPM2_Sign.
+func SignWithSession(rw io.ReadWriter, sessionHandle, key tpmutil.Handle, password string, digest []byte, validation *Ticket, sigScheme *SigScheme) (*Signature, error) {
+	Cmd, err := encodeSign(sessionHandle, key, password, digest, sigScheme, validation)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdSign, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdSign, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
 	return decodeSign(resp)
 }
 
-func encodeCertify(parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes) ([]byte, error) {
+// Sign computes a signature for digest using a given loaded key. Signature
+// algorithm depends on the key type.
+// If 'key' references a Restricted Decryption key, 'validation' must be a valid hash verification
+// ticket from the TPM, which can be obtained by using Hash() to hash the data with the TPM.
+// If 'validation' is nil, a NULL ticket is passed to TPM2_Sign.
+func Sign(rw io.ReadWriter, key tpmutil.Handle, password string, digest []byte, validation *Ticket, sigScheme *SigScheme) (*Signature, error) {
+	return SignWithSession(rw, HandlePasswordSession, key, password, digest, validation, sigScheme)
+}
+
+func encodeCertify(objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes) ([]byte, error) {
 	ha, err := tpmutil.Pack(object, signer)
 	if err != nil {
 		return nil, err
 	}
 
-	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(parentAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(ownerAuth)})
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(objectAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(signerAuth)})
 	if err != nil {
 		return nil, err
 	}
 
-	scheme := tpmtSigScheme{AlgRSASSA, AlgSHA256}
+	scheme := SigScheme{Alg: AlgRSASSA, Hash: AlgSHA256}
 	// Use signing key's scheme.
-	params, err := tpmutil.Pack(qualifyingData, scheme)
+	s, err := scheme.encode()
 	if err != nil {
 		return nil, err
 	}
-	return concat(ha, auth, params)
+	data, err := tpmutil.Pack(qualifyingData)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, data, s)
+}
+
+// This function differs from encodeCertify in that it takes the scheme to be used as an additional argument.
+func encodeCertifyEx(objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData tpmutil.U16Bytes, scheme SigScheme) ([]byte, error) {
+	ha, err := tpmutil.Pack(object, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(objectAuth)}, AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(signerAuth)})
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := scheme.encode()
+	if err != nil {
+		return nil, err
+	}
+	data, err := tpmutil.Pack(qualifyingData)
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, data, s)
 }
 
 func decodeCertify(resp []byte) ([]byte, []byte, error) {
 	var paramSize uint32
 	var attest, signature tpmutil.U16Bytes
 	var sigAlg, hashAlg Algorithm
-	if _, err := tpmutil.Unpack(resp, &paramSize, &attest, &sigAlg, &hashAlg, &signature); err != nil {
+
+	buf := bytes.NewBuffer(resp)
+	if err := tpmutil.UnpackBuf(buf, &paramSize); err != nil {
 		return nil, nil, err
+	}
+	buf.Truncate(int(paramSize))
+	if err := tpmutil.UnpackBuf(buf, &attest, &sigAlg); err != nil {
+		return nil, nil, err
+	}
+	// If sigAlg is AlgNull, there will be no hashAlg or signature.
+	// This will happen if AlgNull was passed in the Certify() as
+	// the signing key (no need to sign the response).
+	// See TPM2 spec part4 pg227 SignAttestInfo()
+	if sigAlg != AlgNull {
+		if sigAlg == AlgECDSA {
+			var r, s tpmutil.U16Bytes
+			if err := tpmutil.UnpackBuf(buf, &hashAlg, &r, &s); err != nil {
+				return nil, nil, err
+			}
+			signature = append(r, s...)
+		} else {
+			if err := tpmutil.UnpackBuf(buf, &hashAlg, &signature); err != nil {
+				return nil, nil, err
+			}
+		}
 	}
 	return attest, signature, nil
 }
 
 // Certify generates a signature of a loaded TPM object with a signing key
-// signer. Returned values are: attestation data (TPMS_ATTEST), signature and
-// error, if any.
-func Certify(rw io.ReadWriter, parentAuth, ownerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
-	cmd, err := encodeCertify(parentAuth, ownerAuth, object, signer, qualifyingData)
+// signer. This function calls encodeCertify which makes use of the hardcoded
+// signing scheme {AlgRSASSA, AlgSHA256}. Returned values are: attestation data (TPMS_ATTEST),
+// signature and error, if any.
+func Certify(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte) ([]byte, []byte, error) {
+	cmd, err := encodeCertify(objectAuth, signerAuth, object, signer, qualifyingData)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdCertify, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(cmd))
 	if err != nil {
 		return nil, nil, err
 	}
 	return decodeCertify(resp)
 }
 
-func encodeCertifyCreation(objectAuth string, object, signer tpmutil.Handle, qualifyingData, creationHash tpmutil.U16Bytes, scheme SigScheme, ticket *Ticket) ([]byte, error) {
+// CertifyEx generates a signature of a loaded TPM object with a signing key
+// signer. This function differs from Certify in that it takes the scheme
+// to be used as an additional argument and calls encodeCertifyEx instead
+// of encodeCertify. Returned values are: attestation data (TPMS_ATTEST),
+// signature and error, if any.
+func CertifyEx(rw io.ReadWriter, objectAuth, signerAuth string, object, signer tpmutil.Handle, qualifyingData []byte, scheme SigScheme) ([]byte, []byte, error) {
+	cmd, err := encodeCertifyEx(objectAuth, signerAuth, object, signer, qualifyingData, scheme)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdCertify, tpmutil.RawBytes(cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeCertify(resp)
+}
+
+func encodeCertifyCreation(objectAuth string, object, signer tpmutil.Handle, qualifyingData, creationHash tpmutil.U16Bytes, scheme SigScheme, ticket Ticket) ([]byte, error) {
 	handles, err := tpmutil.Pack(signer, object)
 	if err != nil {
 		return nil, err
@@ -1364,20 +1826,20 @@ func encodeCertifyCreation(objectAuth string, object, signer tpmutil.Handle, qua
 
 // CertifyCreation generates a signature of a newly-created &
 // loaded TPM object, using signer as the signing key.
-func CertifyCreation(rw io.ReadWriter, objectAuth string, object, signer tpmutil.Handle, qualifyingData, creationHash []byte, sigScheme SigScheme, creationTicket *Ticket) (attestation, signature []byte, err error) {
-	cmd, err := encodeCertifyCreation(objectAuth, object, signer, qualifyingData, creationHash, sigScheme, creationTicket)
+func CertifyCreation(rw io.ReadWriter, objectAuth string, object, signer tpmutil.Handle, qualifyingData, creationHash []byte, sigScheme SigScheme, creationTicket Ticket) (attestation, signature []byte, err error) {
+	Cmd, err := encodeCertifyCreation(objectAuth, object, signer, qualifyingData, creationHash, sigScheme, creationTicket)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdCertifyCreation, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdCertifyCreation, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, nil, err
 	}
 	return decodeCertify(resp)
 }
 
-func runCommand(rw io.ReadWriter, tag tpmutil.Tag, cmd tpmutil.Command, in ...interface{}) ([]byte, error) {
-	resp, code, err := tpmutil.RunCommand(rw, tag, cmd, in...)
+func runCommand(rw io.ReadWriter, tag tpmutil.Tag, Cmd tpmutil.Command, in ...interface{}) ([]byte, error) {
+	resp, code, err := tpmutil.RunCommand(rw, tag, Cmd, in...)
 	if err != nil {
 		return nil, err
 	}
@@ -1413,11 +1875,11 @@ func encodePCRExtend(pcr tpmutil.Handle, hashAlg Algorithm, hash tpmutil.RawByte
 
 // PCRExtend extends a value into the selected PCR
 func PCRExtend(rw io.ReadWriter, pcr tpmutil.Handle, hashAlg Algorithm, hash []byte, password string) error {
-	cmd, err := encodePCRExtend(pcr, hashAlg, hash, password)
+	Cmd, err := encodePCRExtend(pcr, hashAlg, hash, password)
 	if err != nil {
 		return err
 	}
-	_, err = runCommand(rw, TagSessions, cmdPCRExtend, tpmutil.RawBytes(cmd))
+	_, err = runCommand(rw, TagSessions, CmdPCRExtend, tpmutil.RawBytes(Cmd))
 	return err
 }
 
@@ -1518,21 +1980,21 @@ func decodeEncryptDecrypt(resp []byte) ([]byte, []byte, error) {
 }
 
 func encryptDecryptBlockSymmetric(rw io.ReadWriteCloser, keyAuth string, key tpmutil.Handle, iv, data []byte, decrypt bool) ([]byte, []byte, error) {
-	cmd, err := encodeEncryptDecrypt2(keyAuth, key, iv, data, decrypt)
+	Cmd, err := encodeEncryptDecrypt2(keyAuth, key, iv, data, decrypt)
 	if err != nil {
 		return nil, nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdEncryptDecrypt2, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdEncryptDecrypt2, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		fmt0Err, ok := err.(Error)
 		if ok && fmt0Err.Code == RCCommandCode {
 			// If TPM2_EncryptDecrypt2 is not supported, fall back to
 			// TPM2_EncryptDecrypt.
-			cmd, err := encodeEncryptDecrypt(keyAuth, key, iv, data, decrypt)
+			Cmd, _ := encodeEncryptDecrypt(keyAuth, key, iv, data, decrypt)
+			resp, err = runCommand(rw, TagSessions, CmdEncryptDecrypt, tpmutil.RawBytes(Cmd))
 			if err != nil {
 				return nil, nil, err
 			}
-			resp, err = runCommand(rw, TagSessions, cmdEncryptDecrypt, tpmutil.RawBytes(cmd))
 		}
 	}
 	if err != nil {
@@ -1595,11 +2057,11 @@ func decodeRSAEncrypt(resp []byte) ([]byte, error) {
 // a null byte is appended to the label and the null byte is included in the padding
 // scheme.
 func RSAEncrypt(rw io.ReadWriter, key tpmutil.Handle, message []byte, scheme *AsymScheme, label string) ([]byte, error) {
-	cmd, err := encodeRSAEncrypt(key, message, scheme, label)
+	Cmd, err := encodeRSAEncrypt(key, message, scheme, label)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagNoSessions, cmdRSAEncrypt, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagNoSessions, CmdRSAEncrypt, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
@@ -1645,13 +2107,160 @@ func decodeRSADecrypt(resp []byte) ([]byte, error) {
 // label, a null byte is appended to the label and the null byte is included in the
 // padding scheme.
 func RSADecrypt(rw io.ReadWriter, key tpmutil.Handle, password string, message []byte, scheme *AsymScheme, label string) ([]byte, error) {
-	cmd, err := encodeRSADecrypt(key, password, message, scheme, label)
+	Cmd, err := encodeRSADecrypt(key, password, message, scheme, label)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := runCommand(rw, TagSessions, cmdRSADecrypt, tpmutil.RawBytes(cmd))
+	resp, err := runCommand(rw, TagSessions, CmdRSADecrypt, tpmutil.RawBytes(Cmd))
 	if err != nil {
 		return nil, err
 	}
 	return decodeRSADecrypt(resp)
+}
+
+func encodeECDHKeyGen(key tpmutil.Handle) ([]byte, error) {
+	return tpmutil.Pack(key)
+}
+
+func decodeECDHKeyGen(resp []byte) (*ECPoint, *ECPoint, error) {
+	// Unpack z and pub as TPM2B_ECC_POINT, which is a TPMS_ECC_POINT with a total size prepended.
+	var z2B, pub2B tpmutil.U16Bytes
+	_, err := tpmutil.Unpack(resp, &z2B, &pub2B)
+	if err != nil {
+		return nil, nil, err
+	}
+	var zPoint, pubPoint ECPoint
+	_, err = tpmutil.Unpack(z2B, &zPoint.XRaw, &zPoint.YRaw)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = tpmutil.Unpack(pub2B, &pubPoint.XRaw, &pubPoint.YRaw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &zPoint, &pubPoint, nil
+}
+
+// ECDHKeyGen generates an ephemeral ECC key, calculates the ECDH point multiplcation of the
+// ephemeral private key and a loaded public key, and returns the public ephemeral point along with
+// the coordinates of the resulting point.
+func ECDHKeyGen(rw io.ReadWriter, key tpmutil.Handle) (zPoint, pubPoint *ECPoint, err error) {
+	Cmd, err := encodeECDHKeyGen(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := runCommand(rw, TagNoSessions, CmdECDHKeyGen, tpmutil.RawBytes(Cmd))
+	if err != nil {
+		return nil, nil, err
+	}
+	return decodeECDHKeyGen(resp)
+}
+
+func encodeECDHZGen(key tpmutil.Handle, password string, inPoint ECPoint) ([]byte, error) {
+	ha, err := tpmutil.Pack(key)
+	if err != nil {
+		return nil, err
+	}
+	auth, err := encodeAuthArea(AuthCommand{Session: HandlePasswordSession, Attributes: AttrContinueSession, Auth: []byte(password)})
+	if err != nil {
+		return nil, err
+	}
+	p, err := tpmutil.Pack(inPoint)
+	if err != nil {
+		return nil, err
+	}
+	// Pack the TPMS_ECC_POINT as a TPM2B_ECC_POINT.
+	p2B, err := tpmutil.Pack(tpmutil.U16Bytes(p))
+	if err != nil {
+		return nil, err
+	}
+	return concat(ha, auth, p2B)
+}
+
+func decodeECDHZGen(resp []byte) (*ECPoint, error) {
+	var paramSize uint32
+	// Unpack a TPM2B_ECC_POINT, which is a TPMS_ECC_POINT with a total size prepended.
+	var z2B tpmutil.U16Bytes
+	_, err := tpmutil.Unpack(resp, &paramSize, &z2B)
+	if err != nil {
+		return nil, err
+	}
+	var zPoint ECPoint
+	_, err = tpmutil.Unpack(z2B, &zPoint.XRaw, &zPoint.YRaw)
+	if err != nil {
+		return nil, err
+	}
+	return &zPoint, nil
+}
+
+// ECDHZGen performs ECDH point multiplication between a private key held in the TPM and a given
+// public point, returning the coordinates of the resulting point. The key must have FlagDecrypt
+// set.
+func ECDHZGen(rw io.ReadWriter, key tpmutil.Handle, password string, inPoint ECPoint) (zPoint *ECPoint, err error) {
+	Cmd, err := encodeECDHZGen(key, password, inPoint)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := runCommand(rw, TagSessions, CmdECDHZGen, tpmutil.RawBytes(Cmd))
+	if err != nil {
+		return nil, err
+	}
+	return decodeECDHZGen(resp)
+}
+
+// DictionaryAttackLockReset cancels the effect of a TPM lockout due to a number
+// of successive authorization failures, by setting the lockout counter to zero.
+// The command requires Lockout Authorization and only one lockoutAuth authorization
+// failure is allowed for this command during a lockoutRecovery interval.
+// Lockout Authorization value by default is empty and can be changed via
+// a call to HierarchyChangeAuth(HandleLockout).
+func DictionaryAttackLockReset(rw io.ReadWriter, auth AuthCommand) error {
+	ha, err := tpmutil.Pack(HandleLockout)
+	if err != nil {
+		return err
+	}
+	encodedAuth, err := encodeAuthArea(auth)
+	if err != nil {
+		return err
+	}
+	Cmd, err := concat(ha, encodedAuth)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdDictionaryAttackLockReset, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+// DictionaryAttackParameters changes the lockout parameters.
+// The command requires Lockout Authorization and has same authorization policy
+// as in DictionaryAttackLockReset.
+func DictionaryAttackParameters(rw io.ReadWriter, auth AuthCommand, maxTries, recoveryTime, lockoutRecovery uint32) error {
+	ha, err := tpmutil.Pack(HandleLockout)
+	if err != nil {
+		return err
+	}
+	encodedAuth, err := encodeAuthArea(auth)
+	if err != nil {
+		return err
+	}
+	params, err := tpmutil.Pack(maxTries, recoveryTime, lockoutRecovery)
+	if err != nil {
+		return err
+	}
+	Cmd, err := concat(ha, encodedAuth, params)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagSessions, CmdDictionaryAttackParameters, tpmutil.RawBytes(Cmd))
+	return err
+}
+
+// PolicyCommandCode indicates that the authorization will be limited to a specific command code
+func PolicyCommandCode(rw io.ReadWriter, session tpmutil.Handle, cc tpmutil.Command) error {
+	data, err := tpmutil.Pack(session, cc)
+	if err != nil {
+		return err
+	}
+	_, err = runCommand(rw, TagNoSessions, CmdPolicyCommandCode, data)
+	return err
 }

--- a/vendor/github.com/google/go-tpm/tpmutil/BUILD
+++ b/vendor/github.com/google/go-tpm/tpmutil/BUILD
@@ -15,6 +15,18 @@ go_library(
     importpath = "github.com/google/go-tpm/tpmutil",
     visibility = ["//visibility:public"],
     deps = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//vendor/github.com/google/go-tpm/tpmutil/tbs:go_default_library",
         ],

--- a/vendor/github.com/google/go-tpm/tpmutil/poll_unix.go
+++ b/vendor/github.com/google/go-tpm/tpmutil/poll_unix.go
@@ -5,38 +5,28 @@ package tpmutil
 import (
 	"fmt"
 	"os"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
-type pollFD struct {
-	fd      int32
-	events  int16
-	revents int16
-}
-
-// poll blocks until the file descriptior is ready for reading or an error occurs.
+// poll blocks until the file descriptor is ready for reading or an error occurs.
 func poll(f *os.File) error {
 	var (
-		fd = &pollFD{
-			fd:     int32(f.Fd()),
-			events: 0x1, // POLLIN
-		}
-		numFD     = 1
-		timeoutMS = -1 // Do not set a timeout
+		fds = []unix.PollFd{{
+			Fd:     int32(f.Fd()),
+			Events: 0x1, // POLLIN
+		}}
+		timeout = -1 // Indefinite timeout
 	)
-	_, _, errno := syscall.Syscall(syscall.SYS_POLL, uintptr(unsafe.Pointer(fd)), uintptr(numFD), uintptr(timeoutMS))
-	// Convert errno into an error, otherwise err != nil checks up the stack
-	// will hit unexpectedly on 0 errno.
-	var err error
-	if errno != 0 {
-		err = errno
+
+	if _, err := unix.Poll(fds, timeout); err != nil {
 		return err
 	}
-	// revents is filled in by the kernel.
-	// If the expected event happened, revents should match events.
-	if fd.revents != fd.events {
-		return fmt.Errorf("unexpected poll revents 0x%x", fd.revents)
+
+	// Revents is filled in by the kernel.
+	// If the expected event happened, Revents should match Events.
+	if fds[0].Revents != fds[0].Events {
+		return fmt.Errorf("unexpected poll Revents 0x%x", fds[0].Revents)
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-tpm v0.2.0
+# github.com/google/go-tpm v0.3.2
 ## explicit
 github.com/google/go-tpm/tpm2
 github.com/google/go-tpm/tpmutil


### PR DESCRIPTION
Version 0.2.0 of go-tpm library did not support building for linux_arm64.  See error below.

```
bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //cmd/gke-exec-auth-plugin:gke-exec-auth-plugin 

workspace/vendor/github.com/google/go-tpm/tpmutil/poll_unix.go:28:33: undefined: syscall.SYS_POLL
Target //cmd/gke-exec-auth-plugin:gke-exec-auth-plugin failed to build
INFO: Elapsed time: 0.922s, Critical Path: 0.25s
INFO: 15 processes: 10 internal, 5 linux-sandbox.
FAILED: Build did NOT complete successfully
```

The failure above happens because v0.2.0 of the go-tpm library used syscall.SYS_POLL which is not supported in arm64 architecture. To workaround this golang has implemented a shim for poll on arm64 in https://go-review.googlesource.com/c/sys/+/24062/. This issue has been raised in go-tpm library https://github.com/google/go-tpm/issues/146 and was fixed in https://github.com/google/go-tpm/pull/147. Support for arm64 is only available starting v0.3.0 of the go-tpm library. So in order to build gke-exec-auth-plugin for arm64 we will need to update the version of the go-tpm library to v0.3.2. 

All changes were produced by running the following command as recommended in the README.md
```
go get -u github.com/google/go-tpm && ./tools/update_vendor.sh
```

Tests were also updated because in go-tpm v0.3.0 [validation](https://github.com/google/go-tpm/pull/136) was added to check that the magic value in the attestation data is always 0xff544347. We were not setting the value in our tests and so they were failing with the following error:
```
E0923 06:16:16.904904      12 node_csr_approver.go:506] deny CSR "TestValidators/validateTPMAttestation_with_API/good_0": parsing attestation data in CSR: incorrect magic value: 0
```