### PR TITLE
Add verify-vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ go get -u && ./tools/update_vendor.sh
 Note that this most likely won't work due to cross-dependency issues or repos
 not implementing modules correctly.
 
-## Clean up unused dependencies
-
-```
-go mod tidy && ./tools/update_vendor.sh
-```
-
 # Bazel
 
 Bazel is required to build and release cloud-provider-gcp.

--- a/crd/client/gcpfirewall/clientset/versioned/BUILD
+++ b/crd/client/gcpfirewall/clientset/versioned/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clientset.go",
+        "doc.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/clientset/versioned",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/clientset/versioned/fake/BUILD
+++ b/crd/client/gcpfirewall/clientset/versioned/fake/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "clientset_generated.go",
+        "doc.go",
+        "register.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/clientset/versioned/fake",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/fake:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
+        "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/clientset/versioned/scheme/BUILD
+++ b/crd/client/gcpfirewall/clientset/versioned/scheme/BUILD
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "register.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/clientset/versioned/scheme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/BUILD
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "gcpfirewall.go",
+        "gcpfirewall_client.go",
+        "generated_expansion.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned/scheme:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/fake/BUILD
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/fake/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "fake_gcpfirewall.go",
+        "fake_gcpfirewall_client.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1/fake",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/informers/externalversions/BUILD
+++ b/crd/client/gcpfirewall/informers/externalversions/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "factory.go",
+        "generic.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/informers/externalversions",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned:go_default_library",
+        "//crd/client/gcpfirewall/informers/externalversions/gcpfirewall:go_default_library",
+        "//crd/client/gcpfirewall/informers/externalversions/internalinterfaces:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/BUILD
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["interface.go"],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/informers/externalversions/gcpfirewall",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/informers/externalversions/internalinterfaces:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1alpha1/BUILD
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1alpha1/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gcpfirewall.go",
+        "interface.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1alpha1",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//crd/client/gcpfirewall/clientset/versioned:go_default_library",
+        "//crd/client/gcpfirewall/informers/externalversions/internalinterfaces:go_default_library",
+        "//crd/client/gcpfirewall/listers/gcpfirewall/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/informers/externalversions/internalinterfaces/BUILD
+++ b/crd/client/gcpfirewall/informers/externalversions/internalinterfaces/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["factory_interfaces.go"],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/informers/externalversions/internalinterfaces",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/client/gcpfirewall/clientset/versioned:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/crd/client/gcpfirewall/listers/gcpfirewall/v1alpha1/BUILD
+++ b/crd/client/gcpfirewall/listers/gcpfirewall/v1alpha1/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "expansion_generated.go",
+        "gcpfirewall.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/crd/client/gcpfirewall/listers/gcpfirewall/v1alpha1",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//crd/apis/gcpfirewall/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)

--- a/tools/lib/util.sh
+++ b/tools/lib/util.sh
@@ -44,3 +44,32 @@ kube::util::array_contains() {
   done
   return 1
 }
+
+# Example:  kube::util::trap_add 'echo "in trap DEBUG"' DEBUG
+# See: http://stackoverflow.com/questions/3338030/multiple-bash-traps-for-the-same-signal
+kube::util::trap_add() {
+  local trap_add_cmd
+  trap_add_cmd=$1
+  shift
+
+  for trap_add_name in "$@"; do
+    local existing_cmd
+    local new_cmd
+
+    # Grab the currently defined trap commands for this trap
+    existing_cmd=$(trap -p "${trap_add_name}" |  awk -F"'" '{print $2}')
+
+    if [[ -z "${existing_cmd}" ]]; then
+      new_cmd="${trap_add_cmd}"
+    else
+      new_cmd="${trap_add_cmd};${existing_cmd}"
+    fi
+
+    # Assign the test. Disable the shellcheck warning telling that trap
+    # commands should be single quoted to avoid evaluating them at this
+    # point instead evaluating them at run time. The logic of adding new
+    # commands to a single trap requires them to be evaluated right away.
+    # shellcheck disable=SC2064
+    trap "${new_cmd}" "${trap_add_name}"
+  done
+}

--- a/tools/update_vendor.sh
+++ b/tools/update_vendor.sh
@@ -1,13 +1,25 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o xtrace
 set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ ! -d "vendor" ]; then
-    echo must run from repo root
-    exit 1
-fi
+cd "$(pwd -P)"
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
@@ -20,6 +32,8 @@ find vendor -type f \( \
     -o -name '*.bzl' \
   \) -delete
 
