### PR TITLE
Introduce groupversion_info for network API

### DIFF
--- a/crd/apis/network/v1/BUILD
+++ b/crd/apis/network/v1/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "annotations.go",
         "doc.go",
+        "groupversion_info.go",
         "network.go",
         "network_types.go",
         "networkinterface_types.go",

--- a/crd/apis/network/v1/groupversion_info.go
+++ b/crd/apis/network/v1/groupversion_info.go
@@ -1,0 +1,14 @@
+package v1
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+// Kind names for the Network objects.
+const (
+	KindNetwork          = "Network"
+	KindNetworkInterface = "NetworkInterface"
+)
+
+// Kind takes an unqualified kind and returns back a Group qualified GroupKind
+func Kind(kind string) schema.GroupKind {
+	return GroupVersion.WithKind(kind).GroupKind()
+}


### PR DESCRIPTION
groupversion_info includes constants and helper methods for networks and network interfaces.