### PR TITLE
Use Alpha Compute API only in case of dual stack

### DIFF
--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -96,6 +96,11 @@ func TestNodeAddresses(t *testing.T) {
 	instance := &ga.Instance{
 		Name: "n1",
 		Zone: "us-central1-b",
+		NetworkInterfaces: []*ga.NetworkInterface{
+			{
+				NetworkIP: "10.1.1.1",
+			},
+		},
 	}
 	instanceMap["n1"] = instance
 
@@ -121,6 +126,14 @@ func TestNodeAddresses(t *testing.T) {
 	instance = &ga.Instance{
 		Name: "n2",
 		Zone: "us-central1-b",
+		NetworkInterfaces: []*ga.NetworkInterface{
+			{
+				NetworkIP: "10.1.1.2",
+				AccessConfigs: []*ga.AccessConfig{
+					{NatIP: "20.1.1.2"},
+				},
+			},
+		},
 	}
 	instanceMap["n2"] = instance
 
@@ -211,9 +224,10 @@ func TestNodeAddresses(t *testing.T) {
 			wantErr:  "instance not found",
 		},
 		{
-			name:     "alpha instance not found",
-			nodeName: "n3",
-			wantErr:  "alpha instance not found",
+			name:      "alpha instance not found",
+			nodeName:  "n3",
+			dualStack: true,
+			wantErr:   "alpha instance not found",
 		},
 		{
 			name:     "external single stack instance",
@@ -359,13 +373,6 @@ func TestAliasRangesByProviderID(t *testing.T) {
 		{
 			name:       "internal single stack instance",
 			providerId: "gce://p1/us-central1-b/n1",
-			wantCIDRs: []string{
-				"10.11.1.0/24",
-			},
-		},
-		{
-			name:       "internal single stack instance",
-			providerId: "gce://p1/us-central1-b/n1",
 			dualStack:  true,
 			wantCIDRs: []string{
 				"10.11.1.0/24",
@@ -375,14 +382,8 @@ func TestAliasRangesByProviderID(t *testing.T) {
 		{
 			name:       "instance not found",
 			providerId: "gce://p1/us-central1-b/x1",
+			dualStack:  true,
 			wantErr:    "alpha instance not found",
-		},
-		{
-			name:       "external single stack instance",
-			providerId: "gce://p1/us-central1-b/n2",
-			wantCIDRs: []string{
-				"10.11.2.0/24",
-			},
 		},
 		{
 			name:       "internal single stack instance",
@@ -396,6 +397,7 @@ func TestAliasRangesByProviderID(t *testing.T) {
 		{
 			name:       "network interface not found",
 			providerId: "gce://p1/us-central1-b/n4",
+			dualStack:  true,
 			wantErr:    "",
 		},
 		{


### PR DESCRIPTION
A recent change #268 introduced dual stack support, but it also began to require Google Cloud Compute Aplha API access. Unfortunately by default projects don't have this access, and therefore the CCM fails with:

> googleapi: Error 403: Required 'Alpha Access' permission for 'Compute API', forbidden

This commit starts using Alpha API only for dual stack deployments, where it's really required. For all other cases we will continue to use GA API.

Fixes: #281