### PR TITLE
Changes for fetching the subnetworks.

### DIFF
--- a/providers/gce/BUILD
+++ b/providers/gce/BUILD
@@ -29,6 +29,7 @@ go_library(
         "gce_networkendpointgroup.go",
         "gce_routes.go",
         "gce_securitypolicy.go",
+        "gce_subnetworks.go",
         "gce_targetpool.go",
         "gce_targetproxy.go",
         "gce_tpu.go",

--- a/providers/gce/gce_subnetworks.go
+++ b/providers/gce/gce_subnetworks.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+
+	compute "google.golang.org/api/compute/v1"
+)
+
+func newSubnetworkMetricContext(request, region string) *metricContext {
+	return newGenericMetricContext("subnetworks", request, region, unusedMetricLabel, computeV1Version)
+}
+
+// GetSubnetwork returns the GCE resource for the compute.Subnetwork if it exists.
+func (g *Cloud) GetSubnetwork(projectName, region, subnetworkName string) (*compute.Subnetwork, error) {
+	ctx, cancel := cloud.ContextWithCallTimeout()
+	defer cancel()
+
+	mc := newSubnetworkMetricContext("get", region)
+	subnetwork, err := g.service.Subnetworks.Get(projectName, region, subnetworkName).Context(ctx).Do()
+	return subnetwork, mc.Observe(err)
+}


### PR DESCRIPTION
1. Add gce_subnetworks.go for building the library to fetch the subnetworks info. We need the subnetwork info when we create the network manager controller.
2. Add metrics to observe the call and checking time out, since we need to follow other library's style under gce folder