### PR TITLE
Fix broken `TestCACacheVerify` test

### DIFF
--- a/cmd/gcp-controller-manager/ca_cache_test.go
+++ b/cmd/gcp-controller-manager/ca_cache_test.go
@@ -41,6 +41,8 @@ func TestCACacheVerify(t *testing.T) {
 			}
 		})
 		for desc, invalidCert := range ca.invalidCerts {
+			desc := desc
+			invalidCert := invalidCert
 			t.Run(desc, func(t *testing.T) {
 				t.Parallel()
 				if err := c.verify(invalidCert); err == nil {


### PR DESCRIPTION
Parallel test closures execute in a goroutine, possibly after the next
loop iteration has already began. As a result, the loop var they
capture changes before the test execute, leading to all of them
executing just the last test in the map.

This fixes that by making the closure capture local variables rather
than the loop variables

See similar main kubernetes repo PR https://github.com/kubernetes/kubernetes/pull/111846