### PR TITLE
Added clearStalePodsOnNodeRegistration flag to guard removal of pods bound to preemptible node

### DIFF
--- a/cmd/gcp-controller-manager/loops.go
+++ b/cmd/gcp-controller-manager/loops.go
@@ -38,6 +38,7 @@ type controllerContext struct {
 	hmsAuthorizeSAMappingURL           string
 	hmsSyncNodeURL                     string
 	delayDirectPathGSARemove           bool
+	clearStalePodsOnNodeRegistration   bool
 }
 
 // loops returns all the control loops that the GCPControllerManager can start.

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -77,6 +77,7 @@ var (
 	hmsSyncNodeURL                     = pflag.String("hms-sync-node-url", "", "URL for reaching the Hosted Master Service SyncNode API.")
 	kubeletReadOnlyCSRApprover         = pflag.Bool("kubelet-read-only-csr-approver", false, "Enable kubelet readonly csr approver or not")
 	autopilotEnabled                   = pflag.Bool("autopilot", false, "Is this a GKE Autopilot cluster.")
+	clearStalePodsOnNodeRegistration   = pflag.Bool("clearStalePodsOnNodeRegistration", false, "If true, after node registration, delete pods bound to old node.")
 )
 
 func main() {
@@ -115,6 +116,7 @@ func main() {
 		delayDirectPathGSARemove:           *delayDirectPathGSARemove,
 		kubeletReadOnlyCSRApprover:         *kubeletReadOnlyCSRApprover,
 		autopilotEnabled:                   *autopilotEnabled,
+		clearStalePodsOnNodeRegistration:   *clearStalePodsOnNodeRegistration,
 	}
 	var err error
 	s.informerKubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
@@ -172,6 +174,7 @@ type controllerManager struct {
 	hmsSyncNodeURL                     string
 	delayDirectPathGSARemove           bool
 	autopilotEnabled                   bool
+	clearStalePodsOnNodeRegistration   bool
 
 	// Kubelet Readonly CSR Approver
 	kubeletReadOnlyCSRApprover bool
@@ -242,6 +245,7 @@ func run(s *controllerManager) error {
 				hmsAuthorizeSAMappingURL:           s.hmsAuthorizeSAMappingURL,
 				hmsSyncNodeURL:                     s.hmsSyncNodeURL,
 				delayDirectPathGSARemove:           s.delayDirectPathGSARemove,
+				clearStalePodsOnNodeRegistration:   s.clearStalePodsOnNodeRegistration,
 			}); err != nil {
 				klog.Fatalf("Failed to start %q: %v", name, err)
 			}

--- a/cmd/gcp-controller-manager/node_csr_approver_test.go
+++ b/cmd/gcp-controller-manager/node_csr_approver_test.go
@@ -1098,6 +1098,7 @@ func TestShouldDeleteNode(t *testing.T) {
 	testErr := fmt.Errorf("intended error")
 	cases := []struct {
 		desc           string
+		ctx            *controllerContext
 		node           *v1.Node
 		instance       *compute.Instance
 		shouldDelete   bool
@@ -1106,6 +1107,7 @@ func TestShouldDeleteNode(t *testing.T) {
 	}{
 		{
 			desc: "instance with 1 alias range and matches podCIDR",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1128,6 +1130,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "instance with 1 alias range doesn't match podCIDR",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1151,6 +1154,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "instance with 2 alias range and 1 matches podCIDR",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1176,6 +1180,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "instance with 0 alias range",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1188,6 +1193,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "node with empty podCIDR",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1197,6 +1203,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "instance not found",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1210,6 +1217,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "error gettting instance",
+			ctx:  &controllerContext{},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1223,6 +1231,9 @@ func TestShouldDeleteNode(t *testing.T) {
 		},
 		{
 			desc: "node with different instance id",
+			ctx: &controllerContext{
+				clearStalePodsOnNodeRegistration: true,
+			},
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "node-test",
@@ -1244,7 +1255,7 @@ func TestShouldDeleteNode(t *testing.T) {
 		fakeGetInstance := func(_ *controllerContext, _ string) (*compute.Instance, error) {
 			return c.instance, c.getInstanceErr
 		}
-		shouldDelete, err := shouldDeleteNode(&controllerContext{}, c.node, fakeGetInstance)
+		shouldDelete, err := shouldDeleteNode(c.ctx, c.node, fakeGetInstance)
 		if err != c.expectedErr || shouldDelete != c.shouldDelete {
 			t.Errorf("%s: shouldDeleteNode=(%v, %v), want (%v, %v)", c.desc, shouldDelete, err, c.shouldDelete, c.expectedErr)
 		}


### PR DESCRIPTION
To prevent operations that delete pods bound to the old node do not cause any regression in cluster creation, we added cleanPreemptibles flag to toggle the cleaning process.