### PR TITLE
Use instance ListReferrers method to check cluster membership.

### DIFF
--- a/cmd/gcp-controller-manager/loops.go
+++ b/cmd/gcp-controller-manager/loops.go
@@ -27,18 +27,19 @@ import (
 )
 
 type controllerContext struct {
-	client                             clientset.Interface
-	sharedInformers                    informers.SharedInformerFactory
-	recorder                           record.EventRecorder
-	gcpCfg                             gcpConfig
-	clusterSigningGKEKubeconfig        string
-	csrApproverVerifyClusterMembership bool
-	csrApproverAllowLegacyKubelet      bool
-	verifiedSAs                        *saMap
-	hmsAuthorizeSAMappingURL           string
-	hmsSyncNodeURL                     string
-	delayDirectPathGSARemove           bool
-	clearStalePodsOnNodeRegistration   bool
+	client                                 clientset.Interface
+	sharedInformers                        informers.SharedInformerFactory
+	recorder                               record.EventRecorder
+	gcpCfg                                 gcpConfig
+	clusterSigningGKEKubeconfig            string
+	csrApproverVerifyClusterMembership     bool
+	csrApproverAllowLegacyKubelet          bool
+	csrApproverUseGCEInstanceListReferrers bool
+	verifiedSAs                            *saMap
+	hmsAuthorizeSAMappingURL               string
+	hmsSyncNodeURL                         string
+	delayDirectPathGSARemove               bool
+	clearStalePodsOnNodeRegistration       bool
 }
 
 // loops returns all the control loops that the GCPControllerManager can start.

