### PR TITLE
Add a utility method to fetch compute instance

### DIFF
--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -858,7 +858,7 @@ func (g *Cloud) GetNodeTags(nodeNames []string) ([]string, error) {
 }
 
 // NodeNetworkInterfacesByProviderID returns a list of node interfaces that exist on the node.
-func (g *Cloud) NodeNetworkInterfacesByProviderID(providerID string) (interfaces []*compute.NetworkInterface, err error) {
+func (g *Cloud) InstanceByProviderID(providerID string) (res *compute.Instance, err error) {
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -867,10 +867,9 @@ func (g *Cloud) NodeNetworkInterfacesByProviderID(providerID string) (interfaces
 		return nil, err
 	}
 
-	var res *compute.Instance
 	res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
 	if err != nil {
 		return nil, err
 	}
-	return res.NetworkInterfaces, nil
+	return res, nil
 }

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -330,7 +330,7 @@ func TestAliasRangesByProviderID(t *testing.T) {
 	}
 }
 
-func TestNodeNetworkInterfacesByProviderID(t *testing.T) {
+func TestInstanceByProviderID(t *testing.T) {
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
@@ -372,10 +372,10 @@ func TestNodeNetworkInterfacesByProviderID(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name           string
-		providerId     string
-		wantErr        string
-		wantInterfaces []*ga.NetworkInterface
+		name         string
+		providerId   string
+		wantErr      string
+		wantInstance *ga.Instance
 	}{
 		{
 			name:       "invalid provider id",
@@ -388,21 +388,21 @@ func TestNodeNetworkInterfacesByProviderID(t *testing.T) {
 			wantErr:    "instance not found",
 		},
 		{
-			name:           "instance with multiple interfaces",
-			providerId:     "gce://p1/us-central1-b/n1",
-			wantInterfaces: interfaces,
+			name:         "instance with multiple interfaces",
+			providerId:   "gce://p1/us-central1-b/n1",
+			wantInstance: instance,
 		},
 	}
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			gotInterfaces, err := gce.NodeNetworkInterfacesByProviderID(test.providerId)
+			gotInstance, err := gce.InstanceByProviderID(test.providerId)
 			if err != nil && (test.wantErr == "" || !strings.Contains(err.Error(), test.wantErr)) {
-				t.Errorf("gce.NodeNetworkInterfacesByProviderID. Want err: %v, got: %v", test.wantErr, err)
+				t.Errorf("gce.InstanceByProviderID. Want err: %v, got: %v", test.wantErr, err)
 			} else if err == nil && test.wantErr != "" {
-				t.Errorf("gce.NodeNetworkInterfacesByProviderID. Want err: %v, got: %v, gotInterfaces: %v", test.wantErr, err, gotInterfaces)
+				t.Errorf("gce.InstanceByProviderID. Want err: %v, got: %v, gotInstances: %v", test.wantErr, err, gotInstance)
 			}
-			assert.Equal(t, test.wantInterfaces, gotInterfaces)
+			assert.Equal(t, test.wantInstance, gotInstance)
 		})
 	}
 }


### PR DESCRIPTION
Introduce InstanceByProviderID method to fetch gce compute.Instance by provider ID. Removed the previously introduced
NodeNetworkInterfacesByProviderID as it is obsolete now.