### PR TITLE
Add support for nodeipam metrics

### DIFF
--- a/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
+++ b/cluster/addons/cloud-controller-manager/cloud-node-controller-role.yaml
@@ -86,6 +86,19 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - configmaps
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2278,6 +2278,8 @@ function start-cloud-controller-manager {
   params+=" --use-service-account-credentials"
   params+=" --cloud-provider=gce"
   params+=" --kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig"
+  params+=" --authorization-kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig"
+  params+=" --authentication-kubeconfig=/etc/srv/kubernetes/cloud-controller-manager/kubeconfig"
   if [[ -n "${INSTANCE_PREFIX:-}" ]]; then
     params+=" --cluster-name=${INSTANCE_PREFIX}"
   fi

--- a/cluster/gce/manifests/cloud-controller-manager.manifest
+++ b/cluster/gce/manifests/cloud-controller-manager.manifest
@@ -39,7 +39,8 @@
     "livenessProbe": {
       "httpGet": {
         "host": "127.0.0.1",
-        "port": 10253,
+        "port": 10258,
+        "scheme": "HTTPS",
         "path": "/healthz"
       },
       "initialDelaySeconds": 15,

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -159,7 +159,7 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 	if err != nil {
 		return nil, false, err
 	}
-	go nodeIpamController.Run(ctx.Stop)
+	go nodeIpamController.Run(ctx.Stop, ctx.ControllerManagerMetrics)
 	return nil, true, nil
 }
 

--- a/pkg/controller/nodeipam/BUILD
+++ b/pkg/controller/nodeipam/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache",
         "//vendor/k8s.io/client-go/tools/record",
         "//vendor/k8s.io/cloud-provider",
+        "//vendor/k8s.io/component-base/metrics/prometheus/controllers",
         "//vendor/k8s.io/component-base/metrics/prometheus/ratelimiter",
         "//vendor/k8s.io/klog/v2:klog",
     ],

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -33,6 +33,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-gcp/pkg/controller/nodeipam/ipam"
+	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
 )
 
@@ -148,11 +149,13 @@ func NewNodeIpamController(
 }
 
 // Run starts an asynchronous loop that monitors the status of cluster nodes.
-func (nc *Controller) Run(stopCh <-chan struct{}) {
+func (nc *Controller) Run(stopCh <-chan struct{}, controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics) {
 	defer utilruntime.HandleCrash()
 
 	klog.Infof("Starting ipam controller")
 	defer klog.Infof("Shutting down ipam controller")
+	controllerManagerMetrics.ControllerStarted("nodeipam")
+	defer controllerManagerMetrics.ControllerStopped("nodeipam")
 
 	if !cache.WaitForNamedCacheSync("node", stopCh, nc.nodeInformerSynced) {
 		return


### PR DESCRIPTION
Also, fix liveness probe in deployment manifest and add support for accessing '/metrics' endpoint

/assign @tosi3k 