### PR TITLE
Reapply change to use minimum n1-standard-2

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -27,10 +27,7 @@ function get-num-nodes {
 #   NUM_NODES
 #   NUM_WINDOWS_NODES
 function get-master-size {
-  local suggested_master_size=1
-  if [[ "$(get-num-nodes)" -gt "5" ]]; then
-    suggested_master_size=2
-  fi
+  local suggested_master_size=2
   if [[ "$(get-num-nodes)" -gt "10" ]]; then
     suggested_master_size=4
   fi


### PR DESCRIPTION
https://github.com/kubernetes/cloud-provider-gcp/pull/228 got accidentally reverted by https://github.com/kubernetes/cloud-provider-gcp/pull/273. It is causing `cloud-provider-gcp-e2e-full` to consistently fail with errors like:

```
_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:76
Sep 28 21:25:07.516: Error waiting for all pods to be running and ready: 2 / 31 pods in namespace "kube-system" are NOT in RUNNING and READY state in 10m0s
POD                                               NODE                     PHASE   GRACE CONDITIONS
cloud-controller-manager-kt2-4c31e85a-209f-master kt2-4c31e85a-209f-master Pending       []
fluentd-gcp-v3.2.0-s9tng                                                   Pending       [{Type:PodScheduled Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2021-09-28 21:13:08 +0000 UTC Reason:Unschedulable Message:0/4 nodes are available: 1 Insufficient cpu, 3 node(s) didn't match Pod's node affinity/selector.}]

_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:79
```

For example, see https://github.com/kubernetes/cloud-provider-gcp/pull/278's [PR history](https://prow.k8s.io/pr-history/?org=kubernetes&repo=cloud-provider-gcp&pr=278).

cc @cici37 @DangerOnTheRanger @cheftako @sugangli