### PR TITLE
Migrate `cloud-provider-gcp` resourcelock to `endpointsleases`

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -87,7 +87,8 @@ func main() {
 		LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
 		RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
 		RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
-		ResourceLock:  rl.EndpointsResourceLock,
+		//TODO(acumino): Switch endpointsleases to leases in one of the future version.
+		ResourceLock: rl.EndpointsLeasesResourceLock,
 	}
 	options.BindLeaderElectionFlags(leConfig, pflag.CommandLine)
 

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -87,7 +87,7 @@ func main() {
 		LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
 		RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
 		RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
-		//TODO(acumino): Switch endpointsleases to leases in one of the future version.
+		//TODO(acumino): Migrate endpointsleases to leases in vesrion 1.24.
 		ResourceLock: rl.EndpointsLeasesResourceLock,
 	}
 	options.BindLeaderElectionFlags(leConfig, pflag.CommandLine)


### PR DESCRIPTION
Support for endpoints lock for leaderelection is removed in K8s 1.24 with kubernetes/kubernetes#106852.
More details about the motivation to switch to leases - ref kubernetes/kubernetes#80289.

To preserve the backward compatibility, resource lock for migration purposes (endpointsleases) should be used when switching from the legacy resource locks (endpoints).

`cloud-provider-gcp` is currently using endpoints. As the first step, this PR adapts endpointsleases.
Once this is merged, we can migrate to leases.

Fixes - #309