### PR TITLE
Switch the errors to warnings that are expected on first run.

### DIFF
--- a/cmd/gke-exec-auth-plugin/cache.go
+++ b/cmd/gke-exec-auth-plugin/cache.go
@@ -122,12 +122,12 @@ func validPEMKey(key []byte, cert *x509.Certificate) bool {
 func getExistingKeyCert(dir string) ([]byte, []byte, bool) {
 	key, err := ioutil.ReadFile(filepath.Join(dir, keyFileName))
 	if err != nil {
-		klog.Errorf("failed reading existing private key: %v", err)
+		klog.Warningf("failed reading existing private key: %v", err)
 		return nil, nil, false
 	}
 	cert, err := ioutil.ReadFile(filepath.Join(dir, certFileName))
 	if err != nil {
-		klog.Errorf("failed reading existing certificate: %v", err)
+		klog.Warningf("failed reading existing certificate: %v", err)
 		return nil, nil, false
 	}
 	// Check cert expiration.

--- a/cmd/gke-exec-auth-plugin/tpm.go
+++ b/cmd/gke-exec-auth-plugin/tpm.go
@@ -113,8 +113,7 @@ func tpmAttest(dev tpmDevice, privateKey crypto.PrivateKey) ([]byte, error) {
 	// reliable enough.
 	aikCertRaw, aikCert, err := readAIKCert(dev, aikh, aikPub)
 	if err != nil {
-		klog.Errorf("failed reading AIK cert: %v", err)
-		klog.Info("proceeding without AIK cert in CSR")
+		klog.Warningf("proceeding without AIK cert in CSR: failed reading AIK cert: %v", err)
 	} else {
 		klog.Info("AIK cert loaded")
 


### PR DESCRIPTION
These error logs cause a fair bit of confusion when we debug issues with
the gke-exec-auth-plugin. I only switched those errors to warnings that
have a fallback.