### PR TITLE
Increase HMS QPS from default 5 to 50 mainly for nodeSyncer

### DIFF
--- a/cmd/gcp-controller-manager/hms.go
+++ b/cmd/gcp-controller-manager/hms.go
@@ -43,6 +43,8 @@ func newHMSClient(url string, authProvider *clientcmdapi.AuthProviderConfig) (*h
 		Host:         url,
 		AuthProvider: authProvider,
 		Timeout:      hmsRequestTimeout,
+		QPS:          50,
+		Burst:        100,
 		ContentConfig: rest.ContentConfig{
 			NegotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{}),
 		},

--- a/cmd/gcp-controller-manager/loops.go
+++ b/cmd/gcp-controller-manager/loops.go
@@ -133,7 +133,7 @@ func loops() map[string]func(*controllerContext) error {
 			if err != nil {
 				return err
 			}
-			go nodeSyncer.Run(10, ctx.done)
+			go nodeSyncer.Run(30, ctx.done)
 			return nil
 		}
 	}

--- a/cmd/gcp-controller-manager/node_syncer.go
+++ b/cmd/gcp-controller-manager/node_syncer.go
@@ -100,7 +100,7 @@ func (ns *nodeSyncer) enqueue(obj interface{}) {
 		klog.Errorf("internal error. Couldn't get key for Pod %+v: %v", obj, err)
 		return
 	}
-	ns.queue.AddRateLimited(key)
+	ns.queue.Add(key)
 }
 
 func (ns *nodeSyncer) Run(workers int, stopCh <-chan struct{}) {


### PR DESCRIPTION
Use queue.Add instead of queue.AddRateLimited in enqueue as usually Add is for fresh items and AddRateLimited for failed items. AddRateLimited also slows down the process.

Change the nodeSyncer worker from 10 to 30. HMS mean latency is around 400ms, so that 30 workers may have QPS 75. This gives some buffer when HMS's latency is not good.

The default rate limit for GKE API is 3000 requests per min, enforced at intervals of every 100 seconds, see https://cloud.google.com/kubernetes-engine/quotas#limit_for_api_requests. Set QPS from the default 5 to 50 to be aligned with it.