### PR TITLE
Define north-interface annotation.

### DIFF
--- a/crd/apis/network/v1/annotations.go
+++ b/crd/apis/network/v1/annotations.go
@@ -37,6 +37,8 @@ const (
 	AutoGenAnnotationKey = "networking.gke.io/auto-generated"
 	// AutoGenAnnotationValTrue is the value to be set for auto-generated objects.
 	AutoGenAnnotationValTrue = "true"
+	// NorthInterfacesAnnotationKey is the annotation key used to hold interfaces data per node.
+	NorthInterfacesAnnotationKey = "networking.gke.io/north-interfaces"
 )
 
 // InterfaceAnnotation is the value of the interface annotation.
@@ -85,6 +87,10 @@ type PodIPsAnnotation []PodIP
 // +kubebuilder:object:generate:=false
 type MultiNetworkAnnotation []NodeNetwork
 
+// NorthInterfacesAnnotation is the value of north-interfaces annotation.
+// +kubebuilder:object:generate:=false
+type NorthInterfacesAnnotation []NorthInterface
+
 // NodeNetworkStatus specifies the status of a network.
 // +kubebuilder:object:generate:=false
 type NodeNetworkStatus struct {
@@ -120,6 +126,15 @@ type NodeNetwork struct {
 	Scope string `json:"scope"`
 }
 
+// NorthInterface specifies interface data on a node.
+// +kubebuilder:object:generate:=false
+type NorthInterface struct {
+	// Name of the network an interface on node is connected to.
+	Network string `json:"network"`
+	// IP address of the interface.
+	IpAddress string `json:"ipAddress"`
+}
+
 // ParseNodeNetworkAnnotation parses the given annotation to NodeNetworkAnnotation.
 func ParseNodeNetworkAnnotation(annotation string) (NodeNetworkAnnotation, error) {
 	ret := &NodeNetworkAnnotation{}
@@ -141,7 +156,19 @@ func ParseMultiNetworkAnnotation(annotation string) (MultiNetworkAnnotation, err
 	return *ret, err
 }
 
+// ParseNorthInterfacesAnnotation parses given annotation to NorthInterfacesAnnotation.
+func ParseNorthInterfacesAnnotation(annotation string) (NorthInterfacesAnnotation, error) {
+	ret := &NorthInterfacesAnnotation{}
+	err := json.Unmarshal([]byte(annotation), ret)
+	return *ret, err
+}
+
 // MarshalNodeNetworkAnnotation marshals a NodeNetworkAnnotation into string.
 func MarshalNodeNetworkAnnotation(a NodeNetworkAnnotation) (string, error) {
+	return MarshalAnnotation(a)
+}
+
+// MarshalNorthInterfacesAnnotation marshals a NorthInterfacesAnnotation into string.
+func MarshalNorthInterfacesAnnotation(a NorthInterfacesAnnotation) (string, error) {
 	return MarshalAnnotation(a)
 }

--- a/crd/apis/network/v1/annotations_test.go
+++ b/crd/apis/network/v1/annotations_test.go
@@ -171,3 +171,51 @@ func TestParseMultiNetworkAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNorthInterfacesAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    NorthInterfacesAnnotation
+		expected string
+	}{
+		{
+			name:     "nil",
+			input:    nil,
+			expected: "null",
+		},
+		{
+			name:     "empty list",
+			input:    NorthInterfacesAnnotation{},
+			expected: "[]",
+		},
+		{
+			name: "list with items",
+			input: NorthInterfacesAnnotation{
+				{Network: "network-a", IpAddress: "10.0.0.1"},
+				{Network: "network-b", IpAddress: "20.0.0.1"},
+			},
+			expected: `[{"network":"network-a","ipAddress":"10.0.0.1"},{"network":"network-b","ipAddress":"20.0.0.1"}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := MarshalAnnotation(tc.input)
+			if err != nil {
+				t.Fatalf("MarshalAnnotation(%+v) failed with error: %v", tc.input, err)
+			}
+			if marshalled != tc.expected {
+				t.Fatalf("MarshalAnnotation(%+v) returns %q but want %q", tc.input, marshalled, tc.expected)
+			}
+
+			parsed, err := ParseNorthInterfacesAnnotation(marshalled)
+			if err != nil {
+				t.Fatalf("ParseNorthInterfacesAnnotation(%s) failed with error: %v", marshalled, err)
+			}
+
+			if diff := cmp.Diff(parsed, tc.input); diff != "" {
+				t.Fatalf("ParseNorthInterfacesAnnotation(%s) returns diff: (-got +want): %s", marshalled, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This annotation is used to identify the interfaces information on a node. The corresponding struct consists of network and ipAddress information of the interface.