### PR TITLE
Handle IPv6 addresses on network interfaces in validateNodeServerCert

### DIFF
--- a/cmd/gcp-controller-manager/node_csr_approver.go
+++ b/cmd/gcp-controller-manager/node_csr_approver.go
@@ -398,6 +398,14 @@ func validateNodeServerCert(ctx *controllerContext, csr *capi.CertificateSigning
 						continue scanIPs
 					}
 				}
+				if ip.String() == iface.Ipv6Address {
+					continue scanIPs
+				}
+				for _, ac := range iface.Ipv6AccessConfigs {
+					if ip.String() == ac.ExternalIpv6 {
+						continue scanIPs
+					}
+				}
 			}
 			klog.Infof("deny CSR %q: IP addresses in CSR (%q) don't match NetworkInterfaces on instance %q (%+v)", csr.Name, x509cr.IPAddresses, instanceName, inst.NetworkInterfaces)
 			return false, nil

--- a/cmd/gcp-controller-manager/node_csr_approver_test.go
+++ b/cmd/gcp-controller-manager/node_csr_approver_test.go
@@ -398,9 +398,25 @@ func TestValidators(t *testing.T) {
 			b.ips = []net.IP{net.ParseIP("1.2.3.4")}
 			b.dns = []string{"i0.z0.c.p0.internal", "i0.c.p0.internal", "i0"}
 		}
+		dualStackCase := func(b *csrBuilder, c *controllerContext) {
+			c.gcpCfg.ProjectID = "p0"
+			c.gcpCfg.Zones = []string{"z1", "z0"}
+			b.requestor = "system:node:ds0"
+			b.ips = []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("fd20:9b0:892f:800:0:5::")}
+			b.dns = []string{"ds0.z0.c.p0.internal", "ds0.c.p0.internal", "ds0"}
+		}
+		dualStackExtCase := func(b *csrBuilder, c *controllerContext) {
+			c.gcpCfg.ProjectID = "p0"
+			c.gcpCfg.Zones = []string{"z1", "z0"}
+			b.requestor = "system:node:ds1"
+			b.ips = []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("2600:1900:1:1:0:5::")}
+			b.dns = []string{"ds1.z0.c.p0.internal", "ds1.c.p0.internal", "ds1"}
+		}
 		cases := []func(*csrBuilder, *controllerContext){
 			// None Domain-scoped project
 			goodCase,
+			dualStackCase,
+			dualStackExtCase,
 			// Domain-scoped project
 			func(b *csrBuilder, c *controllerContext) {
 				goodCase(b, c)
@@ -943,6 +959,29 @@ func fakeGCPAPI(t *testing.T, ekPub *rsa.PublicKey) (*http.Client, *httptest.Ser
 				ManagedInstances: []*compute.ManagedInstance{{
 					Id: 4,
 				}},
+			})
+		case "/compute/v1/projects/p0/zones/z0/instances/ds0":
+			json.NewEncoder(rw).Encode(compute.Instance{
+				Id:                1,
+				Name:              "ds0",
+				Zone:              "z0",
+				NetworkInterfaces: []*compute.NetworkInterface{{NetworkIP: "1.2.3.4", Ipv6Address: "fd20:9b0:892f:800:0:5::"}},
+			})
+		case "/compute/v1/projects/p0/zones/z0/instances/ds1":
+			json.NewEncoder(rw).Encode(compute.Instance{
+				Id:   1,
+				Name: "ds1",
+				Zone: "z0",
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						NetworkIP: "1.2.3.4",
+						Ipv6AccessConfigs: []*compute.AccessConfig{
+							{
+								ExternalIpv6: "2600:1900:1:1:0:5::",
+							},
+						},
+					},
+				},
 			})
 		default:
 			http.Error(rw, "not found", http.StatusNotFound)


### PR DESCRIPTION
In case of dual stack VMs, the IPv6 addresses are present either under the networkInterface.Ipv6Address or the Ipv6AccessConfig.ExternalIpv6 fields. This function was not reading these.