### PR TITLE
Migrate `cloud-provider-gcp` resource lock to `leases`

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -91,7 +91,7 @@ func main() {
 		LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
 		RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
 		RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
-		ResourceLock: rl.LeasesResourceLock,
+		ResourceLock:  rl.LeasesResourceLock,
 	}
 	options.BindLeaderElectionFlags(leConfig, pflag.CommandLine)
 

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -91,8 +91,7 @@ func main() {
 		LeaseDuration: metav1.Duration{Duration: 15 * time.Second},
 		RenewDeadline: metav1.Duration{Duration: 10 * time.Second},
 		RetryPeriod:   metav1.Duration{Duration: 2 * time.Second},
-		//TODO(acumino): Migrate endpointsleases to leases in vesrion 1.24.
-		ResourceLock: rl.EndpointsLeasesResourceLock,
+		ResourceLock: rl.LeasesResourceLock,
 	}
 	options.BindLeaderElectionFlags(leConfig, pflag.CommandLine)
 


### PR DESCRIPTION
Fixes - #309 
Follow-Up after #310