### PR TITLE
Tolerate CSRs without encipherment key usage

### DIFF
--- a/cmd/gke-exec-auth-plugin/request.go
+++ b/cmd/gke-exec-auth-plugin/request.go
@@ -130,6 +130,8 @@ func processCSR(client clientset.Interface, privateKeyData []byte, hostname stri
 	csrData = append(csrData, attestData...)
 	klog.Info("added TPM attestation")
 
+	// TODO(liggitt): only add this key usage for RSA private keys once the minimum supported control plane is 1.25.
+	// see https://issue.k8s.io/109077
 	usages := []apicertificates.KeyUsage{
 		apicertificates.UsageDigitalSignature,
 		apicertificates.UsageKeyEncipherment,

--- a/pkg/csrapproval/csrapproval.go
+++ b/pkg/csrapproval/csrapproval.go
@@ -38,8 +38,20 @@ var nodeClientKeyUsages = []capi.KeyUsage{
 	capi.UsageClientAuth,
 }
 
+// see https://issue.k8s.io/109077
+var nodeClientKeyUsagesNoEncipherment = []capi.KeyUsage{
+	capi.UsageDigitalSignature,
+	capi.UsageClientAuth,
+}
+
 var nodeServerKeyUsages = []capi.KeyUsage{
 	capi.UsageKeyEncipherment,
+	capi.UsageDigitalSignature,
+	capi.UsageServerAuth,
+}
+
+// see https://issue.k8s.io/109077
+var nodeServerKeyUsagesNoEncipherment = []capi.KeyUsage{
 	capi.UsageDigitalSignature,
 	capi.UsageServerAuth,
 }
@@ -301,7 +313,7 @@ func IsNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.Certific
 		return false
 	}
 
-	return hasExactUsages(csr, nodeClientKeyUsages)
+	return hasExactUsages(csr, nodeClientKeyUsagesNoEncipherment) || hasExactUsages(csr, nodeClientKeyUsages)
 }
 
 // IsNodeServerCert recognizes server certificates
@@ -310,7 +322,7 @@ func IsNodeServerCert(csr *capi.CertificateSigningRequest, x509cr *x509.Certific
 		return false
 	}
 
-	if !hasExactUsages(csr, nodeServerKeyUsages) {
+	if !hasExactUsages(csr, nodeServerKeyUsagesNoEncipherment) && !hasExactUsages(csr, nodeServerKeyUsages) {
 		return false
 	}
 


### PR DESCRIPTION
/cc @mikedanese 

1.26 nodes will start requesting these for non-RSA keys