### PR TITLE
Cloudbuild iterations

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,16 +14,6 @@ steps:
     args:
       - run
       - //cmd/cloud-controller-manager:publish
-  # TODO: use a better way to publish the same image
-  # using two tags: current SHA and :latest
-  - name: 'gcr.io/cloud-builders/bazel'
-    env:
-    - IMAGE_REGISTRY=gcr.io
-    - IMAGE_REPO=k8s-staging-cloud-provider-gcp
-    - IMAGE_TAG=latest
-    args:
-      - run
-      - //cmd/cloud-controller-manager:publish
 
 substitutions:
   _GIT_TAG: '12345'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
     env:
     - IMAGE_REGISTRY=gcr.io
     - IMAGE_REPO=k8s-staging-cloud-provider-gcp
-    - IMAGE_TAG=$_PULL_BASE_REF
+    - IMAGE_TAG=$SHORT_SHA
     args:
       - run
       - //cmd/cloud-controller-manager:publish


### PR DESCRIPTION
Current tag published is always set to `master`and previous one was really weird, use the short sha

Revert the change to publish latest with another build, the digest of the docker images doesn't match, we should be able to push 2 tags for the same image, it seems bazel can do it

https://github.com/bazelbuild/rules_docker/issues/108

@fejta is this something you can guide us or help here?