--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -62,22 +62,23 @@ const (
 )
 
 var (
-	port                               = pflag.Int("port", 8089, "Port to serve status endpoints on (such as /healthz and /metrics).")
-	metricsPort                        = pflag.Int("metrics-port", 8089, "Deprecated. Port to expose Prometheus metrics on. If not set, uses the value of --port.")
-	kubeconfig                         = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
-	clusterSigningGKEKubeconfig        = pflag.String("cluster-signing-gke-kubeconfig", "", "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
-	gceConfigPath                      = pflag.String("gce-config", "/etc/gce.conf", "Path to gce.conf.")
-	controllers                        = pflag.StringSlice("controllers", []string{"*"}, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
-	csrApproverVerifyClusterMembership = pflag.Bool("csr-validate-cluster-membership", true, "Validate that VMs requesting CSRs belong to current GKE cluster.")
-	csrApproverAllowLegacyKubelet      = pflag.Bool("csr-allow-legacy-kubelet", true, "Allow legacy kubelet bootstrap flow.")
-	gceAPIEndpointOverride             = pflag.String("gce-api-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/projects/")
-	directPath                         = pflag.Bool("direct-path", false, "Enable Direct Path.")
-	delayDirectPathGSARemove           = pflag.Bool("delay-direct-path-gsa-remove", false, "Delay removal of deleted Direct Path workloads' Google Service Accounts.")
-	hmsAuthorizeSAMappingURL           = pflag.String("hms-authorize-sa-mapping-url", "", "URL for reaching the Hosted Master Service AuthorizeSAMapping API.")
-	hmsSyncNodeURL                     = pflag.String("hms-sync-node-url", "", "URL for reaching the Hosted Master Service SyncNode API.")
-	kubeletReadOnlyCSRApprover         = pflag.Bool("kubelet-read-only-csr-approver", false, "Enable kubelet readonly csr approver or not")
-	autopilotEnabled                   = pflag.Bool("autopilot", false, "Is this a GKE Autopilot cluster.")
-	clearStalePodsOnNodeRegistration   = pflag.Bool("clearStalePodsOnNodeRegistration", false, "If true, after node registration, delete pods bound to old node.")
+	port                                   = pflag.Int("port", 8089, "Port to serve status endpoints on (such as /healthz and /metrics).")
+	metricsPort                            = pflag.Int("metrics-port", 8089, "Deprecated. Port to expose Prometheus metrics on. If not set, uses the value of --port.")
+	kubeconfig                             = pflag.String("kubeconfig", "", "Path to kubeconfig file with authorization and master location information.")
+	clusterSigningGKEKubeconfig            = pflag.String("cluster-signing-gke-kubeconfig", "", "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
+	gceConfigPath                          = pflag.String("gce-config", "/etc/gce.conf", "Path to gce.conf.")
+	controllers                            = pflag.StringSlice("controllers", []string{"*"}, "Controllers to enable. Possible controllers are: "+strings.Join(loopNames(), ",")+".")
+	csrApproverVerifyClusterMembership     = pflag.Bool("csr-validate-cluster-membership", true, "Validate that VMs requesting CSRs belong to current GKE cluster.")
+	csrApproverAllowLegacyKubelet          = pflag.Bool("csr-allow-legacy-kubelet", true, "Allow legacy kubelet bootstrap flow.")
+	csrApproverUseGCEInstanceListReferrers = pflag.Bool("csr-use-gce-instance-list-referrers", false, "If true use https://cloud.google.com/compute/docs/reference/rest/v1/instances/listReferrers to validate instance cluster membership.")
+	gceAPIEndpointOverride                 = pflag.String("gce-api-endpoint-override", "", "If set, talks to a different GCE API Endpoint. By default it talks to https://www.googleapis.com/compute/v1/projects/")
+	directPath                             = pflag.Bool("direct-path", false, "Enable Direct Path.")
+	delayDirectPathGSARemove               = pflag.Bool("delay-direct-path-gsa-remove", false, "Delay removal of deleted Direct Path workloads' Google Service Accounts.")
+	hmsAuthorizeSAMappingURL               = pflag.String("hms-authorize-sa-mapping-url", "", "URL for reaching the Hosted Master Service AuthorizeSAMapping API.")
+	hmsSyncNodeURL                         = pflag.String("hms-sync-node-url", "", "URL for reaching the Hosted Master Service SyncNode API.")
+	kubeletReadOnlyCSRApprover             = pflag.Bool("kubelet-read-only-csr-approver", false, "Enable kubelet readonly csr approver or not")
+	autopilotEnabled                       = pflag.Bool("autopilot", false, "Is this a GKE Autopilot cluster.")
+	clearStalePodsOnNodeRegistration       = pflag.Bool("clearStalePodsOnNodeRegistration", false, "If true, after node registration, delete pods bound to old node.")
 )
 
 func main() {
@@ -103,20 +104,21 @@ func main() {
 	logs.InitLogs()
 
 	s := &controllerManager{
-		clusterSigningGKEKubeconfig:        *clusterSigningGKEKubeconfig,
-		gceConfigPath:                      *gceConfigPath,
-		gceAPIEndpointOverride:             *gceAPIEndpointOverride,
-		controllers:                        *controllers,
-		csrApproverVerifyClusterMembership: *csrApproverVerifyClusterMembership,
-		csrApproverAllowLegacyKubelet:      *csrApproverAllowLegacyKubelet,
-		leaderElectionConfig:               *leConfig,
-		hmsAuthorizeSAMappingURL:           *hmsAuthorizeSAMappingURL,
-		hmsSyncNodeURL:                     *hmsSyncNodeURL,
-		healthz:                            healthz.NewHandler(),
-		delayDirectPathGSARemove:           *delayDirectPathGSARemove,
-		kubeletReadOnlyCSRApprover:         *kubeletReadOnlyCSRApprover,
-		autopilotEnabled:                   *autopilotEnabled,
-		clearStalePodsOnNodeRegistration:   *clearStalePodsOnNodeRegistration,
+		clusterSigningGKEKubeconfig:            *clusterSigningGKEKubeconfig,
+		gceConfigPath:                          *gceConfigPath,
+		gceAPIEndpointOverride:                 *gceAPIEndpointOverride,
+		controllers:                            *controllers,
+		csrApproverVerifyClusterMembership:     *csrApproverVerifyClusterMembership,
+		csrApproverAllowLegacyKubelet:          *csrApproverAllowLegacyKubelet,
+		csrApproverUseGCEInstanceListReferrers: *csrApproverUseGCEInstanceListReferrers,
+		leaderElectionConfig:                   *leConfig,
+		hmsAuthorizeSAMappingURL:               *hmsAuthorizeSAMappingURL,
+		hmsSyncNodeURL:                         *hmsSyncNodeURL,
+		healthz:                                healthz.NewHandler(),
+		delayDirectPathGSARemove:               *delayDirectPathGSARemove,
+		kubeletReadOnlyCSRApprover:             *kubeletReadOnlyCSRApprover,
+		autopilotEnabled:                       *autopilotEnabled,
+		clearStalePodsOnNodeRegistration:       *clearStalePodsOnNodeRegistration,
 	}
 	var err error
 	s.informerKubeconfig, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
@@ -163,18 +165,19 @@ func main() {
 // controllerManager is the main context object for the package.
 type controllerManager struct {
 	// Fields initialized from flags.
-	clusterSigningGKEKubeconfig        string
-	gceConfigPath                      string
-	gceAPIEndpointOverride             string
-	controllers                        []string
-	csrApproverVerifyClusterMembership bool
-	csrApproverAllowLegacyKubelet      bool
-	leaderElectionConfig               componentbaseconfig.LeaderElectionConfiguration
-	hmsAuthorizeSAMappingURL           string
-	hmsSyncNodeURL                     string
-	delayDirectPathGSARemove           bool
-	autopilotEnabled                   bool
-	clearStalePodsOnNodeRegistration   bool
+	clusterSigningGKEKubeconfig            string
+	gceConfigPath                          string
+	gceAPIEndpointOverride                 string
+	controllers                            []string
+	csrApproverVerifyClusterMembership     bool
+	csrApproverAllowLegacyKubelet          bool
+	csrApproverUseGCEInstanceListReferrers bool
+	leaderElectionConfig                   componentbaseconfig.LeaderElectionConfiguration
+	hmsAuthorizeSAMappingURL               string
+	hmsSyncNodeURL                         string
+	delayDirectPathGSARemove               bool
+	autopilotEnabled                       bool
+	clearStalePodsOnNodeRegistration       bool
 
 	// Kubelet Readonly CSR Approver
 	kubeletReadOnlyCSRApprover bool
@@ -237,15 +240,16 @@ func run(s *controllerManager) error {
 				recorder: eventBroadcaster.NewRecorder(legacyscheme.Scheme, v1.EventSource{
 					Component: name,
 				}),
-				gcpCfg:                             s.gcpConfig,
-				clusterSigningGKEKubeconfig:        s.clusterSigningGKEKubeconfig,
-				csrApproverVerifyClusterMembership: s.csrApproverVerifyClusterMembership,
-				csrApproverAllowLegacyKubelet:      s.csrApproverAllowLegacyKubelet,
-				verifiedSAs:                        verifiedSAs,
-				hmsAuthorizeSAMappingURL:           s.hmsAuthorizeSAMappingURL,
-				hmsSyncNodeURL:                     s.hmsSyncNodeURL,
-				delayDirectPathGSARemove:           s.delayDirectPathGSARemove,
-				clearStalePodsOnNodeRegistration:   s.clearStalePodsOnNodeRegistration,
+				gcpCfg:                                 s.gcpConfig,
+				clusterSigningGKEKubeconfig:            s.clusterSigningGKEKubeconfig,
+				csrApproverVerifyClusterMembership:     s.csrApproverVerifyClusterMembership,
+				csrApproverAllowLegacyKubelet:          s.csrApproverAllowLegacyKubelet,
+				csrApproverUseGCEInstanceListReferrers: s.csrApproverUseGCEInstanceListReferrers,
+				verifiedSAs:                            verifiedSAs,
+				hmsAuthorizeSAMappingURL:               s.hmsAuthorizeSAMappingURL,
+				hmsSyncNodeURL:                         s.hmsSyncNodeURL,
+				delayDirectPathGSARemove:               s.delayDirectPathGSARemove,
+				clearStalePodsOnNodeRegistration:       s.clearStalePodsOnNodeRegistration,
 			}); err != nil {
 				klog.Fatalf("Failed to start %q: %v", name, err)
 			}


### PR DESCRIPTION
ListReferrers will list the instanceGroups that an instance is a MEMBER_OF

For the following request:
```
GET https://compute.googleapis.com/compute/v1/projects/p1/zones/us-central1-c/instances/1234/referrers?key=[YOUR_API_KEY] HTTP/1.1

Authorization: Bearer [YOUR_ACCESS_TOKEN]
Accept: application/json
```

We get the following response:

```
{
  "kind": "compute#instanceListReferrers",
  "id": "projects/p1/zones/us-central1-c/instances/1234/referrers",
  "items": [
    {
      "kind": "compute#reference",
      "target": "https://www.googleapis.com/compute/v1/projects/p1/zones/us-central1-c/instances/abcd",
      "referenceType": "MEMBER_OF",
      "referrer": "https://www.googleapis.com/compute/v1/projects/p1/zones/us-central1-c/instanceGroups/efgh"
    }
  ],
  "selfLink": "https://www.googleapis.com/compute/v1/projects/p1/zones/us-central1-c/instances/1234/referrers"
}
```
  