+# clean up unused dependencies
+go mod tidy
 # create a symlink in vendor directory pointing cloud-provider-gcp/providers to the //providers.
 # This lets other packages and tools use the local staging components as if they were vendored.
 rm -fr "${KUBE_ROOT}/vendor/k8s.io/cloud-provider-gcp/providers"

--- a/tools/verify-all.sh
+++ b/tools/verify-all.sh
@@ -45,6 +45,12 @@ if [[ "${VERIFY_GOVET:-true}" == "true" ]]; then
   cd "${KUBE_ROOT}"
 fi
 
+if [[ "${VERIFY_VENDOR:-true}" == "true" ]]; then
+  echo "[*] Verifying vendor..."
+  tools/verify-vendor.sh || res=1
+  cd "${KUBE_ROOT}"
+fi
+
 # exit based on verify scripts
 if [[ "${res}" = 0 ]]; then
   echo ""

--- a/tools/verify-all.sh
+++ b/tools/verify-all.sh
@@ -25,6 +25,10 @@ cd "${KUBE_ROOT}"
 # exit code, if a script fails we'll set this to 1
 res=0
 
+# printout go version
+echo "The current GO version been used:"
+echo $(GOFLAGS='' go version)
+
 # run all verify scripts, optionally skipping any of them
 
 if [[ "${VERIFY_GOFMT:-true}" == "true" ]]; then

--- a/tools/verify-vendor.sh
+++ b/tools/verify-vendor.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/tools/lib/util.sh"
+
+# create a nice clean place to put our new vendor tree
+mkdir -p "${KUBE_ROOT}/_tmp"
+_tmpdir="$(mktemp -d "${KUBE_ROOT}/_tmp/kube-vendor.XXXXXX")"
+echo ${_tmpdir}
+
+if [[ -z ${KEEP_TMP:-} ]]; then
+    KEEP_TMP=false
+fi
+
+function cleanup {
+  # make go module dirs writeable
+  chmod -R +w "${_tmpdir}"
+  if [ "${KEEP_TMP}" == "true" ]; then
+    echo "Leaving ${_tmpdir} for you to examine or copy. Please delete it manually when finished. (rm -rf ${_tmpdir})"
+  else
+    echo "Removing ${_tmpdir}"
+    rm -rf "${_tmpdir}"
+  fi
+}
+kube::util::trap_add cleanup EXIT
+
+# Copy the contents of the kube directory into the nice clean place (which is NOT shaped like a GOPATH)
+_kubetmp="${_tmpdir}/kubernetes"
+mkdir -p "${_kubetmp}"
+tar --exclude=.git --exclude="./_*" -c . | (cd "${_kubetmp}" && tar xf -)
+# Do all our work in module mode
+export GO111MODULE=on
+
+pushd "${_kubetmp}" > /dev/null 2>&1
+  # Destroy deps in the copy of the kube tree
+  rm -rf ./vendor ./LICENSES
+  # Recreate the vendor tree using the nice clean set we just downloaded
+  tools/update_vendor.sh
+popd > /dev/null 2>&1
+ret=0
+
+pushd "${KUBE_ROOT}" > /dev/null 2>&1
+  # Test for diffs
+  if ! _out="$(diff -Naupr --ignore-matching-lines='^\s*\"GoVersion\":' go.mod "${_kubetmp}/go.mod")"; then
+    echo "Your go.mod file is different:" >&2
+    echo "${_out}" >&2
+    echo "Vendor Verify failed." >&2
+    echo "If you're seeing this locally, run the below command to fix your go.mod:" >&2
+    echo "hack/update_vendor.sh" >&2
+    ret=1
+  fi
+
+  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor "${_kubetmp}/vendor")"; then
+    echo "Your vendored results are different:" >&2
+    echo "${_out}" >&2
+    echo "Vendor Verify failed." >&2
+    echo "${_out}" > vendordiff.patch
+    echo "If you're seeing this locally, run the below command to fix your directories:" >&2
+    echo "hack/update_vendor.sh" >&2
+    ret=1
+  fi
+
+popd > /dev/null 2>&1
+
+if [[ ${ret} -gt 0 ]]; then
+  exit ${ret}
+fi
+
+echo "Vendor Verified."
+# ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
Add go mod tidy into update-vendor
Add verify-vendor.sh and include it into presubmit checking.
Add go version print out when run pre-submit checking.

Close #299 
Close #297 

Here is an sample run of vendor verification in presubmit check: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/cloud-provider-gcp/301/cloud-provider-gcp-verify-all/1470500659454283776