### PR TITLE
Add 3-way merge for node taints

### DIFF
--- a/cmd/gcp-controller-manager/BUILD
+++ b/cmd/gcp-controller-manager/BUILD
@@ -67,6 +67,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
@@ -96,6 +97,7 @@ go_library(
         "//vendor/k8s.io/kubernetes/pkg/apis/certificates/v1:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/controller:go_default_library",
         "//vendor/k8s.io/kubernetes/pkg/controller/certificates:go_default_library",
+        "//vendor/k8s.io/kubernetes/pkg/util/taints:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This change adds a 3-way merge logic for node taints to merge taints
present in the instance metadata with the taints present on the node.
This is similar to the 3-way merge logic that we have for labels today.
The reason we are adding this is to have a consistent way to merge user
provided taints with existing K8s specific node taints similar to what
we do for labels today.