### PR TITLE
Fix GKENetworkParams client asking for namespace. (Resource is cluster wide)

### DIFF
--- a/crd/apis/network/v1/gkenetworkparams_types.go
+++ b/crd/apis/network/v1/gkenetworkparams_types.go
@@ -3,6 +3,7 @@ package v1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_gkenetworkparams.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_gkenetworkparams.go
@@ -33,7 +33,6 @@ import (
 // FakeGKENetworkParams implements GKENetworkParamsInterface
 type FakeGKENetworkParams struct {
 	Fake *FakeNetworkingV1
-	ns   string
 }
 
 var gkenetworkparamsResource = schema.GroupVersionResource{Group: "networking.gke.io", Version: "v1", Resource: "gkenetworkparams"}
@@ -43,8 +42,7 @@ var gkenetworkparamsKind = schema.GroupVersionKind{Group: "networking.gke.io", V
 // Get takes name of the gKENetworkParams, and returns the corresponding gKENetworkParams object, and an error if there is any.
 func (c *FakeGKENetworkParams) Get(ctx context.Context, name string, options v1.GetOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(gkenetworkparamsResource, c.ns, name), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootGetAction(gkenetworkparamsResource, name), &networkv1.GKENetworkParams{})
 	if obj == nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (c *FakeGKENetworkParams) Get(ctx context.Context, name string, options v1.
 // List takes label and field selectors, and returns the list of GKENetworkParams that match those selectors.
 func (c *FakeGKENetworkParams) List(ctx context.Context, opts v1.ListOptions) (result *networkv1.GKENetworkParamsList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(gkenetworkparamsResource, gkenetworkparamsKind, c.ns, opts), &networkv1.GKENetworkParamsList{})
-
+		Invokes(testing.NewRootListAction(gkenetworkparamsResource, gkenetworkparamsKind, opts), &networkv1.GKENetworkParamsList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,15 +73,13 @@ func (c *FakeGKENetworkParams) List(ctx context.Context, opts v1.ListOptions) (r
 // Watch returns a watch.Interface that watches the requested gKENetworkParams.
 func (c *FakeGKENetworkParams) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(gkenetworkparamsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(gkenetworkparamsResource, opts))
 }
 
 // Create takes the representation of a gKENetworkParams and creates it.  Returns the server's representation of the gKENetworkParams, and an error, if there is any.
 func (c *FakeGKENetworkParams) Create(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.CreateOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(gkenetworkparamsResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootCreateAction(gkenetworkparamsResource, gKENetworkParams), &networkv1.GKENetworkParams{})
 	if obj == nil {
 		return nil, err
 	}
@@ -94,8 +89,7 @@ func (c *FakeGKENetworkParams) Create(ctx context.Context, gKENetworkParams *net
 // Update takes the representation of a gKENetworkParams and updates it. Returns the server's representation of the gKENetworkParams, and an error, if there is any.
 func (c *FakeGKENetworkParams) Update(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(gkenetworkparamsResource, c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootUpdateAction(gkenetworkparamsResource, gKENetworkParams), &networkv1.GKENetworkParams{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,8 +100,7 @@ func (c *FakeGKENetworkParams) Update(ctx context.Context, gKENetworkParams *net
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeGKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParams *networkv1.GKENetworkParams, opts v1.UpdateOptions) (*networkv1.GKENetworkParams, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(gkenetworkparamsResource, "status", c.ns, gKENetworkParams), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(gkenetworkparamsResource, "status", gKENetworkParams), &networkv1.GKENetworkParams{})
 	if obj == nil {
 		return nil, err
 	}
@@ -117,14 +110,13 @@ func (c *FakeGKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParam
 // Delete takes name of the gKENetworkParams and deletes it. Returns an error if one occurs.
 func (c *FakeGKENetworkParams) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(gkenetworkparamsResource, c.ns, name), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootDeleteAction(gkenetworkparamsResource, name), &networkv1.GKENetworkParams{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeGKENetworkParams) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(gkenetworkparamsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(gkenetworkparamsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &networkv1.GKENetworkParamsList{})
 	return err
@@ -133,8 +125,7 @@ func (c *FakeGKENetworkParams) DeleteCollection(ctx context.Context, opts v1.Del
 // Patch applies the patch and returns the patched gKENetworkParams.
 func (c *FakeGKENetworkParams) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *networkv1.GKENetworkParams, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(gkenetworkparamsResource, c.ns, name, pt, data, subresources...), &networkv1.GKENetworkParams{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(gkenetworkparamsResource, name, pt, data, subresources...), &networkv1.GKENetworkParams{})
 	if obj == nil {
 		return nil, err
 	}

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
@@ -28,8 +28,8 @@ type FakeNetworkingV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeNetworkingV1) GKENetworkParams(namespace string) v1.GKENetworkParamsInterface {
-	return &FakeGKENetworkParams{c, namespace}
+func (c *FakeNetworkingV1) GKENetworkParams() v1.GKENetworkParamsInterface {
+	return &FakeGKENetworkParams{c}
 }
 
 func (c *FakeNetworkingV1) GKENetworkParamsLists() v1.GKENetworkParamsListInterface {

--- a/crd/client/network/clientset/versioned/typed/network/v1/gkenetworkparams.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/gkenetworkparams.go
@@ -33,7 +33,7 @@ import (
 // GKENetworkParamsGetter has a method to return a GKENetworkParamsInterface.
 // A group's client should implement this interface.
 type GKENetworkParamsGetter interface {
-	GKENetworkParams(namespace string) GKENetworkParamsInterface
+	GKENetworkParams() GKENetworkParamsInterface
 }
 
 // GKENetworkParamsInterface has methods to work with GKENetworkParams resources.
@@ -53,14 +53,12 @@ type GKENetworkParamsInterface interface {
 // gKENetworkParams implements GKENetworkParamsInterface
 type gKENetworkParams struct {
 	client rest.Interface
-	ns     string
 }
 
 // newGKENetworkParams returns a GKENetworkParams
-func newGKENetworkParams(c *NetworkingV1Client, namespace string) *gKENetworkParams {
+func newGKENetworkParams(c *NetworkingV1Client) *gKENetworkParams {
 	return &gKENetworkParams{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -68,7 +66,6 @@ func newGKENetworkParams(c *NetworkingV1Client, namespace string) *gKENetworkPar
 func (c *gKENetworkParams) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,7 +82,6 @@ func (c *gKENetworkParams) List(ctx context.Context, opts metav1.ListOptions) (r
 	}
 	result = &v1.GKENetworkParamsList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,7 +98,6 @@ func (c *gKENetworkParams) Watch(ctx context.Context, opts metav1.ListOptions) (
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,7 +108,6 @@ func (c *gKENetworkParams) Watch(ctx context.Context, opts metav1.ListOptions) (
 func (c *gKENetworkParams) Create(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.CreateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(gKENetworkParams).
@@ -126,7 +120,6 @@ func (c *gKENetworkParams) Create(ctx context.Context, gKENetworkParams *v1.GKEN
 func (c *gKENetworkParams) Update(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		Name(gKENetworkParams.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *gKENetworkParams) Update(ctx context.Context, gKENetworkParams *v1.GKEN
 func (c *gKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParams *v1.GKENetworkParams, opts metav1.UpdateOptions) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		Name(gKENetworkParams.Name).
 		SubResource("status").
@@ -155,7 +147,6 @@ func (c *gKENetworkParams) UpdateStatus(ctx context.Context, gKENetworkParams *v
 // Delete takes name of the gKENetworkParams and deletes it. Returns an error if one occurs.
 func (c *gKENetworkParams) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		Name(name).
 		Body(&opts).
@@ -170,7 +161,6 @@ func (c *gKENetworkParams) DeleteCollection(ctx context.Context, opts metav1.Del
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -183,7 +173,6 @@ func (c *gKENetworkParams) DeleteCollection(ctx context.Context, opts metav1.Del
 func (c *gKENetworkParams) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.GKENetworkParams, err error) {
 	result = &v1.GKENetworkParams{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("gkenetworkparams").
 		Name(name).
 		SubResource(subresources...).

--- a/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
@@ -39,8 +39,8 @@ type NetworkingV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *NetworkingV1Client) GKENetworkParams(namespace string) GKENetworkParamsInterface {
-	return newGKENetworkParams(c, namespace)
+func (c *NetworkingV1Client) GKENetworkParams() GKENetworkParamsInterface {
+	return newGKENetworkParams(c)
 }
 
 func (c *NetworkingV1Client) GKENetworkParamsLists() GKENetworkParamsListInterface {

--- a/crd/client/network/informers/externalversions/network/v1/gkenetworkparams.go
+++ b/crd/client/network/informers/externalversions/network/v1/gkenetworkparams.go
@@ -42,33 +42,32 @@ type GKENetworkParamsInformer interface {
 type gKENetworkParamsInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewGKENetworkParamsInformer constructs a new informer for GKENetworkParams type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewGKENetworkParamsInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredGKENetworkParamsInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewGKENetworkParamsInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredGKENetworkParamsInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredGKENetworkParamsInformer constructs a new informer for GKENetworkParams type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredGKENetworkParamsInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredGKENetworkParamsInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().GKENetworkParams(namespace).List(context.TODO(), options)
+				return client.NetworkingV1().GKENetworkParams().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1().GKENetworkParams(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1().GKENetworkParams().Watch(context.TODO(), options)
 			},
 		},
 		&networkv1.GKENetworkParams{},
@@ -78,7 +77,7 @@ func NewFilteredGKENetworkParamsInformer(client versioned.Interface, namespace s
 }
 
 func (f *gKENetworkParamsInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredGKENetworkParamsInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredGKENetworkParamsInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *gKENetworkParamsInformer) Informer() cache.SharedIndexInformer {

--- a/crd/client/network/informers/externalversions/network/v1/interface.go
+++ b/crd/client/network/informers/externalversions/network/v1/interface.go
@@ -45,7 +45,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // GKENetworkParams returns a GKENetworkParamsInformer.
 func (v *version) GKENetworkParams() GKENetworkParamsInformer {
-	return &gKENetworkParamsInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &gKENetworkParamsInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // Networks returns a NetworkInformer.

--- a/crd/client/network/listers/network/v1/expansion_generated.go
+++ b/crd/client/network/listers/network/v1/expansion_generated.go
@@ -22,10 +22,6 @@ package v1
 // GKENetworkParamsLister.
 type GKENetworkParamsListerExpansion interface{}
 
-// GKENetworkParamsNamespaceListerExpansion allows custom methods to be added to
-// GKENetworkParamsNamespaceLister.
-type GKENetworkParamsNamespaceListerExpansion interface{}
-
 // NetworkListerExpansion allows custom methods to be added to
 // NetworkLister.
 type NetworkListerExpansion interface{}

--- a/crd/client/network/listers/network/v1/gkenetworkparams.go
+++ b/crd/client/network/listers/network/v1/gkenetworkparams.go
@@ -31,8 +31,9 @@ type GKENetworkParamsLister interface {
 	// List lists all GKENetworkParams in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error)
-	// GKENetworkParams returns an object that can list and get GKENetworkParams.
-	GKENetworkParams(namespace string) GKENetworkParamsNamespaceLister
+	// Get retrieves the GKENetworkParams from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.GKENetworkParams, error)
 	GKENetworkParamsListerExpansion
 }
 
@@ -54,41 +55,9 @@ func (s *gKENetworkParamsLister) List(selector labels.Selector) (ret []*v1.GKENe
 	return ret, err
 }
 
-// GKENetworkParams returns an object that can list and get GKENetworkParams.
-func (s *gKENetworkParamsLister) GKENetworkParams(namespace string) GKENetworkParamsNamespaceLister {
-	return gKENetworkParamsNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// GKENetworkParamsNamespaceLister helps list and get GKENetworkParams.
-// All objects returned here must be treated as read-only.
-type GKENetworkParamsNamespaceLister interface {
-	// List lists all GKENetworkParams in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error)
-	// Get retrieves the GKENetworkParams from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.GKENetworkParams, error)
-	GKENetworkParamsNamespaceListerExpansion
-}
-
-// gKENetworkParamsNamespaceLister implements the GKENetworkParamsNamespaceLister
-// interface.
-type gKENetworkParamsNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all GKENetworkParams in the indexer for a given namespace.
-func (s gKENetworkParamsNamespaceLister) List(selector labels.Selector) (ret []*v1.GKENetworkParams, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.GKENetworkParams))
-	})
-	return ret, err
-}
-
-// Get retrieves the GKENetworkParams from the indexer for a given namespace and name.
-func (s gKENetworkParamsNamespaceLister) Get(name string) (*v1.GKENetworkParams, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the GKENetworkParams from the index for a given name.
+func (s *gKENetworkParamsLister) Get(name string) (*v1.GKENetworkParams, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GKENetworkParams is a cluster wide resource. We shouldn't be asking for namespace in the client.