### PR TITLE
remove deprecation warning in new clientauthplugin package

### DIFF
--- a/pkg/clientauthplugin/gcp/gcp.go
+++ b/pkg/clientauthplugin/gcp/gcp.go
@@ -112,14 +112,7 @@ type gcpAuthProvider struct {
 	persister   restclient.AuthProviderConfigPersister
 }
 
-var warnOnce sync.Once
-
 func newGCPAuthProvider(_ string, gcpConfig map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
-	warnOnce.Do(func() {
-		klog.Warningf(`WARNING: the gcp auth plugin is deprecated in v1.22+, unavailable in v1.25+; use gcloud instead.
-To learn more, consult https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke`)
-	})
-
 	ts, err := tokenSource(isCmdTokenSource(gcpConfig), gcpConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This was copied over and isn't correct. This is the new location for this plugin.