### PR TITLE
Remove check for expiry on existing gcloud token

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/cred/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred/cred.go
@@ -199,9 +199,6 @@ func (p *plugin) gcloudAccessToken() (string, *metav1.Time, error) {
 	if gc.Credential.AccessToken == "" {
 		return "", nil, fmt.Errorf("gcloud config config-helper returned an empty access token")
 	}
-	if gc.Credential.TokenExpiry.IsZero() {
-		return "", nil, fmt.Errorf("failed to retrieve expiry time from gcloud config json object")
-	}
 
 	// Authorization Token File is not commonly used. Currently, this is for specific internal debugging scenarios.
 	token := gc.Credential.AccessToken


### PR DESCRIPTION
https://github.com/kubernetes/cloud-provider-gcp/issues/345

I'm not sure that this check for an expiry date on the located token is needed, as the expiry field is optional.

This check breaks using `gke-gcloud-auth-plugin` with OAuth tokens.

From https://kubernetes.io/docs/reference/access-authn-authz/authentication/#input-and-output-formats
```
Optionally, the response can include the expiry of the credential formatted as a [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) timestamp.

Presence or absence of an expiry has the following impact:

    If an expiry is included, the bearer token and TLS credentials are cached until the expiry time is reached, or if the server responds with a 401 HTTP status code, or when the process exits.
    If an expiry is omitted, the bearer token and TLS credentials are cached until the server responds with a 401 HTTP status code or until the process exits.
```