### PR TITLE
e2e: add test scenario to test with kOps

### DIFF
--- a/deploy/packages/default/manifest.yaml
+++ b/deploy/packages/default/manifest.yaml
@@ -1,0 +1,356 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    component: cloud-controller-manager
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+spec:
+  selector:
+    matchLabels:
+      component: cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: control-plane
+        component: cloud-controller-manager
+    spec:
+      nodeSelector: null
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+      - name: cloud-controller-manager
+        image: k8scloudprovidergcp/cloud-controller-manager:latest
+        imagePullPolicy: IfNotPresent
+        # ko puts it somewhere else... command: ['/usr/local/bin/cloud-controller-manager']
+        args: [] # args must be replaced by tooling
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10258
+            scheme: HTTPS
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          requests:
+            cpu: "200m"
+        volumeMounts:
+        - mountPath: /etc/kubernetes/cloud.config
+          name: cloudconfig
+          readOnly: true
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes/cloud.config
+          type: ""
+        name: cloudconfig
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloud-controller-manager:apiserver-authentication-reader
+  namespace: kube-system
+  labels:
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/cloud-node-controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - cloud-controller-manager
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - update
+  - patch # until #393 lands
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system::leader-locking-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cloud-controller-manager
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:cloud-node-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - get
+  - list
+  - update
+  - delete
+  - patch
+
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - list
+  - delete
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/cloud-node-controller-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system::leader-locking-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system::leader-locking-cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  apiGroup: ""
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:controller:cloud-node-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controller:cloud-node-controller
+subjects:
+- kind: ServiceAccount
+  name: cloud-node-controller
+  namespace: kube-system
+---
+
+# https://github.com/kubernetes/cloud-provider-gcp/blob/master/deploy/pvl-controller-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:controller:pvl-controller
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    addon.kops.k8s.io/name: gcp-cloud-controller.addons.k8s.io
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - list
+  - watch

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd ${REPO_ROOT}
+cd ..
+WORKSPACE=$(pwd)
+
+# Create bindir
+BINDIR=${WORKSPACE}/bin
+export PATH=${BINDIR}:${PATH}
+mkdir -p "${BINDIR}"
+
+# Build kOps & kubetest-2 kOps support
+pushd ${WORKSPACE}/kops
+GOBIN=${BINDIR} go install k8s.io/kops/cmd/kops
+GOBIN=${BINDIR} make test-e2e-install
+popd
+
+if [[ -z "${K8S_VERSION:-}" ]]; then
+  K8S_VERSION="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"
+fi
+
+CLOUD_PROVIDER="gce"
+echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
+
+if [[ -z "${CLUSTER_NAME:-}" ]]; then
+  SCRIPT_NAME=$(basename $0 .sh)
+  CLUSTER_NAME="${SCRIPT_NAME}.k8s.local"
+fi
+echo "CLUSTER_NAME=${CLUSTER_NAME}"
+
+if [[ -z "${WORKDIR:-}" ]]; then
+  WORKDIR="${WORKSPACE}/clusters/${CLUSTER_NAME}"
+fi
+mkdir -p "${WORKDIR}"
+
+if [[ -z "${GCP_PROJECT}" ]]; then
+  GCP_PROJECT=$(gcloud config get project)
+fi
+echo "GCP_PROJECT=${GCP_PROJECT}"
+
+if [[ -z "${KOPS_STATE_STORE}" ]]; then
+  KOPS_STATE_STORE="gs://kops-state-${GCP_PROJECT}"
+fi
+echo "KOPS_STATE_STORE=${KOPS_STATE_STORE}"
+export KOPS_STATE_STORE
+
+if [[ -z "${IMAGE_REPO}" ]]; then
+  IMAGE_REPO="gcr.io/${GCP_PROJECT}"
+fi
+echo "IMAGE_REPO=${IMAGE_REPO}"
+
+cd ${REPO_ROOT}
+if [[ -z "${IMAGE_TAG}" ]]; then
+  IMAGE_TAG=$(git rev-parse --short HEAD)-$(date +%Y%m%dT%H%M%S)
+fi
+echo "IMAGE_TAG=${IMAGE_REPO}"
+
+# Build and push cloud-controller-manager
+cd ${REPO_ROOT}
+export KO_DOCKER_REPO="${IMAGE_REPO}"
+ko build --tags ${IMAGE_TAG} --base-import-paths --push=true ./cmd/cloud-controller-manager/
+
+# TODO: Only if running in a test project?
+gsutil iam ch allAuthenticatedUsers:objectViewer gs://artifacts.${GCP_PROJECT}.appspot.com
+
+if [[ -z "${ADMIN_ACCESS}" ]]; then
+  ADMIN_ACCESS="0.0.0.0/0" # Or use your IPv4 with /32
+fi
+echo "ADMIN_ACCESS=${ADMIN_ACCESS}"
+
+create_args="--networking gce"
+if [[ -n "${ZONES:-}" ]]; then
+    create_args="${create_args} --zones=${ZONES}"
+fi
+
+cp "${REPO_ROOT}/deploy/packages/default/manifest.yaml" "${WORKDIR}/cloud-provider-gcp.yaml"
+sed -i -e "s@k8scloudprovidergcp/cloud-controller-manager:latest@${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}@g" "${WORKDIR}/cloud-provider-gcp.yaml"
+create_args="${create_args} --add=${WORKDIR}/cloud-provider-gcp.yaml"
+
+
+# Enable cluster addons, this enables us to replace the built-in manifest
+KOPS_FEATURE_FLAGS="ClusterAddons,${KOPS_FEATURE_FLAGS}"
+echo "KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
+
+# Note that these arguments for kubetest2 and kOps, not (for example) the arguments passed to the cloud-provider-gcp
+KUBETEST2_ARGS="kops --kops-binary-path=${BINDIR}/kops"
+KUBETEST2_ARGS="${KUBETEST2_ARGS} -v=2 --cloud-provider=${CLOUD_PROVIDER}"
+KUBETEST2_ARGS="${KUBETEST2_ARGS} --cluster-name=${CLUSTER_NAME:-} --kops-root=${REPO_ROOT}"
+KUBETEST2_ARGS="${KUBETEST2_ARGS} --admin-access=${ADMIN_ACCESS:-} --env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
+
+if [[ -n "${GCP_PROJECT:-}" ]]; then
+  KUBETEST2_ARGS="${KUBETEST2_ARGS} --gcp-project=${GCP_PROJECT}"
+fi
+
+function delete-cluster {
+    # shellcheck disable=SC2153
+  if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
+      kubetest2 ${KUBETEST2_ARGS} --down || echo "kubetest2 down failed"
+  fi
+}
+trap delete-cluster EXIT
+
+# The caller can set DELETE_CLUSTER=false to stop us deleting the cluster
+if [[ -z "${DELETE_CLUSTER:-}" ]]; then
+  DELETE_CLUSTER="true"
+fi
+
+kubetest2 ${KUBETEST2_ARGS} \
+  --up \
+   \
+  --kubernetes-version="${K8S_VERSION}" \
+  --create-args="${create_args}" \
+  --control-plane-size="${KOPS_CONTROL_PLANE_SIZE:-1}" \
+  --template-path="${KOPS_TEMPLATE:-}"
+
+
+kubetest2 ${KUBETEST2_ARGS} \
+  --test=kops \
+  -- \
+  --test-package-version="${K8S_VERSION}" \
+  --parallel=25 \
+  --skip-regex="\[Serial\]" \
+  --focus-regex="\[Conformance\]"
+
+if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
+  kubetest2 ${KUBETEST2_ARGS} --down
+  DELETE_CLUSTER=false # Don't delete again in trap
+fi


### PR DESCRIPTION
Uploading for discussion.

A simple e2e test that tests with a manifest that we provide. Solves the problem that we need to test with a configuration, treating that as part of our distribution (unless we want to test and support everything!).

Example issue: https://github.com/kubernetes/cloud-provider-gcp/pull/393