### PR TITLE
[FIX] Add an annotation for the Load Balancer service instead of the deprecated field LoadBalancerIP

### DIFF
--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -51,6 +51,9 @@ const (
 	// ALPHA feature - this may be removed in a future release.
 	ServiceAnnotationILBBackendShare = "alpha.cloud.google.com/load-balancer-backend-share"
 
+	// ServiceAnnotationLBIPv4 aim to instead of the deprecated spec field LoadBalancerIP from v1.24
+	ServiceAnnotationLBIPv4 = "service.beta.kubernetes.io/gcp-load-balancer-eip"
+
 	// This annotation did not correctly specify "alpha", so both annotations will be checked.
 	deprecatedServiceAnnotationILBBackendShare = "cloud.google.com/load-balancer-backend-share"
 

--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -52,6 +52,11 @@ const (
 	ServiceAnnotationILBBackendShare = "alpha.cloud.google.com/load-balancer-backend-share"
 
 	// ServiceAnnotationLBIPv4 aim to instead of the deprecated spec field LoadBalancerIP from v1.24
+	// BETA feature - Priority Description:
+	//  load balancer has this annotation and spec-field LoadBalancerIP,
+	//     the external IP address from this annotation is preferred for reconciling the load balancer.
+	//  meanwhile, load balancer has spec-field LoadBalancerIP without this annotation,
+	//     the load balancer's external IP address will be from the field LoadBalancerIP.
 	ServiceAnnotationLBIPv4 = "service.beta.kubernetes.io/gcp-load-balancer-eip"
 
 	// This annotation did not correctly specify "alpha", so both annotations will be checked.

--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -63,7 +63,7 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	}
 
 	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, apiService)
-	requestedIP := apiService.Spec.LoadBalancerIP
+	requestedIP := GetStaticIPFromLoadBalancer(apiService)
 	ports := apiService.Spec.Ports
 	portStr := []string{}
 	for _, p := range apiService.Spec.Ports {

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -900,8 +900,8 @@ func getNameFromLink(link string) string {
 // specified by the user, that is used. If there is an existing ForwardingRule, the ip address from
 // that is reused. In case a subnetwork change is requested, the existing ForwardingRule IP is ignored.
 func ilbIPToUse(svc *v1.Service, fwdRule *compute.ForwardingRule, requestedSubnet string) string {
-	if svc.Spec.LoadBalancerIP != "" {
-		return svc.Spec.LoadBalancerIP
+	if ip := GetStaticIPFromLoadBalancer(svc); ip != "" {
+		return ip
 	}
 	if fwdRule == nil {
 		return ""

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -393,6 +393,10 @@ func removeString(slice []string, s string) []string {
 // GetStaticIPFromLoadBalancer get Public IP from the load balancer
 func GetStaticIPFromLoadBalancer(svc *v1.Service) string {
 
+	if svc == nil {
+		return ""
+	}
+
 	if ip, ok := svc.Annotations[ServiceAnnotationLBIPv4]; ok && ip != "" {
 		return ip
 	}

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -391,24 +391,6 @@ func removeString(slice []string, s string) []string {
 	return newSlice
 }
 
-// AssignStaticIPToLoadBalancer assign Public IP to the load balancer
-func AssignStaticIPToLoadBalancer(svc *v1.Service, ip string) {
-
-	if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
-		return
-	}
-
-	if ip == "" {
-		delete(svc.Annotations, ServiceAnnotationLBIPv4)
-	} else {
-		svc.Annotations[ServiceAnnotationLBIPv4] = ip
-	}
-
-	if v := reflect.ValueOf(&svc.Spec).Elem().FieldByName("LoadBalancerIP"); v.IsValid() && v.CanSet() {
-		v.SetString(ip)
-	}
-}
-
 // GetStaticIPFromLoadBalancer get Public IP from the load balancer
 func GetStaticIPFromLoadBalancer(svc *v1.Service) string {
 

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -398,9 +397,5 @@ func GetStaticIPFromLoadBalancer(svc *v1.Service) string {
 		return ip
 	}
 
-	if v := reflect.ValueOf(&svc.Spec).Elem().FieldByName("LoadBalancerIP"); v.IsValid() {
-		return v.String()
-	}
-
-	return ""
+	return svc.Spec.LoadBalancerIP
 }

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -394,10 +394,6 @@ func removeString(slice []string, s string) []string {
 // GetStaticIPFromLoadBalancer get Public IP from the load balancer
 func GetStaticIPFromLoadBalancer(svc *v1.Service) string {
 
-	//if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
-	//	return ""
-	//}
-
 	if ip, ok := svc.Annotations[ServiceAnnotationLBIPv4]; ok && ip != "" {
 		return ip
 	}

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -171,7 +171,7 @@ func TestGetStaticIPFromLoadBalancer(t *testing.T) {
 		want string
 	}{
 		{
-			name: "load balancer have the annotation about static IP",
+			name: "load balancer has the annotation of static IP",
 			args: args{
 				svc: &v1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -186,7 +186,7 @@ func TestGetStaticIPFromLoadBalancer(t *testing.T) {
 			},
 			want: "10.10.10.10"},
 		{
-			name: "load balancer have the annotation about static IP and deprecated spec field LoadBalancerIP",
+			name: "load balancer has the annotation of static IP and spec field LoadBalancerIP",
 			args: args{
 				svc: &v1.Service{
 					ObjectMeta: metav1.ObjectMeta{
@@ -201,7 +201,7 @@ func TestGetStaticIPFromLoadBalancer(t *testing.T) {
 			want: "10.10.10.10",
 		},
 		{
-			name: "load balancer only have the deprecated spec field LoadBalancerIP",
+			name: "load balancer only has the spec field LoadBalancerIP",
 			args: args{
 				svc: &v1.Service{
 					Spec: v1.ServiceSpec{
@@ -224,7 +224,7 @@ func TestGetStaticIPFromLoadBalancer(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "not load balancer",
+			name: "not a load balancer",
 			args: args{
 				svc: &v1.Service{
 					Spec: v1.ServiceSpec{


### PR DESCRIPTION
fix issue https://github.com/kubernetes/cloud-provider-gcp/issues/371