### PR TITLE
Take the lastest changes from upstream  kuberneres gce provider code 

### DIFF
--- a/providers/gce/gce_alpha.go
+++ b/providers/gce/gce_alpha.go
@@ -23,6 +23,10 @@ const (
 	// AlphaFeatureILBSubsets allows InternalLoadBalancer services to include a subset
 	// of cluster nodes as backends instead of all nodes.
 	AlphaFeatureILBSubsets = "ILBSubsets"
+
+	// AlphaFeatureSkipIGsManagement enabled L4 Regional Backend Services and
+	// disables instance group management in service controller
+	AlphaFeatureSkipIGsManagement = "SkipIGsManagement"
 )
 
 // AlphaFeatureGate contains a mapping of alpha features to whether they are enabled

--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -74,6 +74,13 @@ const (
 
 	// NetworkTierAnnotationPremium is an annotation to indicate the Service is on the Premium network tier
 	NetworkTierAnnotationPremium = cloud.NetworkTierPremium
+
+	// RBSAnnotationKey is annotated on a Service object to indicate
+	// opt-in mode for RBS NetLB
+	RBSAnnotationKey = "cloud.google.com/l4-rbs"
+
+	// RBSEnabled is an annotation to indicate the Service is opt-in for RBS
+	RBSEnabled = "enabled"
 )
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.

