### PR TITLE
Fix GKENetworkParams pluralization 

### DIFF
--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_gkenetworkparams.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_gkenetworkparams.go
@@ -30,20 +30,20 @@ import (
 	networkv1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1"
 )
 
-// FakeGKENetworkParamses implements GKENetworkParamsInterface
-type FakeGKENetworkParamses struct {
+// FakeGKENetworkParams implements GKENetworkParamsInterface
+type FakeGKENetworkParams struct {
 	Fake *FakeNetworkingV1
 	ns   string
 }
 
-var gkenetworkparamsesResource = schema.GroupVersionResource{Group: "networking.gke.io", Version: "v1", Resource: "gkenetworkparamses"}
+var gkenetworkparamsResource = schema.GroupVersionResource{Group: "networking.gke.io", Version: "v1", Resource: "gkenetworkparams"}
 
-var gkenetworkparamsesKind = schema.GroupVersionKind{Group: "networking.gke.io", Version: "v1", Kind: "GKENetworkParams"}
+var gkenetworkparamsKind = schema.GroupVersionKind{Group: "networking.gke.io", Version: "v1", Kind: "GKENetworkParams"}
 
 // Get takes name of the gKENetworkParams, and returns the corresponding gKENetworkParams object, and an error if there is any.
-func (c *FakeGKENetworkParamses) Get(ctx context.Context, name string, options v1.GetOptions) (result *networkv1.GKENetworkParams, err error) {
+func (c *FakeGKENetworkParams) Get(ctx context.Context, name string, options v1.GetOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(gkenetworkparamsesResource, c.ns, name), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewGetAction(gkenetworkparamsResource, c.ns, name), &networkv1.GKENetworkParams{})
 
 	if obj == nil {
 		return nil, err
@@ -51,10 +51,10 @@ func (c *FakeGKENetworkParamses) Get(ctx context.Context, name string, options v
 	return obj.(*networkv1.GKENetworkParams), err
 }
 
-// List takes label and field selectors, and returns the list of GKENetworkParamses that match those selectors.
-func (c *FakeGKENetworkParamses) List(ctx context.Context, opts v1.ListOptions) (result *networkv1.GKENetworkParamsList, err error) {
+// List takes label and field selectors, and returns the list of GKENetworkParams that match those selectors.
+func (c *FakeGKENetworkParams) List(ctx context.Context, opts v1.ListOptions) (result *networkv1.GKENetworkParamsList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(gkenetworkparamsesResource, gkenetworkparamsesKind, c.ns, opts), &networkv1.GKENetworkParamsList{})
+		Invokes(testing.NewListAction(gkenetworkparamsResource, gkenetworkparamsKind, c.ns, opts), &networkv1.GKENetworkParamsList{})
 
 	if obj == nil {
 		return nil, err
@@ -73,17 +73,17 @@ func (c *FakeGKENetworkParamses) List(ctx context.Context, opts v1.ListOptions) 
 	return list, err
 }
 
-// Watch returns a watch.Interface that watches the requested gKENetworkParamses.
-func (c *FakeGKENetworkParamses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested gKENetworkParams.
+func (c *FakeGKENetworkParams) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(gkenetworkparamsesResource, c.ns, opts))
+		InvokesWatch(testing.NewWatchAction(gkenetworkparamsResource, c.ns, opts))
 
 }
 
 // Create takes the representation of a gKENetworkParams and creates it.  Returns the server's representation of the gKENetworkParams, and an error, if there is any.
-func (c *FakeGKENetworkParamses) Create(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.CreateOptions) (result *networkv1.GKENetworkParams, err error) {
+func (c *FakeGKENetworkParams) Create(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.CreateOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(gkenetworkparamsesResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewCreateAction(gkenetworkparamsResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
 
 	if obj == nil {
 		return nil, err
@@ -92,9 +92,9 @@ func (c *FakeGKENetworkParamses) Create(ctx context.Context, gKENetworkParams *n
 }
 
 // Update takes the representation of a gKENetworkParams and updates it. Returns the server's representation of the gKENetworkParams, and an error, if there is any.
-func (c *FakeGKENetworkParamses) Update(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (result *networkv1.GKENetworkParams, err error) {
+func (c *FakeGKENetworkParams) Update(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(gkenetworkparamsesResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewUpdateAction(gkenetworkparamsResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
 
 	if obj == nil {
 		return nil, err
@@ -104,9 +104,9 @@ func (c *FakeGKENetworkParamses) Update(ctx context.Context, gKENetworkParams *n
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeGKENetworkParamses) UpdateStatus(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (*networkv1.GKENetworkParams, error) {
+func (c *FakeGKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (*networkv1.GKENetworkParams, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(gkenetworkparamsesResource, "status", c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewUpdateSubresourceAction(gkenetworkparamsResource, "status", c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
 
 	if obj == nil {
 		return nil, err
@@ -115,25 +115,25 @@ func (c *FakeGKENetworkParamses) UpdateStatus(ctx context.Context, gKENetworkPar
 }
 
 // Delete takes name of the gKENetworkParams and deletes it. Returns an error if one occurs.
-func (c *FakeGKENetworkParamses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
+func (c *FakeGKENetworkParams) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(gkenetworkparamsesResource, c.ns, name), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewDeleteAction(gkenetworkparamsResource, c.ns, name), &networkv1.GKENetworkParams{})
 
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *FakeGKENetworkParamses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(gkenetworkparamsesResource, c.ns, listOpts)
+func (c *FakeGKENetworkParams) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(gkenetworkparamsResource, c.ns, listOpts)
 
 	_, err := c.Fake.Invokes(action, &networkv1.GKENetworkParamsList{})
 	return err
 }
 
 // Patch applies the patch and returns the patched gKENetworkParams.
-func (c *FakeGKENetworkParamses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *networkv1.GKENetworkParams, err error) {
+func (c *FakeGKENetworkParams) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(gkenetworkparamsesResource, c.ns, name, pt, data, subresources...), &networkv1.GKENetworkParams{})
+		Invokes(testing.NewPatchSubresourceAction(gkenetworkparamsResource, c.ns, name, pt, data, subresources...), &networkv1.GKENetworkParams{})
 
 	if obj == nil {
 		return nil, err

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
@@ -28,8 +28,8 @@ type FakeNetworkingV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeNetworkingV1) GKENetworkParamses(namespace string) v1.GKENetworkParamsInterface {
-	return &FakeGKENetworkParamses{c, namespace}
+func (c *FakeNetworkingV1) GKENetworkParams(namespace string) v1.GKENetworkParamsInterface {
+	return &FakeGKENetworkParams{c, namespace}
 }
 
 func (c *FakeNetworkingV1) GKENetworkParamsLists() v1.GKENetworkParamsListInterface {

--- a/crd/client/network/clientset/versioned/typed/network/v1/gkenetworkparams.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/gkenetworkparams.go
@@ -30,10 +30,10 @@ import (
 	scheme "k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/scheme"
 )
 
-// GKENetworkParamsesGetter has a method to return a GKENetworkParamsInterface.
+// GKENetworkParamsGetter has a method to return a GKENetworkParamsInterface.
 // A group's client should implement this interface.
-type GKENetworkParamsesGetter interface {
-	GKENetworkParamses(namespace string) GKENetworkParamsInterface
+type GKENetworkParamsGetter interface {
+	GKENetworkParams(namespace string) GKENetworkParamsInterface
 }
 
 // GKENetworkParamsInterface has methods to work with GKENetworkParams resources.
@@ -50,26 +50,26 @@ type GKENetworkParamsInterface interface {
 	GKENetworkParamsExpansion
 }
 
-// gKENetworkParamses implements GKENetworkParamsInterface
-type gKENetworkParamses struct {
+// gKENetworkParams implements GKENetworkParamsInterface
+type gKENetworkParams struct {
 	client rest.Interface
 	ns     string
 }
 
-// newGKENetworkParamses returns a GKENetworkParamses
-func newGKENetworkParamses(c *NetworkingV1Client, namespace string) *gKENetworkParamses {
-	return &gKENetworkParamses{
+// newGKENetworkParams returns a GKENetworkParams
+func newGKENetworkParams(c *NetworkingV1Client, namespace string) *gKENetworkParams {
+	return &gKENetworkParams{
 		client: c.RESTClient(),
 		ns:     namespace,
 	}
 }
 
 // Get takes name of the gKENetworkParams, and returns the corresponding gKENetworkParams object, and an error if there is any.
-func (c *gKENetworkParamses) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.GKENetworkParams, err error) {
+func (c *gKENetworkParams) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(ctx).
@@ -77,8 +77,8 @@ func (c *gKENetworkParamses) Get(ctx context.Context, name string, options metav
 	return
 }
 
-// List takes label and field selectors, and returns the list of GKENetworkParamses that match those selectors.
-func (c *gKENetworkParamses) List(ctx context.Context, opts metav1.ListOptions) (result *v1.GKENetworkParamsList, err error) {
+// List takes label and field selectors, and returns the list of GKENetworkParams that match those selectors.
+func (c *gKENetworkParams) List(ctx context.Context, opts metav1.ListOptions) (result *v1.GKENetworkParamsList, err error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -86,7 +86,7 @@ func (c *gKENetworkParamses) List(ctx context.Context, opts metav1.ListOptions) 
 	result = &v1.GKENetworkParamsList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Do(ctx).
@@ -94,8 +94,8 @@ func (c *gKENetworkParamses) List(ctx context.Context, opts metav1.ListOptions) 
 	return
 }
 
-// Watch returns a watch.Interface that watches the requested gKENetworkParamses.
-func (c *gKENetworkParamses) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+// Watch returns a watch.Interface that watches the requested gKENetworkParams.
+func (c *gKENetworkParams) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
 	if opts.TimeoutSeconds != nil {
 		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
@@ -103,18 +103,18 @@ func (c *gKENetworkParamses) Watch(ctx context.Context, opts metav1.ListOptions)
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch(ctx)
 }
 
 // Create takes the representation of a gKENetworkParams and creates it.  Returns the server's representation of the gKENetworkParams, and an error, if there is any.
-func (c *gKENetworkParamses) Create(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.CreateOptions) (result *v1.GKENetworkParams, err error) {
+func (c *gKENetworkParams) Create(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.CreateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(gKENetworkParams).
 		Do(ctx).
@@ -123,11 +123,11 @@ func (c *gKENetworkParamses) Create(ctx context.Context, gKENetworkParams *v1.GK
 }
 
 // Update takes the representation of a gKENetworkParams and updates it. Returns the server's representation of the gKENetworkParams, and an error, if there is any.
-func (c *gKENetworkParamses) Update(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
+func (c *gKENetworkParams) Update(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		Name(gKENetworkParams.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(gKENetworkParams).
@@ -138,11 +138,11 @@ func (c *gKENetworkParamses) Update(ctx context.Context, gKENetworkParams *v1.GK
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *gKENetworkParamses) UpdateStatus(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
+func (c *gKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		Name(gKENetworkParams.Name).
 		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -153,10 +153,10 @@ func (c *gKENetworkParamses) UpdateStatus(ctx context.Context, gKENetworkParams 
 }
 
 // Delete takes name of the gKENetworkParams and deletes it. Returns an error if one occurs.
-func (c *gKENetworkParamses) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+func (c *gKENetworkParams) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		Name(name).
 		Body(&opts).
 		Do(ctx).
@@ -164,14 +164,14 @@ func (c *gKENetworkParamses) Delete(ctx context.Context, name string, opts metav
 }
 
 // DeleteCollection deletes a collection of objects.
-func (c *gKENetworkParamses) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+func (c *gKENetworkParams) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
 	var timeout time.Duration
 	if listOpts.TimeoutSeconds != nil {
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(&opts).
@@ -180,11 +180,11 @@ func (c *gKENetworkParamses) DeleteCollection(ctx context.Context, opts metav1.D
 }
 
 // Patch applies the patch and returns the patched gKENetworkParams.
-func (c *gKENetworkParamses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.GKENetworkParams, err error) {
+func (c *gKENetworkParams) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
-		Resource("gkenetworkparamses").
+		Resource("gkenetworkparams").
 		Name(name).
 		SubResource(subresources...).
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
@@ -26,7 +26,7 @@ import (
 
 type NetworkingV1Interface interface {
 	RESTClient() rest.Interface
-	GKENetworkParamsesGetter
+	GKENetworkParamsGetter
 	GKENetworkParamsListsGetter
 	NetworksGetter
 	NetworkInterfacesGetter
@@ -39,8 +39,8 @@ type NetworkingV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *NetworkingV1Client) GKENetworkParamses(namespace string) GKENetworkParamsInterface {
-	return newGKENetworkParamses(c, namespace)
+func (c *NetworkingV1Client) GKENetworkParams(namespace string) GKENetworkParamsInterface {
+	return newGKENetworkParams(c, namespace)
 }
 
 func (c *NetworkingV1Client) GKENetworkParamsLists() GKENetworkParamsListInterface {

--- a/crd/client/network/informers/externalversions/generic.go
+++ b/crd/client/network/informers/externalversions/generic.go
@@ -53,8 +53,8 @@ func (f *genericInformer) Lister() cache.GenericLister {
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
 	// Group=networking.gke.io, Version=v1
-	case v1.SchemeGroupVersion.WithResource("gkenetworkparamses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1().GKENetworkParamses().Informer()}, nil
+	case v1.SchemeGroupVersion.WithResource("gkenetworkparams"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1().GKENetworkParams().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("networks"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1().Networks().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("networkinterfaces"):

--- a/crd/client/network/informers/externalversions/network/v1/gkenetworkparams.go
+++ b/crd/client/network/informers/externalversions/network/v1/gkenetworkparams.go
@@ -33,7 +33,7 @@ import (
 )
 
 // GKENetworkParamsInformer provides access to a shared informer and lister for
-// GKENetworkParamses.
+// GKENetworkParams.
 type GKENetworkParamsInformer interface {
 	Informer() cache.SharedIndexInformer
 	Lister() v1.GKENetworkParamsLister
@@ -62,13 +62,13 @@ func NewFilteredGKENetworkParamsInformer(client versioned.Interface, namespace s
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().GKENetworkParamses(namespace).List(context.TODO(), options)
+				return client.NetworkingV1().GKENetworkParams(namespace).List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().GKENetworkParamses(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1().GKENetworkParams(namespace).Watch(context.TODO(), options)
 			},
 		},
 		&networkv1.GKENetworkParams{},

--- a/crd/client/network/informers/externalversions/network/v1/interface.go
+++ b/crd/client/network/informers/externalversions/network/v1/interface.go
@@ -24,8 +24,8 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// GKENetworkParamses returns a GKENetworkParamsInformer.
-	GKENetworkParamses() GKENetworkParamsInformer
+	// GKENetworkParams returns a GKENetworkParamsInformer.
+	GKENetworkParams() GKENetworkParamsInformer
 	// Networks returns a NetworkInformer.
 	Networks() NetworkInformer
 	// NetworkInterfaces returns a NetworkInterfaceInformer.
@@ -43,8 +43,8 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// GKENetworkParamses returns a GKENetworkParamsInformer.
-func (v *version) GKENetworkParamses() GKENetworkParamsInformer {
+// GKENetworkParams returns a GKENetworkParamsInformer.
+func (v *version) GKENetworkParams() GKENetworkParamsInformer {
 	return &gKENetworkParamsInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 

--- a/crd/client/network/listers/network/v1/gkenetworkparams.go
+++ b/crd/client/network/listers/network/v1/gkenetworkparams.go
@@ -25,14 +25,14 @@ import (
 	v1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1"
 )
 
-// GKENetworkParamsLister helps list GKENetworkParamses.
+// GKENetworkParamsLister helps list GKENetworkParams.
 // All objects returned here must be treated as read-only.
 type GKENetworkParamsLister interface {
-	// List lists all GKENetworkParamses in the indexer.
+	// List lists all GKENetworkParams in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error)
-	// GKENetworkParamses returns an object that can list and get GKENetworkParamses.
-	GKENetworkParamses(namespace string) GKENetworkParamsNamespaceLister
+	// GKENetworkParams returns an object that can list and get GKENetworkParams.
+	GKENetworkParams(namespace string) GKENetworkParamsNamespaceLister
 	GKENetworkParamsListerExpansion
 }
 
@@ -46,7 +46,7 @@ func NewGKENetworkParamsLister(indexer cache.Indexer) GKENetworkParamsLister {
 	return &gKENetworkParamsLister{indexer: indexer}
 }
 
-// List lists all GKENetworkParamses in the indexer.
+// List lists all GKENetworkParams in the indexer.
 func (s *gKENetworkParamsLister) List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.GKENetworkParams))
@@ -54,15 +54,15 @@ func (s *gKENetworkParamsLister) List(selector labels.Selector) (ret []*v1.GKENe
 	return ret, err
 }
 
-// GKENetworkParamses returns an object that can list and get GKENetworkParamses.
-func (s *gKENetworkParamsLister) GKENetworkParamses(namespace string) GKENetworkParamsNamespaceLister {
+// GKENetworkParams returns an object that can list and get GKENetworkParams.
+func (s *gKENetworkParamsLister) GKENetworkParams(namespace string) GKENetworkParamsNamespaceLister {
 	return gKENetworkParamsNamespaceLister{indexer: s.indexer, namespace: namespace}
 }
 
-// GKENetworkParamsNamespaceLister helps list and get GKENetworkParamses.
+// GKENetworkParamsNamespaceLister helps list and get GKENetworkParams.
 // All objects returned here must be treated as read-only.
 type GKENetworkParamsNamespaceLister interface {
-	// List lists all GKENetworkParamses in the indexer for a given namespace.
+	// List lists all GKENetworkParams in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error)
 	// Get retrieves the GKENetworkParams from the indexer for a given namespace and name.
@@ -78,7 +78,7 @@ type gKENetworkParamsNamespaceLister struct {
 	namespace string
 }
 
-// List lists all GKENetworkParamses in the indexer for a given namespace.
+// List lists all GKENetworkParams in the indexer for a given namespace.
 func (s gKENetworkParamsNamespaceLister) List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
 		ret = append(ret, m.(*v1.GKENetworkParams))

--- a/crd/hack/update-codegen.sh
+++ b/crd/hack/update-codegen.sh
@@ -48,6 +48,7 @@ if [[ "${VERIFY_CODEGEN:-}" == "true" ]]; then
 fi
 
 readonly COMMON_FLAGS="${VERIFY_FLAG:-} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+readonly PLURAL_EXCEPTIONS="--plural-exceptions=GKENetworkParams:GKENetworkParams"
 
 generate_config() {
   local crd_name version apis_pkg
@@ -88,14 +89,15 @@ codegen_for () {
           --input-base "" \
           --input "${apis_pkg}" \
           --clientset-name "${CLIENTSET_NAME}" \
-          --plural-exceptions="GKENetworkParams:GKENetworkParams" \
           --output-package "${output_pkg}/${CLIENTSET_PKG_NAME}" \
+          ${PLURAL_EXCEPTIONS} \
           ${COMMON_FLAGS}
 
   echo "Generating listers at ${output_pkg}/listers"
   go run k8s.io/code-generator/cmd/lister-gen \
           --input-dirs "${apis_pkg}" \
           --output-package "${output_pkg}/listers" \
+          ${PLURAL_EXCEPTIONS} \
           ${COMMON_FLAGS}
 
   echo "Generating informers at ${output_pkg}/informers"
@@ -104,6 +106,7 @@ codegen_for () {
            --versioned-clientset-package "${output_pkg}/${CLIENTSET_PKG_NAME}/${CLIENTSET_NAME}" \
            --listers-package "${output_pkg}/listers" \
            --output-package "${output_pkg}/informers" \
+           ${PLURAL_EXCEPTIONS} \
            ${COMMON_FLAGS}
 
   echo "Generating register at ${apis_pkg}"

--- a/crd/hack/update-codegen.sh
+++ b/crd/hack/update-codegen.sh
@@ -88,6 +88,7 @@ codegen_for () {
           --input-base "" \
           --input "${apis_pkg}" \
           --clientset-name "${CLIENTSET_NAME}" \
+          --plural-exceptions="GKENetworkParams:GKENetworkParams" \
           --output-package "${output_pkg}/${CLIENTSET_PKG_NAME}" \
           ${COMMON_FLAGS}
 


### PR DESCRIPTION
Updates codegen script to account for incorrect pluralization of GKENetworkParams. It was transforming the resource to GKENetworkParamses. We think this is due to the resource name ending in s, some implicit name change is done in client-gen.

This fix allows the clientset to correctly find GKENetworkParams resources inside the cluster.