### PR TITLE
Add gcp.go from client-go to cloud-provider-gcp 

### DIFF
--- a/pkg/clientauthplugin/README.md
+++ b/pkg/clientauthplugin/README.md
@@ -1,0 +1,3 @@
+TODO: Add README with the following topics
+* How to use this library? (import _ pkg/pluginclientauth/gcp/gcp).
+* How to build kube config to use this library.

--- a/pkg/clientauthplugin/gcp/BUILD
+++ b/pkg/clientauthplugin/gcp/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+load("//defs:version.bzl", "version_x_defs")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gcp.go",
+    ],
+    importpath = "k8s.io/cloud-provider-gcp/pkg/clientauthplugin/gcp",
+    deps = [
+        "//vendor/github.com/natefinch/atomic:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+        "//vendor/golang.org/x/oauth2/google:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//vendor/k8s.io/client-go/util/jsonpath:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
+        "//vendor/k8s.io/klog/v2:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gcp_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+    ],
+)

--- a/pkg/clientauthplugin/gcp/gcp.go
+++ b/pkg/clientauthplugin/gcp/gcp.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/klog/v2"
+)
+
+func init() {
+	if err := restclient.RegisterAuthProviderPlugin("gcp", newGCPAuthProvider); err != nil {
+		klog.Fatalf("Failed to register gcp auth plugin: %v", err)
+	}
+}
+
+var (
+	// Stubbable for testing
+	execCommand = exec.Command
+
+	// defaultScopes:
+	// - cloud-platform is the base scope to authenticate to GCP.
+	// - userinfo.email is used to authenticate to GKE APIs with gserviceaccount
+	//   email instead of numeric uniqueID.
+	defaultScopes = []string{
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/userinfo.email"}
+)
+
+// gcpAuthProvider is an auth provider plugin that uses GCP credentials to provide
+// tokens for kubectl to authenticate itself to the apiserver. A sample json config
+// is provided below with all recognized options described.
+//
+//	{
+//	  'auth-provider': {
+//	    # Required
+//	    "name": "gcp",
+//
+//	    'config': {
+//	      # Authentication options
+//	      # These options are used while getting a token.
+//
+//	      # comma-separated list of GCP API scopes. default value of this field
+//	      # is "https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/userinfo.email".
+//			 # to override the API scopes, specify this field explicitly.
+//	      "scopes": "https://www.googleapis.com/auth/cloud-platform"
+//
+//	      # Caching options
+//
+//	      # Raw string data representing cached access token.
+//	      "access-token": "ya29.CjWdA4GiBPTt",
+//	      # RFC3339Nano expiration timestamp for cached access token.
+//	      "expiry": "2016-10-31 22:31:9.123",
+//
+//	      # Command execution options
+//	      # These options direct the plugin to execute a specified command and parse
+//	      # token and expiry time from the output of the command.
+//
+//	      # Command to execute for access token. Command output will be parsed as JSON.
+//	      # If "cmd-args" is not present, this value will be split on whitespace, with
+//	      # the first element interpreted as the command, remaining elements as args.
+//	      "cmd-path": "/usr/bin/gcloud",
+//
+//	      # Arguments to pass to command to execute for access token.
+//	      "cmd-args": "config config-helper --output=json"
+//
+//	      # JSONPath to the string field that represents the access token in
+//	      # command output. If omitted, defaults to "{.access_token}".
+//	      "token-key": "{.credential.access_token}",
+//
+//	      # JSONPath to the string field that represents expiration timestamp
+//	      # of the access token in the command output. If omitted, defaults to
+//	      # "{.token_expiry}"
+//	      "expiry-key": ""{.credential.token_expiry}",
+//
+//	      # golang reference time in the format that the expiration timestamp uses.
+//	      # If omitted, defaults to time.RFC3339Nano
+//	      "time-fmt": "2006-01-02 15:04:05.999999999"
+//	    }
+//	  }
+//	}
+type gcpAuthProvider struct {
+	tokenSource oauth2.TokenSource
+	persister   restclient.AuthProviderConfigPersister
+}
+
+var warnOnce sync.Once
+
+func newGCPAuthProvider(_ string, gcpConfig map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+	warnOnce.Do(func() {
+		klog.Warningf(`WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
+To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke`)
+	})
+
+	ts, err := tokenSource(isCmdTokenSource(gcpConfig), gcpConfig)
+	if err != nil {
+		return nil, err
+	}
+	cts, err := newCachedTokenSource(gcpConfig["access-token"], gcpConfig["expiry"], persister, ts, gcpConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &gcpAuthProvider{cts, persister}, nil
+}
+
+func isCmdTokenSource(gcpConfig map[string]string) bool {
+	_, ok := gcpConfig["cmd-path"]
+	return ok
+}
+
+func tokenSource(isCmd bool, gcpConfig map[string]string) (oauth2.TokenSource, error) {
+	// Command-based token source
+	if isCmd {
+		cmd := gcpConfig["cmd-path"]
+		if len(cmd) == 0 {
+			return nil, fmt.Errorf("missing access token cmd")
+		}
+		if gcpConfig["scopes"] != "" {
+			return nil, fmt.Errorf("scopes can only be used when kubectl is using a gcp service account key")
+		}
+		var args []string
+		if cmdArgs, ok := gcpConfig["cmd-args"]; ok {
+			args = strings.Fields(cmdArgs)
+		} else {
+			fields := strings.Fields(cmd)
+			cmd = fields[0]
+			args = fields[1:]
+		}
+		return newCmdTokenSource(cmd, args, gcpConfig["token-key"], gcpConfig["expiry-key"], gcpConfig["time-fmt"]), nil
+	}
+
+	// Google Application Credentials-based token source
+	scopes := parseScopes(gcpConfig)
+	ts, err := google.DefaultTokenSource(context.Background(), scopes...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot construct google default token source: %v", err)
+	}
+	return ts, nil
+}
+
+// parseScopes constructs a list of scopes that should be included in token source
+// from the config map.
+func parseScopes(gcpConfig map[string]string) []string {
+	scopes, ok := gcpConfig["scopes"]
+	if !ok {
+		return defaultScopes
+	}
+	if scopes == "" {
+		return []string{}
+	}
+	return strings.Split(gcpConfig["scopes"], ",")
+}
+
+func (g *gcpAuthProvider) WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	var resetCache map[string]string
+	if cts, ok := g.tokenSource.(*cachedTokenSource); ok {
+		resetCache = cts.baseCache()
+	} else {
+		resetCache = make(map[string]string)
+	}
+	return &conditionalTransport{&oauth2.Transport{Source: g.tokenSource, Base: rt}, g.persister, resetCache}
+}
+
+func (g *gcpAuthProvider) Login() error { return nil }
+
+type cachedTokenSource struct {
+	lk          sync.Mutex
+	source      oauth2.TokenSource
+	accessToken string `datapolicy:"token"`
+	expiry      time.Time
+	persister   restclient.AuthProviderConfigPersister
+	cache       map[string]string
+}
+
+func newCachedTokenSource(accessToken, expiry string, persister restclient.AuthProviderConfigPersister, ts oauth2.TokenSource, cache map[string]string) (*cachedTokenSource, error) {
+	var expiryTime time.Time
+	if parsedTime, err := time.Parse(time.RFC3339Nano, expiry); err == nil {
+		expiryTime = parsedTime
+	}
+	if cache == nil {
+		cache = make(map[string]string)
+	}
+	return &cachedTokenSource{
+		source:      ts,
+		accessToken: accessToken,
+		expiry:      expiryTime,
+		persister:   persister,
+		cache:       cache,
+	}, nil
+}
+
+func (t *cachedTokenSource) Token() (*oauth2.Token, error) {
+	tok := t.cachedToken()
+	if tok.Valid() && !tok.Expiry.IsZero() {
+		return tok, nil
+	}
+	tok, err := t.source.Token()
+	if err != nil {
+		return nil, err
+	}
+	cache := t.update(tok)
+	if t.persister != nil {
+		if err := t.persister.Persist(cache); err != nil {
+			klog.V(4).Infof("Failed to persist token: %v", err)
+		}
+	}
+	return tok, nil
+}
+
+func (t *cachedTokenSource) cachedToken() *oauth2.Token {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+	return &oauth2.Token{
+		AccessToken: t.accessToken,
+		TokenType:   "Bearer",
+		Expiry:      t.expiry,
+	}
+}
+
+func (t *cachedTokenSource) update(tok *oauth2.Token) map[string]string {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+	t.accessToken = tok.AccessToken
+	t.expiry = tok.Expiry
+	ret := map[string]string{}
+	for k, v := range t.cache {
+		ret[k] = v
+	}
+	ret["access-token"] = t.accessToken
+	ret["expiry"] = t.expiry.Format(time.RFC3339Nano)
+	return ret
+}
+
+// baseCache is the base configuration value for this TokenSource, without any cached ephemeral tokens.
+func (t *cachedTokenSource) baseCache() map[string]string {
+	t.lk.Lock()
+	defer t.lk.Unlock()
+	ret := map[string]string{}
+	for k, v := range t.cache {
+		ret[k] = v
+	}
+	delete(ret, "access-token")
+	delete(ret, "expiry")
+	return ret
+}
+
+type commandTokenSource struct {
+	cmd       string
+	args      []string
+	tokenKey  string `datapolicy:"token"`
+	expiryKey string `datapolicy:"secret-key"`
+	timeFmt   string
+}
+
+func newCmdTokenSource(cmd string, args []string, tokenKey, expiryKey, timeFmt string) *commandTokenSource {
+	if len(timeFmt) == 0 {
+		timeFmt = time.RFC3339Nano
+	}
+	if len(tokenKey) == 0 {
+		tokenKey = "{.access_token}"
+	}
+	if len(expiryKey) == 0 {
+		expiryKey = "{.token_expiry}"
+	}
+	return &commandTokenSource{
+		cmd:       cmd,
+		args:      args,
+		tokenKey:  tokenKey,
+		expiryKey: expiryKey,
+		timeFmt:   timeFmt,
+	}
+}
+
+func (c *commandTokenSource) Token() (*oauth2.Token, error) {
+	fullCmd := strings.Join(append([]string{c.cmd}, c.args...), " ")
+	cmd := execCommand(c.cmd, c.args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("error executing access token command %q: err=%v output=%s stderr=%s", fullCmd, err, output, string(stderr.Bytes()))
+	}
+	token, err := c.parseTokenCmdOutput(output)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing output for access token command %q: %v", fullCmd, err)
+	}
+	return token, nil
+}
+
+func (c *commandTokenSource) parseTokenCmdOutput(output []byte) (*oauth2.Token, error) {
+	output, err := yaml.ToJSON(output)
+	if err != nil {
+		return nil, err
+	}
+	var data interface{}
+	if err := json.Unmarshal(output, &data); err != nil {
+		return nil, err
+	}
+
+	accessToken, err := parseJSONPath(data, "token-key", c.tokenKey)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing token-key %q from %q: %v", c.tokenKey, string(output), err)
+	}
+	expiryStr, err := parseJSONPath(data, "expiry-key", c.expiryKey)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing expiry-key %q from %q: %v", c.expiryKey, string(output), err)
+	}
+	var expiry time.Time
+	if t, err := time.Parse(c.timeFmt, expiryStr); err != nil {
+		klog.V(4).Infof("Failed to parse token expiry from %s (fmt=%s): %v", expiryStr, c.timeFmt, err)
+	} else {
+		expiry = t
+	}
+
+	return &oauth2.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		Expiry:      expiry,
+	}, nil
+}
+
+func parseJSONPath(input interface{}, name, template string) (string, error) {
+	j := jsonpath.New(name)
+	buf := new(bytes.Buffer)
+	if err := j.Parse(template); err != nil {
+		return "", err
+	}
+	if err := j.Execute(buf, input); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+type conditionalTransport struct {
+	oauthTransport *oauth2.Transport
+	persister      restclient.AuthProviderConfigPersister
+	resetCache     map[string]string
+}
+
+var _ net.RoundTripperWrapper = &conditionalTransport{}
+
+func (t *conditionalTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return t.oauthTransport.Base.RoundTrip(req)
+	}
+
+	res, err := t.oauthTransport.RoundTrip(req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == 401 {
+		klog.V(4).Infof("The credentials that were supplied are invalid for the target cluster")
+		t.persister.Persist(t.resetCache)
+	}
+
+	return res, nil
+}
+
+func (t *conditionalTransport) WrappedRoundTripper() http.RoundTripper { return t.oauthTransport.Base }

--- a/pkg/clientauthplugin/gcp/gcp_test.go
+++ b/pkg/clientauthplugin/gcp/gcp_test.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+type fakeOutput struct {
+	args   []string
+	output string
+}
+
+var (
+	wantCmd []string
+	// Output for fakeExec, keyed by command
+	execOutputs = map[string]fakeOutput{
+		"/default/no/args": {
+			args: []string{},
+			output: `{
+  "access_token": "faketoken",
+  "token_expiry": "2016-10-31T22:31:09.123000000Z"
+}`},
+		"/default/legacy/args": {
+			args: []string{"arg1", "arg2", "arg3"},
+			output: `{
+  "access_token": "faketoken",
+  "token_expiry": "2016-10-31T22:31:09.123000000Z"
+}`},
+		"/space in path/customkeys": {
+			args: []string{"can", "haz", "auth"},
+			output: `{
+  "token": "faketoken",
+  "token_expiry": {
+    "datetime": "2016-10-31 22:31:09.123"
+  }
+}`},
+		"missing/tokenkey/noargs": {
+			args: []string{},
+			output: `{
+  "broken": "faketoken",
+  "token_expiry": {
+    "datetime": "2016-10-31 22:31:09.123000000Z"
+  }
+}`},
+		"missing/expirykey/legacyargs": {
+			args: []string{"split", "on", "whitespace"},
+			output: `{
+  "access_token": "faketoken",
+  "expires": "2016-10-31T22:31:09.123000000Z"
+}`},
+		"invalid expiry/timestamp": {
+			args: []string{"foo", "--bar", "--baz=abc,def"},
+			output: `{
+  "access_token": "faketoken",
+  "token_expiry": "sometime soon, idk"
+}`},
+		"badjson": {
+			args: []string{},
+			output: `{
+  "access_token": "faketoken",
+  "token_expiry": "sometime soon, idk"
+  ------
+`},
+	}
+)
+
+func fakeExec(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	// Strip out the leading args used to exec into this function.
+	gotCmd := os.Args[3]
+	gotArgs := os.Args[4:]
+	output, ok := execOutputs[gotCmd]
+	if !ok {
+		fmt.Fprintf(os.Stdout, "unexpected call cmd=%q args=%v\n", gotCmd, gotArgs)
+		os.Exit(1)
+	} else if !reflect.DeepEqual(output.args, gotArgs) {
+		fmt.Fprintf(os.Stdout, "call cmd=%q got args %v, want: %v\n", gotCmd, gotArgs, output.args)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, output.output)
+	os.Exit(0)
+}
+
+func Test_isCmdTokenSource(t *testing.T) {
+	c1 := map[string]string{"cmd-path": "foo"}
+	if v := isCmdTokenSource(c1); !v {
+		t.Fatalf("cmd-path present in config (%+v), but got %v", c1, v)
+	}
+
+	c2 := map[string]string{"cmd-args": "foo bar"}
+	if v := isCmdTokenSource(c2); v {
+		t.Fatalf("cmd-path not present in config (%+v), but got %v", c2, v)
+	}
+}
+
+func Test_tokenSource_cmd(t *testing.T) {
+	if _, err := tokenSource(true, map[string]string{}); err == nil {
+		t.Fatalf("expected error, cmd-args not present in config")
+	}
+
+	c := map[string]string{
+		"cmd-path": "foo",
+		"cmd-args": "bar"}
+	ts, err := tokenSource(true, c)
+	if err != nil {
+		t.Fatalf("failed to return cmd token source: %+v", err)
+	}
+	if ts == nil {
+		t.Fatal("returned nil token source")
+	}
+	if _, ok := ts.(*commandTokenSource); !ok {
+		t.Fatalf("returned token source type:(%T) expected:(*commandTokenSource)", ts)
+	}
+}
+
+func Test_tokenSource_cmdCannotBeUsedWithScopes(t *testing.T) {
+	c := map[string]string{
+		"cmd-path": "foo",
+		"scopes":   "A,B"}
+	if _, err := tokenSource(true, c); err == nil {
+		t.Fatal("expected error when scopes is used with cmd-path")
+	}
+}
+
+func Test_tokenSource_applicationDefaultCredentials_fails(t *testing.T) {
+	// try to use empty ADC file
+	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+	if err != nil {
+		t.Fatalf("failed to create fake token file: +%v", err)
+	}
+	fakeTokenFile.Close()
+	defer os.Remove(fakeTokenFile.Name())
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if _, err := tokenSource(false, map[string]string{}); err == nil {
+		t.Fatalf("expected error because specified ADC token file is not a JSON")
+	}
+}
+
+func Test_tokenSource_applicationDefaultCredentials(t *testing.T) {
+	fakeTokenFile, err := ioutil.TempFile("", "adctoken")
+	if err != nil {
+		t.Fatalf("failed to create fake token file: +%v", err)
+	}
+	fakeTokenFile.Close()
+	defer os.Remove(fakeTokenFile.Name())
+	if err := ioutil.WriteFile(fakeTokenFile.Name(), []byte(`{"type":"service_account"}`), 0600); err != nil {
+		t.Fatalf("failed to write to fake token file: %+v", err)
+	}
+
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", fakeTokenFile.Name())
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	ts, err := tokenSource(false, map[string]string{})
+	if err != nil {
+		t.Fatalf("failed to get a token source: %+v", err)
+	}
+	if ts == nil {
+		t.Fatal("returned nil token source")
+	}
+}
+
+func Test_parseScopes(t *testing.T) {
+	cases := []struct {
+		in  map[string]string
+		out []string
+	}{
+		{
+			map[string]string{},
+			[]string{
+				"https://www.googleapis.com/auth/cloud-platform",
+				"https://www.googleapis.com/auth/userinfo.email"},
+		},
+		{
+			map[string]string{"scopes": ""},
+			[]string{},
+		},
+		{
+			map[string]string{"scopes": "A,B,C"},
+			[]string{"A", "B", "C"},
+		},
+	}
+
+	for _, c := range cases {
+		got := parseScopes(c.in)
+		if !reflect.DeepEqual(got, c.out) {
+			t.Errorf("expected=%v, got=%v", c.out, got)
+		}
+	}
+}
+
+func errEquiv(got, want error) bool {
+	if got == want {
+		return true
+	}
+	if got != nil && want != nil {
+		return strings.Contains(got.Error(), want.Error())
+	}
+	return false
+}
+
+func TestCmdTokenSource(t *testing.T) {
+	execCommand = fakeExec
+	fakeExpiry := time.Date(2016, 10, 31, 22, 31, 9, 123000000, time.UTC)
+	customFmt := "2006-01-02 15:04:05.999999999"
+
+	tests := []struct {
+		name             string
+		gcpConfig        map[string]string
+		tok              *oauth2.Token
+		newErr, tokenErr error
+	}{
+		{
+			"default",
+			map[string]string{
+				"cmd-path": "/default/no/args",
+			},
+			&oauth2.Token{
+				AccessToken: "faketoken",
+				TokenType:   "Bearer",
+				Expiry:      fakeExpiry,
+			},
+			nil,
+			nil,
+		},
+		{
+			"default legacy args",
+			map[string]string{
+				"cmd-path": "/default/legacy/args arg1 arg2 arg3",
+			},
+			&oauth2.Token{
+				AccessToken: "faketoken",
+				TokenType:   "Bearer",
+				Expiry:      fakeExpiry,
+			},
+			nil,
+			nil,
+		},
+
+		{
+			"custom keys",
+			map[string]string{
+				"cmd-path":   "/space in path/customkeys",
+				"cmd-args":   "can haz auth",
+				"token-key":  "{.token}",
+				"expiry-key": "{.token_expiry.datetime}",
+				"time-fmt":   customFmt,
+			},
+			&oauth2.Token{
+				AccessToken: "faketoken",
+				TokenType:   "Bearer",
+				Expiry:      fakeExpiry,
+			},
+			nil,
+			nil,
+		},
+		{
+			"missing cmd",
+			map[string]string{
+				"cmd-path": "",
+			},
+			nil,
+			fmt.Errorf("missing access token cmd"),
+			nil,
+		},
+		{
+			"missing token-key",
+			map[string]string{
+				"cmd-path":  "missing/tokenkey/noargs",
+				"token-key": "{.token}",
+			},
+			nil,
+			nil,
+			fmt.Errorf("error parsing token-key %q", "{.token}"),
+		},
+
+		{
+			"missing expiry-key",
+			map[string]string{
+				"cmd-path":   "missing/expirykey/legacyargs split on whitespace",
+				"expiry-key": "{.expiry}",
+			},
+			nil,
+			nil,
+			fmt.Errorf("error parsing expiry-key %q", "{.expiry}"),
+		},
+		{
+			"invalid expiry timestamp",
+			map[string]string{
+				"cmd-path": "invalid expiry/timestamp",
+				"cmd-args": "foo --bar --baz=abc,def",
+			},
+			&oauth2.Token{
+				AccessToken: "faketoken",
+				TokenType:   "Bearer",
+				Expiry:      time.Time{},
+			},
+			nil,
+			nil,
+		},
+		{
+			"bad JSON",
+			map[string]string{
+				"cmd-path": "badjson",
+			},
+			nil,
+			nil,
+			fmt.Errorf("invalid character '-' after object key:value pair"),
+		},
+	}
+
+	for _, tc := range tests {
+		provider, err := newGCPAuthProvider("", tc.gcpConfig, nil /* persister */)
+		if !errEquiv(err, tc.newErr) {
+			t.Errorf("%q newGCPAuthProvider error: got %v, want %v", tc.name, err, tc.newErr)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		ts := provider.(*gcpAuthProvider).tokenSource.(*cachedTokenSource).source.(*commandTokenSource)
+		wantCmd = append([]string{ts.cmd}, ts.args...)
+		tok, err := ts.Token()
+		if !errEquiv(err, tc.tokenErr) {
+			t.Errorf("%q Token() error: got %v, want %v", tc.name, err, tc.tokenErr)
+		}
+		if !reflect.DeepEqual(tok, tc.tok) {
+			t.Errorf("%q Token() got %v, want %v", tc.name, tok, tc.tok)
+		}
+	}
+}
+
+type fakePersister struct {
+	lk    sync.Mutex
+	cache map[string]string
+}
+
+func (f *fakePersister) Persist(cache map[string]string) error {
+	f.lk.Lock()
+	defer f.lk.Unlock()
+	f.cache = map[string]string{}
+	for k, v := range cache {
+		f.cache[k] = v
+	}
+	return nil
+}
+
+func (f *fakePersister) read() map[string]string {
+	ret := map[string]string{}
+	f.lk.Lock()
+	defer f.lk.Unlock()
+	for k, v := range f.cache {
+		ret[k] = v
+	}
+	return ret
+}
+
+type fakeTokenSource struct {
+	token *oauth2.Token
+	err   error
+}
+
+func (f *fakeTokenSource) Token() (*oauth2.Token, error) {
+	return f.token, f.err
+}
+
+func TestCachedTokenSource(t *testing.T) {
+	tok := &oauth2.Token{AccessToken: "fakeaccesstoken"}
+	persister := &fakePersister{}
+	source := &fakeTokenSource{
+		token: tok,
+		err:   nil,
+	}
+	cache := map[string]string{
+		"foo": "bar",
+		"baz": "bazinga",
+	}
+	ts, err := newCachedTokenSource("fakeaccesstoken", "", persister, source, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			_, err := ts.Token()
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	cache["access-token"] = "fakeaccesstoken"
+	cache["expiry"] = tok.Expiry.Format(time.RFC3339Nano)
+	if got := persister.read(); !reflect.DeepEqual(got, cache) {
+		t.Errorf("got cache %v, want %v", got, cache)
+	}
+}
+
+type MockTransport struct {
+	res *http.Response
+}
+
+func (t *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.res, nil
+}
+
+func Test_cmdTokenSource_roundTrip(t *testing.T) {
+
+	accessToken := "fakeToken"
+	fakeExpiry := time.Now().Add(time.Hour)
+	fakeExpiryStr := fakeExpiry.Format(time.RFC3339Nano)
+	fs := &fakeTokenSource{
+		token: &oauth2.Token{
+			AccessToken: accessToken,
+			Expiry:      fakeExpiry,
+		},
+	}
+
+	cmdCache := map[string]string{
+		"cmd-path": "/path/to/tokensource/cmd",
+		"cmd-args": "--output=json",
+	}
+	cmdCacheUpdated := map[string]string{
+		"cmd-path":     "/path/to/tokensource/cmd",
+		"cmd-args":     "--output=json",
+		"access-token": accessToken,
+		"expiry":       fakeExpiryStr,
+	}
+	simpleCacheUpdated := map[string]string{
+		"access-token": accessToken,
+		"expiry":       fakeExpiryStr,
+	}
+
+	tests := []struct {
+		name                     string
+		res                      http.Response
+		baseCache, expectedCache map[string]string
+	}{
+		{
+			"Unauthorized",
+			http.Response{StatusCode: http.StatusUnauthorized},
+			make(map[string]string),
+			make(map[string]string),
+		},
+		{
+			"Unauthorized, nonempty defaultCache",
+			http.Response{StatusCode: http.StatusUnauthorized},
+			cmdCache,
+			cmdCache,
+		},
+		{
+			"Authorized",
+			http.Response{StatusCode: http.StatusOK},
+			make(map[string]string),
+			simpleCacheUpdated,
+		},
+		{
+			"Authorized, nonempty defaultCache",
+			http.Response{StatusCode: http.StatusOK},
+			cmdCache,
+			cmdCacheUpdated,
+		},
+	}
+
+	persister := &fakePersister{}
+	req := http.Request{Header: http.Header{}}
+
+	for _, tc := range tests {
+		cts, err := newCachedTokenSource(accessToken, fakeExpiry.String(), persister, fs, tc.baseCache)
+		if err != nil {
+			t.Fatalf("unexpected error from newCachedTokenSource: %v", err)
+		}
+		authProvider := gcpAuthProvider{cts, persister}
+
+		fakeTransport := MockTransport{&tc.res}
+		transport := (authProvider.WrapTransport(&fakeTransport))
+		// call Token to persist/update cache
+		if _, err := cts.Token(); err != nil {
+			t.Fatalf("unexpected error from cachedTokenSource.Token(): %v", err)
+		}
+
+		transport.RoundTrip(&req)
+
+		if got := persister.read(); !reflect.DeepEqual(got, tc.expectedCache) {
+			t.Errorf("got cache %v, want %v", got, tc.expectedCache)
+		}
+	}
+
+}


### PR DESCRIPTION
Add gcp.go from client-go to cloud-provider-gcp as that file is being deprecated from client-go.

If users do not want to use an additional binary (gke-gcloud-auth-plugin),
then we they can reference and build this library in to their custom k8s
clients to provide the same functionality. This use case becomes
necessary if customers are unwilling to add additional binaries on their
system to avoid remote code execution attacks.