--- a/providers/gce/gce_disks_test.go
+++ b/providers/gce/gce_disks_test.go
@@ -29,7 +29,7 @@ import (
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
@@ -268,13 +268,12 @@ func TestCreateDisk_MultiZone(t *testing.T) {
 		nodeInformerSynced: func() bool { return true },
 	}
 
-	diskName := "disk"
 	diskType := DiskTypeStandard
 	const sizeGb int64 = 128
 
 	/* Act & Assert */
 	for _, zone := range gce.managedZones {
-		diskName = zone + "disk"
+		diskName := zone + "disk"
 		_, err := gce.CreateDisk(diskName, diskType, zone, sizeGb, nil)
 		if err != nil {
 			t.Errorf("Error creating disk in zone '%v'; error: \"%v\"", zone, err)
@@ -420,19 +419,19 @@ func TestDeleteDisk_DiffDiskMultiZone(t *testing.T) {
 		nodeZones:          createNodeZones(zonesWithNodes),
 		nodeInformerSynced: func() bool { return true },
 	}
-	diskName := "disk"
+
 	diskType := DiskTypeSSD
 	const sizeGb int64 = 128
 
 	for _, zone := range gce.managedZones {
-		diskName = zone + "disk"
+		diskName := zone + "disk"
 		gce.CreateDisk(diskName, diskType, zone, sizeGb, nil)
 	}
 
 	/* Act & Assert */
 	var err error
 	for _, zone := range gce.managedZones {
-		diskName = zone + "disk"
+		diskName := zone + "disk"
 		err = gce.DeleteDisk(diskName)
 		if err != nil {
 			t.Errorf("Error deleting disk in zone '%v'; error: \"%v\"", zone, err)

--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -78,6 +78,7 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		ClusterID:        fakeClusterID(vals.ClusterID),
 		onXPN:            vals.OnXPN,
 		metricsCollector: newLoadBalancerMetrics(),
+		projectsBasePath: getProjectsBasePath(service.BasePath),
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c

--- a/providers/gce/gce_firewall.go
+++ b/providers/gce/gce_firewall.go
@@ -66,3 +66,12 @@ func (g *Cloud) UpdateFirewall(f *compute.Firewall) error {
 	mc := newFirewallMetricContext("update")
 	return mc.Observe(g.c.Firewalls().Update(ctx, meta.GlobalKey(f.Name), f))
 }
+
+// PatchFirewall applies the given firewall as an update to an existing service.
+func (g *Cloud) PatchFirewall(f *compute.Firewall) error {
+	ctx, cancel := cloud.ContextWithCallTimeout()
+	defer cancel()
+
+	mc := newFirewallMetricContext("Patch")
+	return mc.Observe(g.c.Firewalls().Patch(ctx, meta.GlobalKey(f.Name), f))
+}

--- a/providers/gce/gce_instancegroup.go
+++ b/providers/gce/gce_instancegroup.go
@@ -50,6 +50,16 @@ func (g *Cloud) DeleteInstanceGroup(name string, zone string) error {
 	return mc.Observe(g.c.InstanceGroups().Delete(ctx, meta.ZonalKey(name, zone)))
 }
 
+// FilterInstanceGroupsByName lists all InstanceGroups in the project and
+// zone that match the name regexp.
+func (g *Cloud) FilterInstanceGroupsByNamePrefix(namePrefix, zone string) ([]*compute.InstanceGroup, error) {
+	ctx, cancel := cloud.ContextWithCallTimeout()
+	defer cancel()
+	mc := newInstanceGroupMetricContext("filter", zone)
+	v, err := g.c.InstanceGroups().List(ctx, zone, filter.Regexp("name", namePrefix+".*"))
+	return v, mc.Observe(err)
+}
+
 // ListInstanceGroups lists all InstanceGroups in the project and
 // zone.
 func (g *Cloud) ListInstanceGroups(zone string) ([]*compute.InstanceGroup, error) {

--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -23,20 +23,19 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net"
 	"sort"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	cloudprovider "k8s.io/cloud-provider"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 type cidrs struct {
-	ipn   utilnet.IPNetSet
+	ipn   netutils.IPNetSet
 	isSet bool
 }
 
@@ -48,12 +47,12 @@ var (
 func init() {
 	var err error
 	// L3/4 health checkers have client addresses within these known CIDRs.
-	l4LbSrcRngsFlag.ipn, err = utilnet.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"}...)
+	l4LbSrcRngsFlag.ipn, err = netutils.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"}...)
 	if err != nil {
 		panic("Incorrect default GCE L3/4 source ranges")
 	}
 	// L7 health checkers have client addresses within these known CIDRs.
-	l7lbSrcRngsFlag.ipn, err = utilnet.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16"}...)
+	l7lbSrcRngsFlag.ipn, err = netutils.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16"}...)
 	if err != nil {
 		panic("Incorrect default GCE L7 source ranges")
 	}
@@ -74,13 +73,13 @@ func (c *cidrs) Set(value string) error {
 	// On first Set(), clear the original defaults
 	if !c.isSet {
 		c.isSet = true
-		c.ipn = make(utilnet.IPNetSet)
+		c.ipn = make(netutils.IPNetSet)
 	} else {
 		return fmt.Errorf("GCE LB CIDRs have already been set")
 	}
 
 	for _, cidr := range strings.Split(value, ",") {
-		_, ipnet, err := net.ParseCIDR(cidr)
+		_, ipnet, err := netutils.ParseCIDRSloppy(cidr)
 		if err != nil {
 			return err
 		}

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -22,7 +22,6 @@ package gce
 import (
 	"context"
 	"fmt"
-
 	"reflect"
 	"strings"
 	"testing"
@@ -30,11 +29,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	compute "google.golang.org/api/compute/v1"
+	v1 "k8s.io/api/core/v1"
+	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -305,6 +305,86 @@ func createExternalLoadBalancer(gce *Cloud, svc *v1.Service, nodeNames []string,
 	)
 }
 
+func TestShouldNotRecreateLBWhenNetworkTiersMismatch(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	nodeNames := []string{"test-node-1"}
+
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	svc := fakeLoadbalancerService("")
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+	staticIP := "1.2.3.4"
+	gce.ReserveRegionAddress(&compute.Address{Address: staticIP, Name: "foo", NetworkTier: cloud.NetworkTierStandard.ToGCEValue()}, vals.Region)
+
+	for _, tc := range []struct {
+		desc          string
+		mutateSvc     func(service *v1.Service)
+		expectNetTier string
+		expectError   bool
+	}{
+		{
+			desc: "initial LB config with standard network tier annotation",
+			mutateSvc: func(service *v1.Service) {
+				svc.Annotations[NetworkTierAnnotationKey] = string(NetworkTierAnnotationStandard)
+			},
+			expectNetTier: NetworkTierAnnotationStandard.ToGCEValue(),
+		},
+		{
+			desc: "svc changed to empty network tier annotation",
+			mutateSvc: func(service *v1.Service) {
+				svc.Annotations = make(map[string]string)
+			},
+			expectNetTier: NetworkTierAnnotationStandard.ToGCEValue(),
+		},
+		{
+			desc: "network tier annotation changed to premium",
+			mutateSvc: func(service *v1.Service) {
+				svc.Annotations[NetworkTierAnnotationKey] = string(NetworkTierAnnotationPremium)
+			},
+			expectNetTier: NetworkTierAnnotationPremium.ToGCEValue(),
+		},
+		{
+			desc: " Network tiers annotation set to Standard and reserved static IP is specified",
+			mutateSvc: func(service *v1.Service) {
+				svc.Annotations[NetworkTierAnnotationKey] = string(NetworkTierAnnotationStandard)
+				svc.Spec.LoadBalancerIP = staticIP
+
+			},
+			expectNetTier: NetworkTierAnnotationStandard.ToGCEValue(),
+		},
+		{
+			desc: "svc changed to empty network tier annotation with static ip",
+			mutateSvc: func(service *v1.Service) {
+				svc.Annotations = make(map[string]string)
+			},
+			expectNetTier: NetworkTierAnnotationStandard.ToGCEValue(),
+			expectError:   true,
+		},
+	} {
+		tc.mutateSvc(svc)
+		status, err := gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("for test case %q, expect errror != nil, but got %v", tc.desc, err)
+			}
+		} else {
+			assert.NoError(t, err)
+			assert.NotEmpty(t, status.Ingress)
+		}
+
+		lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
+		fwdRule, err := gce.GetRegionForwardingRule(lbName, gce.region)
+		assert.NoError(t, err)
+		if fwdRule.NetworkTier != tc.expectNetTier {
+			t.Fatalf("for test case %q, expect fwdRule.NetworkTier == %q, got %v ", tc.desc, tc.expectNetTier, fwdRule.NetworkTier)
+		}
+		assertExternalLbResources(t, gce, svc, vals, nodeNames)
+	}
+}
+
 func TestEnsureExternalLoadBalancer(t *testing.T) {
 	t.Parallel()
 
@@ -498,6 +578,172 @@ func TestEnsureExternalLoadBalancerFailsWithNoNodes(t *testing.T) {
 	_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, []*v1.Node{})
 	require.Error(t, err)
 	assert.EqualError(t, err, errStrLbNoHosts)
+}
+
+func TestEnsureExternalLoadBalancerRBSAnnotation(t *testing.T) {
+	t.Parallel()
+
+	for desc, tc := range map[string]struct {
+		annotations map[string]string
+		wantError   *error
+	}{
+		"When RBS enabled": {
+			annotations: map[string]string{RBSAnnotationKey: RBSEnabled},
+			wantError:   &cloudprovider.ImplementedElsewhere,
+		},
+		"When RBS not enabled": {
+			annotations: map[string]string{},
+			wantError:   nil,
+		},
+		"When RBS annotation has wrong value": {
+			annotations: map[string]string{RBSAnnotationKey: "WrongValue"},
+			wantError:   nil,
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			vals := DefaultTestClusterValues()
+			gce, err := fakeGCECloud(vals)
+			if err != nil {
+				t.Fatalf("fakeGCECloud(%v) returned error %v, want nil", vals, err)
+			}
+
+			nodeNames := []string{"test-node-1"}
+			nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+			if err != nil {
+				t.Fatalf("createAndInsertNodes(_, %v, %v) returned error %v, want nil", nodeNames, vals.ZoneName, err)
+			}
+
+			svc := fakeLoadbalancerService("")
+			svc.Annotations = tc.annotations
+
+			_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+
+			err = gce.updateExternalLoadBalancer(vals.ClusterName, svc, nodes)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+
+			err = gce.ensureExternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+		})
+	}
+}
+
+func TestEnsureExternalLoadBalancerRBSFinalizer(t *testing.T) {
+	t.Parallel()
+
+	for desc, tc := range map[string]struct {
+		finalizers []string
+		wantError  *error
+	}{
+		"When has ELBRbsFinalizer": {
+			finalizers: []string{NetLBFinalizerV2},
+			wantError:  &cloudprovider.ImplementedElsewhere,
+		},
+		"When has no finalizer": {
+			finalizers: []string{},
+			wantError:  nil,
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			vals := DefaultTestClusterValues()
+
+			gce, err := fakeGCECloud(vals)
+			if err != nil {
+				t.Fatalf("fakeGCECloud(%v) returned error %v, want nil", vals, err)
+			}
+
+			nodeNames := []string{"test-node-1"}
+			nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+			if err != nil {
+				t.Fatalf("createAndInsertNodes(_, %v, %v) returned error %v, want nil", nodeNames, vals.ZoneName, err)
+			}
+
+			svc := fakeLoadbalancerService("")
+			svc.Finalizers = tc.finalizers
+
+			_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+
+			err = gce.updateExternalLoadBalancer(vals.ClusterName, svc, nodes)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+
+			err = gce.ensureExternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+		})
+	}
+}
+
+func TestEnsureExternalLoadBalancerExistingFwdRule(t *testing.T) {
+	t.Parallel()
+
+	for desc, tc := range map[string]struct {
+		existingForwardingRule *compute.ForwardingRule
+		wantError              *error
+	}{
+		"When has existingForwardingRule with backend service": {
+			existingForwardingRule: &compute.ForwardingRule{
+				BackendService: "exists",
+			},
+			wantError: &cloudprovider.ImplementedElsewhere,
+		},
+		"When has existingForwardingRule with empty backend service": {
+			existingForwardingRule: &compute.ForwardingRule{
+				BackendService: "",
+			},
+			wantError: nil,
+		},
+		"When has no existingForwardingRule": {
+			existingForwardingRule: nil,
+			wantError:              nil,
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			vals := DefaultTestClusterValues()
+
+			gce, err := fakeGCECloud(vals)
+			if err != nil {
+				t.Fatalf("fakeGCECloud(%v) returned error %v, want nil", vals, err)
+			}
+
+			nodeNames := []string{"test-node-1"}
+			nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+			if err != nil {
+				t.Fatalf("createAndInsertNodes(_, %v, %v) returned error %v, want nil", nodeNames, vals.ZoneName, err)
+			}
+
+			svc := fakeLoadbalancerService("")
+			_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, tc.existingForwardingRule, nodes)
+			if tc.wantError != nil {
+				assert.EqualError(t, err, (*tc.wantError).Error())
+			} else {
+				assert.NoError(t, err, "Should not return an error "+desc)
+			}
+		})
+	}
 }
 
 func TestForwardingRuleNeedsUpdate(t *testing.T) {
@@ -798,6 +1044,18 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 			needsUpdate:  true,
 			hasErr:       false,
 		},
+		"When the destination ranges are not equal.": {
+			lbName:       lbName,
+			ipAddr:       "8.8.8.8",
+			ports:        svc.Spec.Ports,
+			ipnet:        ipnet,
+			fwIPProtocol: "tcp",
+			getHook:      nil,
+			sourceRange:  fw.SourceRanges[0],
+			exists:       true,
+			needsUpdate:  true,
+			hasErr:       false,
+		},
 		"When basic flow without exceptions.": {
 			lbName:       lbName,
 			ipAddr:       ipAddr,
@@ -893,6 +1151,7 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 			fw.SourceRanges[0] = tc.sourceRange
 			fw, err = gce.GetFirewall(MakeFirewallName(lbName))
 			require.Equal(t, fw.SourceRanges[0], tc.sourceRange)
+			require.Equal(t, fw.DestinationRanges[0], status.Ingress[0].IP)
 
 			c := gce.c.(*cloud.MockGCE)
 			c.MockFirewalls.GetHook = tc.getHook
@@ -1014,7 +1273,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 
 	c := gce.c.(*cloud.MockGCE)
 	c.MockFirewalls.InsertHook = mock.InsertFirewallsUnauthorizedErrHook
-	c.MockFirewalls.UpdateHook = mock.UpdateFirewallsUnauthorizedErrHook
+	c.MockFirewalls.PatchHook = mock.UpdateFirewallsUnauthorizedErrHook
 	gce.onXPN = true
 	require.True(t, gce.OnXPN())
 
@@ -1032,6 +1291,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 	gce.createFirewall(
 		svc,
 		gce.GetLoadBalancerName(context.TODO(), "", svc),
+		"10.0.0.1",
 		"A sad little firewall",
 		ipnet,
 		svc.Spec.Ports,
@@ -1045,6 +1305,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 		svc,
 		gce.GetLoadBalancerName(context.TODO(), "", svc),
 		"A sad little firewall",
+		"10.0.0.1",
 		ipnet,
 		svc.Spec.Ports,
 		hosts)
@@ -1352,6 +1613,7 @@ func TestFirewallObject(t *testing.T) {
 	gce, err := fakeGCECloud(vals)
 	gce.nodeTags = []string{"node-tags"}
 	require.NoError(t, err)
+	dstIP := "10.0.0.1"
 	srcRanges := []string{"10.10.0.0/24", "10.20.0.0/24"}
 	sourceRanges, _ := utilnet.ParseIPNets(srcRanges...)
 	fwName := "test-fw"
@@ -1373,6 +1635,7 @@ func TestFirewallObject(t *testing.T) {
 	for _, tc := range []struct {
 		desc             string
 		sourceRanges     utilnet.IPNetSet
+		destinationIP    string
 		svcPorts         []v1.ServicePort
 		expectedFirewall func(fw compute.Firewall) compute.Firewall
 	}{
@@ -1394,6 +1657,18 @@ func TestFirewallObject(t *testing.T) {
 			},
 			expectedFirewall: func(fw compute.Firewall) compute.Firewall {
 				fw.SourceRanges = srcRanges
+				return fw
+			},
+		},
+		{
+			desc:          "has destination IP",
+			sourceRanges:  utilnet.IPNetSet{},
+			destinationIP: dstIP,
+			svcPorts: []v1.ServicePort{
+				{Name: "port1", Protocol: v1.ProtocolTCP, Port: int32(80), TargetPort: intstr.FromInt(80)},
+			},
+			expectedFirewall: func(fw compute.Firewall) compute.Firewall {
+				fw.DestinationRanges = []string{dstIP}
 				return fw
 			},
 		},
@@ -1441,7 +1716,7 @@ func TestFirewallObject(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			ret, err := gce.firewallObject(fwName, fwDesc, tc.sourceRanges, tc.svcPorts, nil)
+			ret, err := gce.firewallObject(fwName, fwDesc, tc.destinationIP, tc.sourceRanges, tc.svcPorts, nil)
 			require.NoError(t, err)
 			expectedFirewall := tc.expectedFirewall(baseFw)
 			retSrcRanges := sets.NewString(ret.SourceRanges...)

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
 	compute "google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
@@ -53,18 +53,20 @@ const (
 )
 
 func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) && existingFwdRule == nil {
-		// When ILBSubsets is enabled, new ILB services will not be processed here.
-		// Services that have existing GCE resources created by this controller will continue to update.
-		g.eventRecorder.Eventf(svc, v1.EventTypeNormal, "SkippingEnsureInternalLoadBalancer",
-			"Skipped ensureInternalLoadBalancer since %s feature is enabled.", AlphaFeatureILBSubsets)
-		return nil, cloudprovider.ImplementedElsewhere
-	}
-	if hasFinalizer(svc, ILBFinalizerV2) {
-		// Another controller is handling the resources for this service.
-		g.eventRecorder.Eventf(svc, v1.EventTypeNormal, "SkippingEnsureInternalLoadBalancer",
-			"Skipped ensureInternalLoadBalancer as service contains '%s' finalizer.", ILBFinalizerV2)
-		return nil, cloudprovider.ImplementedElsewhere
+	if existingFwdRule == nil && !hasFinalizer(svc, ILBFinalizerV1) {
+		// Neither the forwarding rule nor the V1 finalizer exists. This is most likely a new service.
+		if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) {
+			// When ILBSubsets is enabled, new ILB services will not be processed here.
+			// Services that have existing GCE resources created by this controller or the v1 finalizer
+			// will continue to update.
+			klog.V(2).Infof("Skipped ensureInternalLoadBalancer for service %s/%s, since %s feature is enabled.", svc.Namespace, svc.Name, AlphaFeatureILBSubsets)
+			return nil, cloudprovider.ImplementedElsewhere
+		}
+		if hasFinalizer(svc, ILBFinalizerV2) {
+			// No V1 resources present - Another controller is handling the resources for this service.
+			klog.V(2).Infof("Skipped ensureInternalLoadBalancer for service %s/%s, as service contains %q finalizer.", svc.Namespace, svc.Name, ILBFinalizerV2)
+			return nil, cloudprovider.ImplementedElsewhere
+		}
 	}
 
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
@@ -164,11 +166,6 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 		}()
 	}
 
-	// Ensure firewall rules if necessary
-	if err = g.ensureInternalFirewalls(loadBalancerName, ipToUse, clusterID, nm, svc, strconv.Itoa(int(hcPort)), sharedHealthCheck, nodes); err != nil {
-		return nil, err
-	}
-
 	fwdRuleDescription := &forwardingRuleDescription{ServiceName: nm.String()}
 	fwdRuleDescriptionString, err := fwdRuleDescription.marshal()
 	if err != nil {
@@ -200,8 +197,10 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 		// Delete existing forwarding rule before making changes to the backend service. For example - changing protocol
 		// of backend service without first deleting forwarding rule will throw an error since the linked forwarding
 		// rule would show the old protocol.
-		frDiff := cmp.Diff(existingFwdRule, newFwdRule)
-		klog.V(2).Infof("ensureInternalLoadBalancer(%v): forwarding rule changed - Existing - %+v\n, New - %+v\n, Diff(-existing, +new) - %s\n. Deleting existing forwarding rule.", loadBalancerName, existingFwdRule, newFwdRule, frDiff)
+		if klogV := klog.V(2); klogV.Enabled() {
+			frDiff := cmp.Diff(existingFwdRule, newFwdRule)
+			klogV.Infof("ensureInternalLoadBalancer(%v): forwarding rule changed - Existing - %+v\n, New - %+v\n, Diff(-existing, +new) - %s\n. Deleting existing forwarding rule.", loadBalancerName, existingFwdRule, newFwdRule, frDiff)
+		}
 		if err = ignoreNotFound(g.DeleteRegionForwardingRule(loadBalancerName, g.region)); err != nil {
 			return nil, err
 		}
@@ -221,15 +220,21 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 		}
 	}
 
-	// Delete the previous internal load balancer resources if necessary
-	if existingBackendService != nil {
-		g.clearPreviousInternalResources(svc, loadBalancerName, existingBackendService, backendServiceName, hcName)
-	}
-
 	// Get the most recent forwarding rule for the address.
 	updatedFwdRule, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
 	if err != nil {
 		return nil, err
+	}
+
+	ipToUse = updatedFwdRule.IPAddress
+	// Ensure firewall rules if necessary
+	if err = g.ensureInternalFirewalls(loadBalancerName, ipToUse, clusterID, nm, svc, strconv.Itoa(int(hcPort)), sharedHealthCheck, nodes); err != nil {
+		return nil, err
+	}
+
+	// Delete the previous internal load balancer resources if necessary
+	if existingBackendService != nil {
+		g.clearPreviousInternalResources(svc, loadBalancerName, existingBackendService, backendServiceName, hcName)
 	}
 
 	serviceState.InSuccess = true
@@ -275,7 +280,8 @@ func (g *Cloud) clearPreviousInternalResources(svc *v1.Service, loadBalancerName
 // updateInternalLoadBalancer is called when the list of nodes has changed. Therefore, only the instance groups
 // and possibly the backend service need to be updated.
 func (g *Cloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, nodes []*v1.Node) error {
-	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) {
+	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) && !hasFinalizer(svc, ILBFinalizerV1) {
+		klog.V(2).Infof("Skipped updateInternalLoadBalancer for service %s/%s since it does not contain %q finalizer.", svc.Namespace, svc.Name, ILBFinalizerV1)
 		return cloudprovider.ImplementedElsewhere
 	}
 	g.sharedResourceLock.Lock()
@@ -411,7 +417,7 @@ func (g *Cloud) teardownInternalHealthCheckAndFirewall(svc *v1.Service, hcName s
 	return nil
 }
 
-func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, sourceRanges []string, portRanges []string, protocol v1.Protocol, nodes []*v1.Node, legacyFwName string) error {
+func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc, destinationIP string, sourceRanges []string, portRanges []string, protocol v1.Protocol, nodes []*v1.Node, legacyFwName string) error {
 	klog.V(2).Infof("ensureInternalFirewall(%v): checking existing firewall", fwName)
 	targetTags, err := g.GetNodeTags(nodeNames(nodes))
 	if err != nil {
@@ -460,6 +466,10 @@ func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, s
 		},
 	}
 
+	if destinationIP != "" {
+		expectedFirewall.DestinationRanges = []string{destinationIP}
+	}
+
 	if existingFirewall == nil {
 		klog.V(2).Infof("ensureInternalFirewall(%v): creating firewall", fwName)
 		err = g.CreateFirewall(expectedFirewall)
@@ -476,7 +486,7 @@ func (g *Cloud) ensureInternalFirewall(svc *v1.Service, fwName, fwDesc string, s
 	}
 
 	klog.V(2).Infof("ensureInternalFirewall(%v): updating firewall", fwName)
-	err = g.UpdateFirewall(expectedFirewall)
+	err = g.PatchFirewall(expectedFirewall)
 	if err != nil && isForbidden(err) && g.OnXPN() {
 		klog.V(2).Infof("ensureInternalFirewall(%v): do not have permission to update firewall rule (on XPN). Raising event.", fwName)
 		g.raiseFirewallChangeNeededEvent(svc, FirewallToGCloudUpdateCmd(expectedFirewall, g.NetworkProjectID()))
@@ -493,7 +503,7 @@ func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID s
 	if err != nil {
 		return err
 	}
-	err = g.ensureInternalFirewall(svc, MakeFirewallName(loadBalancerName), fwDesc, sourceRanges.StringSlice(), portRanges, protocol, nodes, loadBalancerName)
+	err = g.ensureInternalFirewall(svc, MakeFirewallName(loadBalancerName), fwDesc, ipAddress, sourceRanges.StringSlice(), portRanges, protocol, nodes, loadBalancerName)
 	if err != nil {
 		return err
 	}
@@ -501,7 +511,7 @@ func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID s
 	// Second firewall is for health checking nodes / services
 	fwHCName := makeHealthCheckFirewallName(loadBalancerName, clusterID, sharedHealthCheck)
 	hcSrcRanges := L4LoadBalancerSrcRanges()
-	return g.ensureInternalFirewall(svc, fwHCName, "", hcSrcRanges, []string{healthCheckPort}, v1.ProtocolTCP, nodes, "")
+	return g.ensureInternalFirewall(svc, fwHCName, "", "", hcSrcRanges, []string{healthCheckPort}, v1.ProtocolTCP, nodes, "")
 }
 
 func (g *Cloud) ensureInternalHealthCheck(name string, svcName types.NamespacedName, shared bool, path string, port int32) (*compute.HealthCheck, error) {
@@ -620,11 +630,21 @@ func (g *Cloud) ensureInternalInstanceGroups(name string, nodes []*v1.Node) ([]s
 	klog.V(2).Infof("ensureInternalInstanceGroups(%v): %d nodes over %d zones in region %v", name, len(nodes), len(zonedNodes), g.region)
 	var igLinks []string
 	for zone, nodes := range zonedNodes {
-		igLink, err := g.ensureInternalInstanceGroup(name, zone, nodes)
-		if err != nil {
-			return []string{}, err
+		if g.AlphaFeatureGate.Enabled(AlphaFeatureSkipIGsManagement) {
+			igs, err := g.FilterInstanceGroupsByNamePrefix(name, zone)
+			if err != nil {
+				return nil, err
+			}
+			for _, ig := range igs {
+				igLinks = append(igLinks, ig.SelfLink)
+			}
+		} else {
+			igLink, err := g.ensureInternalInstanceGroup(name, zone, nodes)
+			if err != nil {
+				return nil, err
+			}
+			igLinks = append(igLinks, igLink)
 		}
-		igLinks = append(igLinks, igLink)
 	}
 
 	return igLinks, nil
@@ -637,10 +657,13 @@ func (g *Cloud) ensureInternalInstanceGroupsDeleted(name string) error {
 		return err
 	}
 
-	klog.V(2).Infof("ensureInternalInstanceGroupsDeleted(%v): attempting delete instance group in all %d zones", name, len(zones))
-	for _, z := range zones {
-		if err := g.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
-			return err
+	// Skip Instance Group deletion if IG management was moved out of k/k code
+	if !g.AlphaFeatureGate.Enabled(AlphaFeatureSkipIGsManagement) {
+		klog.V(2).Infof("ensureInternalInstanceGroupsDeleted(%v): attempting delete instance group in all %d zones", name, len(zones))
+		for _, z := range zones {
+			if err := g.DeleteInstanceGroup(name, z.Name); err != nil && !isNotFoundOrInUse(err) {
+				return err
+			}
 		}
 	}
 	return nil
@@ -753,6 +776,7 @@ func firewallRuleEqual(a, b *compute.Firewall) bool {
 		a.Allowed[0].IPProtocol == b.Allowed[0].IPProtocol &&
 		equalStringSets(a.Allowed[0].Ports, b.Allowed[0].Ports) &&
 		equalStringSets(a.SourceRanges, b.SourceRanges) &&
+		equalStringSets(a.DestinationRanges, b.DestinationRanges) &&
 		equalStringSets(a.TargetTags, b.TargetTags)
 }
 
@@ -884,7 +908,7 @@ func getPortRanges(ports []int) (ranges []string) {
 }
 
 func (g *Cloud) getBackendServiceLink(name string) string {
-	return g.service.BasePath + strings.Join([]string{g.projectID, "regions", g.region, "backendServices", name}, "/")
+	return g.projectsBasePath + strings.Join([]string{g.projectID, "regions", g.region, "backendServices", name}, "/")
 }
 
 func getNameFromLink(link string) string {

--- a/providers/gce/gce_loadbalancer_internal_test.go
+++ b/providers/gce/gce_loadbalancer_internal_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -33,7 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
 	"google.golang.org/api/compute/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -165,10 +166,37 @@ func TestEnsureInternalInstanceGroupsLimit(t *testing.T) {
 	igName := makeInstanceGroupName(vals.ClusterID)
 	_, err = gce.ensureInternalInstanceGroups(igName, nodes)
 	require.NoError(t, err)
-
 	instances, err := gce.ListInstancesInInstanceGroup(igName, vals.ZoneName, allInstances)
 	require.NoError(t, err)
 	assert.Equal(t, maxInstancesPerInstanceGroup, len(instances))
+}
+
+func TestEnsureMultipleInstanceGroups(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureSkipIGsManagement})
+
+	nodes, err := createAndInsertNodes(gce, []string{"n1"}, vals.ZoneName)
+	require.NoError(t, err)
+
+	baseName := makeInstanceGroupName(vals.ClusterID)
+	clusterIGs := []string{baseName, baseName + "-1", baseName + "-2", baseName + "-3"}
+	for _, igName := range append(clusterIGs, "zz-another-ig", "k8s-ig--cluster2-id") {
+		ig := &compute.InstanceGroup{Name: igName}
+		err := gce.CreateInstanceGroup(ig, vals.ZoneName)
+		require.NoError(t, err)
+	}
+
+	igsFromCloud, err := gce.ensureInternalInstanceGroups(baseName, nodes)
+	require.NoError(t, err)
+	assert.Len(t, igsFromCloud, len(clusterIGs), "Incorrect number of Instance Groups")
+	sort.Strings(igsFromCloud)
+	for i, igName := range clusterIGs {
+		assert.True(t, strings.HasSuffix(igsFromCloud[i], igName))
+	}
 }
 
 func TestEnsureInternalLoadBalancer(t *testing.T) {
@@ -492,7 +520,7 @@ func TestUpdateInternalLoadBalancerNodes(t *testing.T) {
 	assert.Contains(
 		t,
 		instances[0].Instance,
-		fmt.Sprintf("%s/zones/%s/instances/%s", vals.ProjectID, vals.ZoneName, node2Name),
+		fmt.Sprintf("projects/%s/zones/%s/instances/%s", vals.ProjectID, vals.ZoneName, node2Name),
 	)
 
 	// Expect initial zone to have test-node-3
@@ -502,7 +530,7 @@ func TestUpdateInternalLoadBalancerNodes(t *testing.T) {
 	assert.Contains(
 		t,
 		instances[0].Instance,
-		fmt.Sprintf("%s/zones/%s/instances/%s", vals.ProjectID, vals.SecondaryZoneName, node3Name),
+		fmt.Sprintf("projects/%s/zones/%s/instances/%s", vals.ProjectID, vals.SecondaryZoneName, node3Name),
 	)
 }
 
@@ -523,6 +551,29 @@ func TestEnsureInternalLoadBalancerDeleted(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
+}
+
+func TestSkipInstanceGroupDeletion(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	svc := fakeLoadbalancerService(string(LBTypeInternal))
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = createInternalLoadBalancer(gce, svc, nil, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	assert.NoError(t, err)
+
+	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureSkipIGsManagement})
+	err = gce.ensureInternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
+	assert.NoError(t, err)
+
+	igName := makeInstanceGroupName(vals.ClusterID)
+	ig, err := gce.GetInstanceGroup(igName, vals.ZoneName)
+	assert.NoError(t, err)
+	assert.NotNil(t, ig, "Instance group should not be deleted when flag 'NetLB_RBS' is present")
 }
 
 func TestEnsureInternalLoadBalancerDeletedTwiceDoesNotError(t *testing.T) {
@@ -653,12 +704,14 @@ func TestEnsureInternalFirewallDeletesLegacyFirewall(t *testing.T) {
 
 	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
 	require.NoError(t, err)
+	destinationIP := "10.1.2.3"
 	sourceRange := []string{"10.0.0.0/20"}
 	// Manually create a firewall rule with the legacy name - lbName
 	gce.ensureInternalFirewall(
 		svc,
 		lbName,
 		"firewall with legacy name",
+		destinationIP,
 		sourceRange,
 		[]string{"123"},
 		v1.ProtocolTCP,
@@ -673,6 +726,7 @@ func TestEnsureInternalFirewallDeletesLegacyFirewall(t *testing.T) {
 		svc,
 		fwName,
 		"firewall with new name",
+		destinationIP,
 		sourceRange,
 		[]string{"123", "456"},
 		v1.ProtocolTCP,
@@ -695,6 +749,7 @@ func TestEnsureInternalFirewallDeletesLegacyFirewall(t *testing.T) {
 		svc,
 		fwName,
 		"firewall with new name",
+		destinationIP,
 		sourceRange,
 		[]string{"123", "456", "789"},
 		v1.ProtocolTCP,
@@ -725,7 +780,7 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 
 	c := gce.c.(*cloud.MockGCE)
 	c.MockFirewalls.InsertHook = mock.InsertFirewallsUnauthorizedErrHook
-	c.MockFirewalls.UpdateHook = mock.UpdateFirewallsUnauthorizedErrHook
+	c.MockFirewalls.PatchHook = mock.UpdateFirewallsUnauthorizedErrHook
 	gce.onXPN = true
 	require.True(t, gce.OnXPN())
 
@@ -734,11 +789,13 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 
 	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
 	require.NoError(t, err)
+	destinationIP := "10.1.2.3"
 	sourceRange := []string{"10.0.0.0/20"}
 	gce.ensureInternalFirewall(
 		svc,
 		fwName,
 		"A sad little firewall",
+		destinationIP,
 		sourceRange,
 		[]string{"123"},
 		v1.ProtocolTCP,
@@ -746,17 +803,18 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 		lbName)
 	require.Nil(t, err, "Should success when XPN is on.")
 
-	checkEvent(t, recorder, FilewallChangeMsg, true)
+	checkEvent(t, recorder, FirewallChangeMsg, true)
 
 	// Create a firewall.
 	c.MockFirewalls.InsertHook = nil
-	c.MockFirewalls.UpdateHook = nil
+	c.MockFirewalls.PatchHook = nil
 	gce.onXPN = false
 
 	gce.ensureInternalFirewall(
 		svc,
 		fwName,
 		"A sad little firewall",
+		destinationIP,
 		sourceRange,
 		[]string{"123"},
 		v1.ProtocolTCP,
@@ -769,13 +827,14 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 
 	gce.onXPN = true
 	c.MockFirewalls.InsertHook = mock.InsertFirewallsUnauthorizedErrHook
-	c.MockFirewalls.UpdateHook = mock.UpdateFirewallsUnauthorizedErrHook
+	c.MockFirewalls.PatchHook = mock.UpdateFirewallsUnauthorizedErrHook
 
 	// Try to update the firewall just created.
 	gce.ensureInternalFirewall(
 		svc,
 		fwName,
 		"A happy little firewall",
+		destinationIP,
 		sourceRange,
 		[]string{"123"},
 		v1.ProtocolTCP,
@@ -783,7 +842,7 @@ func TestEnsureInternalFirewallSucceedsOnXPN(t *testing.T) {
 		lbName)
 	require.Nil(t, err, "Should success when XPN is on.")
 
-	checkEvent(t, recorder, FilewallChangeMsg, true)
+	checkEvent(t, recorder, FirewallChangeMsg, true)
 }
 
 func TestEnsureLoadBalancerDeletedSucceedsOnXPN(t *testing.T) {
@@ -805,7 +864,7 @@ func TestEnsureLoadBalancerDeletedSucceedsOnXPN(t *testing.T) {
 
 	err = gce.ensureInternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, fakeLoadbalancerService(string(LBTypeInternal)))
 	assert.NoError(t, err)
-	checkEvent(t, recorder, FilewallChangeMsg, true)
+	checkEvent(t, recorder, FirewallChangeMsg, true)
 }
 
 func TestEnsureInternalInstanceGroupsDeleted(t *testing.T) {
@@ -1044,39 +1103,67 @@ func TestCompareHealthChecks(t *testing.T) {
 // Test creation of InternalLoadBalancer with ILB Subsets featuregate enabled.
 func TestEnsureInternalLoadBalancerSubsetting(t *testing.T) {
 	t.Parallel()
+	for _, tc := range []struct {
+		desc                 string
+		finalizers           []string
+		createForwardingRule bool
+		expectErrorMsg       string
+	}{
+		{desc: "New service creation fails with Implemented Elsewhere", expectErrorMsg: cloudprovider.ImplementedElsewhere.Error()},
+		{desc: "Service with existing ForwardingRule is processed", createForwardingRule: true},
+		{desc: "Service with v1 finalizer is processed", finalizers: []string{ILBFinalizerV1}},
+		{desc: "Service with v2 finalizer is skipped", finalizers: []string{ILBFinalizerV2}, expectErrorMsg: cloudprovider.ImplementedElsewhere.Error()},
+		{desc: "Service with v2 finalizer and existing ForwardingRule is processed", finalizers: []string{ILBFinalizerV2}, createForwardingRule: true},
+		{desc: "Service with v1 and v2 finalizers is processed", finalizers: []string{ILBFinalizerV1, ILBFinalizerV2}},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			vals := DefaultTestClusterValues()
+			gce, err := fakeGCECloud(vals)
+			require.NoError(t, err)
+			gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureILBSubsets})
+			recorder := record.NewFakeRecorder(1024)
+			gce.eventRecorder = recorder
 
-	vals := DefaultTestClusterValues()
-	gce, err := fakeGCECloud(vals)
-	require.NoError(t, err)
-	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureILBSubsets})
-	recorder := record.NewFakeRecorder(1024)
-	gce.eventRecorder = recorder
-
-	nodeNames := []string{"test-node-1"}
-	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
-	require.NoError(t, err)
-
-	svc := fakeLoadbalancerService(string(LBTypeInternal))
-	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
-	require.NoError(t, err)
-	status, err := createInternalLoadBalancer(gce, svc, nil, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
-	assert.EqualError(t, err, cloudprovider.ImplementedElsewhere.Error())
-	expectedEvent := fmt.Sprintf("Normal SkippingEnsureInternalLoadBalancer Skipped ensureInternalLoadBalancer"+
-		" since %s feature is enabled.", AlphaFeatureILBSubsets)
-	checkEvent(t, recorder, expectedEvent, true)
-	// No loadbalancer resources will be created due to the ILB Feature Gate
-	assert.Empty(t, status)
-	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
-	// Invoking delete should be a no-op
-	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
-	assert.NoError(t, err)
-	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
-	// Now remove the feature gate so that lb resources are created
-	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{})
-	status, err = gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, svc, nodes)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, status.Ingress)
-	assertInternalLbResources(t, gce, svc, vals, nodeNames)
+			nodeNames := []string{"test-node-1"}
+			_, err = createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+			require.NoError(t, err)
+			svc := fakeLoadbalancerService(string(LBTypeInternal))
+			svc.Finalizers = tc.finalizers
+			svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+			require.NoError(t, err)
+			var existingFwdRule *compute.ForwardingRule
+			if tc.createForwardingRule {
+				// Create a ForwardingRule with the expected name
+				existingFwdRule = &compute.ForwardingRule{
+					Name:                gce.GetLoadBalancerName(context.TODO(), "", svc),
+					IPAddress:           "5.6.7.8",
+					Ports:               []string{"123"},
+					IPProtocol:          "TCP",
+					LoadBalancingScheme: string(cloud.SchemeInternal),
+				}
+				gce.CreateRegionForwardingRule(existingFwdRule, gce.region)
+			}
+			gotErrorMsg := ""
+			status, err := createInternalLoadBalancer(gce, svc, existingFwdRule, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+			if err != nil {
+				gotErrorMsg = err.Error()
+			}
+			if gotErrorMsg != tc.expectErrorMsg {
+				t.Errorf("createInternalLoadBalancer() = %q, want error %q", err, tc.expectErrorMsg)
+			}
+			if err != nil {
+				assert.Empty(t, status)
+				assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
+			} else {
+				assert.NotEmpty(t, status.Ingress)
+				assertInternalLbResources(t, gce, svc, vals, nodeNames)
+			}
+			// Ensure that cleanup is successful, if applicable.
+			err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
+			assert.NoError(t, err)
+			assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
+		})
+	}
 }
 
 // TestEnsureInternalLoadBalancerDeletedSubsetting verifies that updates and deletion of existing ILB resources
@@ -1106,6 +1193,60 @@ func TestEnsureInternalLoadBalancerDeletedSubsetting(t *testing.T) {
 	assert.NoError(t, err)
 	// ensure that the status has the new IP
 	assert.Equal(t, status.Ingress[0].IP, "1.2.3.4")
+	// Invoked when service is deleted.
+	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
+	assert.NoError(t, err)
+	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
+}
+
+// TestEnsureInternalLoadBalancerUpdateSubsetting verifies that updates of existing ILB instance groups
+// continue to work, even if ILBSubsets feature is enabled.
+func TestEnsureInternalLoadBalancerUpdateSubsetting(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	assert.NoError(t, err)
+	recorder := record.NewFakeRecorder(1024)
+	gce.eventRecorder = recorder
+
+	nodeNames := []string{"test-node-1"}
+	svc := fakeLoadbalancerService(string(LBTypeInternal))
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	status, err := createInternalLoadBalancer(gce, svc, nil, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, status.Ingress)
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	if !hasFinalizer(svc, ILBFinalizerV1) {
+		t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
+	}
+	// Enable FeatureGate after service has been created.
+	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureILBSubsets})
+	// mock scenario where user adds more nodes, this should be updated in the ILB.
+	nodeNames = []string{"test-node-1", "test-node-2"}
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	assert.NoError(t, err)
+	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, svc, nodes)
+	assert.NoError(t, err)
+	// Ensure that the backend service/Instance group has both nodes.
+	igName := makeInstanceGroupName(vals.ClusterID)
+	instances, err := gce.ListInstancesInInstanceGroup(igName, vals.ZoneName, allInstances)
+	assert.NoError(t, err)
+	var instanceNames []string
+	for _, inst := range instances {
+		resourceID, err := cloud.ParseResourceURL(inst.Instance)
+		if err != nil || resourceID == nil || resourceID.Key == nil {
+			t.Errorf("Failed to parse instance url - %q, error - %v", inst.Instance, err)
+			continue
+		}
+		instanceNames = append(instanceNames, resourceID.Key.Name)
+	}
+	if !equalStringSets(instanceNames, nodeNames) {
+		t.Errorf("Got instances - %v, want %v", instanceNames, nodeNames)
+	}
 	// Invoked when service is deleted.
 	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
 	assert.NoError(t, err)
@@ -1546,12 +1687,14 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 
 	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
 	require.NoError(t, err)
+	destinationIP := "10.1.2.3"
 	sourceRange := []string{"10.0.0.0/20"}
 	// Manually create a firewall rule with the legacy name - lbName
-	gce.ensureInternalFirewall(
+	err = gce.ensureInternalFirewall(
 		svc,
 		fwName,
 		"firewall with legacy name",
+		destinationIP,
 		sourceRange,
 		getPortRanges(tc.Input),
 		v1.ProtocolTCP,
@@ -1568,6 +1711,65 @@ func TestEnsureInternalFirewallPortRanges(t *testing.T) {
 	if !reflect.DeepEqual(existingPorts, tc.Result) {
 		t.Errorf("Expected firewall rule with ports %v,got %v", tc.Result, existingPorts)
 	}
+}
+
+func TestEnsureInternalFirewallDestinations(t *testing.T) {
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+	vals := DefaultTestClusterValues()
+	svc := fakeLoadbalancerService(string(LBTypeInternal))
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
+	fwName := MakeFirewallName(lbName)
+
+	nodes, err := createAndInsertNodes(gce, []string{"test-node-1"}, vals.ZoneName)
+	require.NoError(t, err)
+
+	destinationIP := "10.1.2.3"
+	sourceRange := []string{"10.0.0.0/20"}
+
+	err = gce.ensureInternalFirewall(
+		svc,
+		fwName,
+		"firewall with legacy name",
+		destinationIP,
+		sourceRange,
+		[]string{"8080"},
+		v1.ProtocolTCP,
+		nodes,
+		"")
+	if err != nil {
+		t.Errorf("Unexpected error %v when ensuring firewall %s for svc %+v", err, fwName, svc)
+	}
+	existingFirewall, err := gce.GetFirewall(fwName)
+	if err != nil || existingFirewall == nil || len(existingFirewall.Allowed) == 0 {
+		t.Errorf("Unexpected error %v when looking up firewall %s, Got firewall %+v", err, fwName, existingFirewall)
+	}
+
+	newDestinationIP := "20.1.2.3"
+
+	err = gce.ensureInternalFirewall(
+		svc,
+		fwName,
+		"firewall with legacy name",
+		newDestinationIP,
+		sourceRange,
+		[]string{"8080"},
+		v1.ProtocolTCP,
+		nodes,
+		"")
+	if err != nil {
+		t.Errorf("Unexpected error %v when ensuring firewall %s for svc %+v", err, fwName, svc)
+	}
+
+	updatedFirewall, err := gce.GetFirewall(fwName)
+	if err != nil || updatedFirewall == nil || len(updatedFirewall.Allowed) == 0 {
+		t.Errorf("Unexpected error %v when looking up firewall %s, Got firewall %+v", err, fwName, existingFirewall)
+	}
+
+	if reflect.DeepEqual(existingFirewall.DestinationRanges, updatedFirewall.DestinationRanges) {
+		t.Errorf("DestinationRanges is not updated. existingFirewall.DestinationRanges: %v, updatedFirewall.DestinationRanges: %v", existingFirewall.DestinationRanges, updatedFirewall.DestinationRanges)
+	}
+
 }
 
 func TestEnsureInternalLoadBalancerFinalizer(t *testing.T) {
@@ -1611,8 +1813,6 @@ func TestEnsureLoadBalancerSkipped(t *testing.T) {
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
-	recorder := record.NewFakeRecorder(1024)
-	gce.eventRecorder = recorder
 
 	nodeNames := []string{"test-node-1"}
 	svc := fakeLoadbalancerService(string(LBTypeInternal))
@@ -1622,10 +1822,6 @@ func TestEnsureLoadBalancerSkipped(t *testing.T) {
 	require.NoError(t, err)
 	status, err := createInternalLoadBalancer(gce, svc, nil, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 	assert.EqualError(t, err, cloudprovider.ImplementedElsewhere.Error())
-	expectedEvent := fmt.Sprintf("Normal SkippingEnsureInternalLoadBalancer Skipped ensureInternalLoadBalancer"+
-		" as service contains '%s' finalizer",
-		ILBFinalizerV2)
-	checkEvent(t, recorder, expectedEvent, true)
 	// No loadbalancer resources will be created due to the ILB Feature Gate
 	assert.Empty(t, status)
 	assertInternalLbResourcesDeleted(t, gce, svc, vals, true)

--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -179,3 +179,17 @@ func TestEnsureLoadBalancerDeletedDeletesInternalLb(t *testing.T) {
 	assert.NoError(t, err)
 	assertInternalLbResourcesDeleted(t, gce, apiService, vals, true)
 }
+
+func TestProjectsBasePath(t *testing.T) {
+	t.Parallel()
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	// Loadbalancer controller code expects basepath to contain the projects string.
+	expectProjectsBasePath := "https://compute.googleapis.com/compute/v1/projects/"
+	// See https://github.com/kubernetes/kubernetes/issues/102757, the endpoint can have mtls in some cases.
+	expectMtlsProjectsBasePath := "https://compute.mtls.googleapis.com/compute/v1/projects/"
+	require.NoError(t, err)
+	if gce.projectsBasePath != expectProjectsBasePath && gce.projectsBasePath != expectMtlsProjectsBasePath {
+		t.Errorf("Compute projectsBasePath has changed. Got %q, want %q or %q", gce.projectsBasePath, expectProjectsBasePath, expectMtlsProjectsBasePath)
+	}
+}

--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -73,7 +73,7 @@ func fakeLoadbalancerServiceHelper(lbType string, annotationKey string) *v1.Serv
 }
 
 var (
-	FilewallChangeMsg = fmt.Sprintf("%s %s %s", v1.EventTypeNormal, eventReasonManualChange, eventMsgFirewallChange)
+	FirewallChangeMsg = fmt.Sprintf("%s %s %s", v1.EventTypeNormal, eventReasonManualChange, eventMsgFirewallChange)
 )
 
 func createAndInsertNodes(gce *Cloud, nodeNames []string, zoneName string) ([]*v1.Node, error) {

--- a/providers/gce/gce_test.go
+++ b/providers/gce/gce_test.go
@@ -603,3 +603,38 @@ func TestLastComponent(t *testing.T) {
 		}
 	}
 }
+
+func TestGetProjectsBasePath(t *testing.T) {
+	testCases := []struct {
+		basePath               string
+		expectProjectsBasePath string
+	}{
+		// basepath ends in `/projects/`
+		{
+			basePath:               "path/to/api/projects/",
+			expectProjectsBasePath: "path/to/api/projects/",
+		},
+		// basepath ends in `/projects`, without trailing /
+		{
+			basePath:               "path/to/api/projects",
+			expectProjectsBasePath: "path/to/api/projects/",
+		},
+		// basepath does not end in `/projects/`
+		{
+			basePath:               "path/to/api/",
+			expectProjectsBasePath: "path/to/api/projects/",
+		},
+		// basepath does not end in `/projects/` and does not have trailing /
+		{
+			basePath:               "path/to/api",
+			expectProjectsBasePath: "path/to/api/projects/",
+		},
+	}
+
+	for _, tc := range testCases {
+		projectsBasePath := getProjectsBasePath(tc.basePath)
+		if projectsBasePath != tc.expectProjectsBasePath {
+			t.Errorf("Expected projects base path %s; but got %s", tc.expectProjectsBasePath, projectsBasePath)
+		}
+	}
+}

--- a/providers/gce/gce_tpu.go
+++ b/providers/gce/gce_tpu.go
@@ -104,10 +104,7 @@ func (g *Cloud) DeleteTPU(ctx context.Context, name, zone string) error {
 		return err
 	}
 	err = getErrorFromTPUOp(op)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // GetTPU returns the Cloud TPU with the specified name in the specified zone.

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -21,12 +21,12 @@ package gce
 
 import (
 	"context"
-	"net"
 	"reflect"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutils "k8s.io/utils/net"
 )
 
 func TestLastIPInRange(t *testing.T) {
@@ -43,9 +43,9 @@ func TestLastIPInRange(t *testing.T) {
 		{"::0/126", "::3"},
 		{"::0/120", "::ff"},
 	} {
-		_, c, err := net.ParseCIDR(tc.cidr)
+		_, c, err := netutils.ParseCIDRSloppy(tc.cidr)
 		if err != nil {
-			t.Errorf("net.ParseCIDR(%v) = _, %v, %v; want nil", tc.cidr, c, err)
+			t.Errorf("can't parse CIDR %v = _, %v, %v; want nil", tc.cidr, c, err)
 			continue
 		}
 

--- a/providers/gce/gce_zones.go
+++ b/providers/gce/gce_zones.go
@@ -91,5 +91,5 @@ func (g *Cloud) ListZonesInRegion(region string) ([]*compute.Zone, error) {
 }
 
 func (g *Cloud) getRegionLink(region string) string {
-	return g.service.BasePath + strings.Join([]string{g.projectID, "regions", region}, "/")
+	return g.projectsBasePath + strings.Join([]string{g.projectID, "regions", region}, "/")
 }

--- a/providers/gce/gcpcredential/credentialutil.go
+++ b/providers/gce/gcpcredential/credentialutil.go
@@ -60,7 +60,7 @@ func ReadURL(url string, client *http.Client, header *http.Header) (body []byte,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		klog.V(2).Infof("body of failing http response: %v", resp.Body)
+		klog.V(2).InfoS("Failed to read URL", "statusCode", resp.StatusCode, "URL", url)
 		return nil, &HTTPError{
 			StatusCode: resp.StatusCode,
 			URL:        url,

--- a/providers/gce/gcpcredential/gcpcredential.go
+++ b/providers/gce/gcpcredential/gcpcredential.go
@@ -112,7 +112,7 @@ func ProvideContainerRegistry(client *http.Client, image string) credentialconfi
 
 	var parsedBlob TokenBlob
 	if err := json.Unmarshal([]byte(tokenJSONBlob), &parsedBlob); err != nil {
-		klog.Errorf("while parsing json blob %s: %v", tokenJSONBlob, err)
+		klog.Errorf("error while parsing json blob of length %d", len(tokenJSONBlob))
 		return cfg
 	}
 

--- a/providers/gce/metrics.go
+++ b/providers/gce/metrics.go
@@ -46,7 +46,7 @@ var (
 		"version", // API version.
 	}
 
-	apiMetrics = registerAPIMetrics(metricLabels...)
+	apiMetrics = registerAPIMetrics()
 )
 
 type metricContext struct {
@@ -84,7 +84,7 @@ func newGenericMetricContext(prefix, request, region, zone, version string) *met
 }
 
 // registerApiMetrics adds metrics definitions for a category of API calls.
-func registerAPIMetrics(attributes ...string) *apiCallMetrics {
+func registerAPIMetrics() *apiCallMetrics {
 	metrics := &apiCallMetrics{
 		latency: metrics.NewHistogramVec(
 			&metrics.HistogramOpts{
@@ -92,7 +92,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Latency of a GCE API call",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 		errors: metrics.NewCounterVec(
 			&metrics.CounterOpts{
@@ -100,7 +100,7 @@ func registerAPIMetrics(attributes ...string) *apiCallMetrics {
 				Help:           "Number of errors for an API call",
 				StabilityLevel: metrics.ALPHA,
 			},
-			attributes,
+			metricLabels,
 		),
 	}
 


### PR DESCRIPTION
Take the lastest changes from upstream  kuberneres gce provider code  (staging/src/k8s.io/legacy-cloud-providers/gce)

upstream commit id 68f808e6db388b249dae8c6c9dfb078bc0947b49