### PR TITLE
Update default network name

### DIFF
--- a/crd/apis/network/v1/network_types.go
+++ b/crd/apis/network/v1/network_types.go
@@ -4,7 +4,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 const (
 	// DefaultNetworkName is the network used by the VETH interface.
-	DefaultNetworkName = "pod-network"
+	DefaultNetworkName = "default"
 	// NetworkResourceKeyPrefix is the prefix for extended resource
 	// name corresponding to the network.
 	// e.g. "networking.gke.io.networks/my-network.IP"


### PR DESCRIPTION
The DefaultNetwork was initially called 'pod-network'. We are planning to change this to 'default'. 