### PR TITLE
Bump CRD modele go version and update gcpfirewall CRD version to v1

### DIFF
--- a/crd/apis/gcpfirewall/v1beta1/zz_generated.register.go
+++ b/crd/apis/gcpfirewall/v1beta1/zz_generated.register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/apis/network/v1/zz_generated.register.go
+++ b/crd/apis/network/v1/zz_generated.register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/apis/network/v1alpha1/zz_generated.register.go
+++ b/crd/apis/network/v1alpha1/zz_generated.register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/clientset.go
+++ b/crd/client/gcpfirewall/clientset/versioned/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/doc.go
+++ b/crd/client/gcpfirewall/clientset/versioned/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/fake/clientset_generated.go
+++ b/crd/client/gcpfirewall/clientset/versioned/fake/clientset_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/fake/doc.go
+++ b/crd/client/gcpfirewall/clientset/versioned/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/fake/register.go
+++ b/crd/client/gcpfirewall/clientset/versioned/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/scheme/doc.go
+++ b/crd/client/gcpfirewall/clientset/versioned/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/scheme/register.go
+++ b/crd/client/gcpfirewall/clientset/versioned/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/doc.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/doc.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall_client.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall_client.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/generated_expansion.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/factory.go
+++ b/crd/client/gcpfirewall/informers/externalversions/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/interface.go
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/gcpfirewall.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/interface.go
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/generic.go
+++ b/crd/client/gcpfirewall/informers/externalversions/generic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/crd/client/gcpfirewall/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/expansion_generated.go
+++ b/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/gcpfirewall.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/clientset.go
+++ b/crd/client/network/clientset/versioned/clientset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/doc.go
+++ b/crd/client/network/clientset/versioned/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/fake/clientset_generated.go
+++ b/crd/client/network/clientset/versioned/fake/clientset_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/fake/doc.go
+++ b/crd/client/network/clientset/versioned/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/fake/register.go
+++ b/crd/client/network/clientset/versioned/fake/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/scheme/doc.go
+++ b/crd/client/network/clientset/versioned/scheme/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/scheme/register.go
+++ b/crd/client/network/clientset/versioned/scheme/register.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/doc.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/doc.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_network_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networkinterface.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networkinterfacelist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networkinterfacelist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networklist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/fake/fake_networklist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/generated_expansion.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/network.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/network_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/networkinterface.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/networkinterfacelist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/networkinterfacelist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1/networklist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1/networklist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/doc.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/doc.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_gkenetworkparamset.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_gkenetworkparamset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_gkenetworkparamsetlist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_gkenetworkparamsetlist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_network.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_network_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networkinterface.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networkinterfacelist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networkinterfacelist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networklist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/fake/fake_networklist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/generated_expansion.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/generated_expansion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/gkenetworkparamset.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/gkenetworkparamset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/gkenetworkparamsetlist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/gkenetworkparamsetlist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/network.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/network_client.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/network_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/networkinterface.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/networkinterfacelist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/networkinterfacelist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/clientset/versioned/typed/network/v1alpha1/networklist.go
+++ b/crd/client/network/clientset/versioned/typed/network/v1alpha1/networklist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/factory.go
+++ b/crd/client/network/informers/externalversions/factory.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/generic.go
+++ b/crd/client/network/informers/externalversions/generic.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/crd/client/network/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/interface.go
+++ b/crd/client/network/informers/externalversions/network/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1/interface.go
+++ b/crd/client/network/informers/externalversions/network/v1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1/network.go
+++ b/crd/client/network/informers/externalversions/network/v1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1/networkinterface.go
+++ b/crd/client/network/informers/externalversions/network/v1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1alpha1/gkenetworkparamset.go
+++ b/crd/client/network/informers/externalversions/network/v1alpha1/gkenetworkparamset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1alpha1/interface.go
+++ b/crd/client/network/informers/externalversions/network/v1alpha1/interface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1alpha1/network.go
+++ b/crd/client/network/informers/externalversions/network/v1alpha1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/informers/externalversions/network/v1alpha1/networkinterface.go
+++ b/crd/client/network/informers/externalversions/network/v1alpha1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1/expansion_generated.go
+++ b/crd/client/network/listers/network/v1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1/network.go
+++ b/crd/client/network/listers/network/v1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1/networkinterface.go
+++ b/crd/client/network/listers/network/v1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1alpha1/expansion_generated.go
+++ b/crd/client/network/listers/network/v1alpha1/expansion_generated.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1alpha1/gkenetworkparamset.go
+++ b/crd/client/network/listers/network/v1alpha1/gkenetworkparamset.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1alpha1/network.go
+++ b/crd/client/network/listers/network/v1alpha1/network.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/client/network/listers/network/v1alpha1/networkinterface.go
+++ b/crd/client/network/listers/network/v1alpha1/networkinterface.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2023 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/crd/config/crds/networking.gke.io_gcpfirewalls.yaml
+++ b/crd/config/crds/networking.gke.io_gcpfirewalls.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -17,227 +17,231 @@ spec:
     - gf
     singular: gcpfirewall
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      description: GCPFirewall describes a GCP firewall spec that can be used to configure
-        GCE firewalls. A GCPFirewallSpec will correspond 1:1 with a GCE firewall rule.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: 'Spec is the desired configuration for GCP firewall More info:
-            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          properties:
-            action:
-              description: Rule action of the firewall rule. Only allow action is
-                supported. If not specified, defaults to ALLOW.
-              enum:
-              - ALLOW
-              type: string
-            disabled:
-              description: If set to true, the GCPFirewall is not synced by the controller.
-              type: boolean
-            ingress:
-              description: A collection of sources and destinations to determine which
-                ingress traffic is allowed. If source is nil or empty, the traffic
-                is allowed from all sources (0.0.0.0/0). If destination is nil or
-                empty, the traffic is allowed to all kubernetes cluster entities (nodes,
-                pods and services) from the specified sources. If both are nil, the
-                traffic is allowed from all sources (0.0.00/0) to the cluster entities.
-              properties:
-                destination:
-                  description: ' Destination specifies the target of the firewall
-                    rule. If this field is empty, this rule allows traffic from specified
-                    sources to all kubernetes cluster entities.'
-                  properties:
-                    ipBlocks:
-                      description: IPBlocks specify the set of destination CIDRs that
-                        the rule applies to. If this field is present and contains
-                        at least one item, this rule allows traffic only if the traffic
-                        matches at least one item in the list. If this field is empty,
-                        this rule allows all destinations. Valid example list items
-                        are "192.168.1.1/24" or "2001:db9::/64".
-                      items:
-                        description: CIDR defines a IP block. TODO(sugangli) Modify
-                          the validation to include IPv6 CIDRs with FW 3.0 support.
-                        pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/(3[0-2]|2[0-9]|1[0-9]|[0-9]))?$
-                        type: string
-                      maxItems: 256
-                      minItems: 1
-                      type: array
-                  type: object
-                source:
-                  description: Source describes a peer to allow traffic from.
-                  properties:
-                    ipBlocks:
-                      description: IPBlocks specify the set of source CIDR ranges
-                        that the rule applies to. If this field is present and contains
-                        at least one item, this rule allows traffic only if the traffic
-                        matches at least one item in the list. If this field is empty,
-                        this rule allows all sources. Valid example list items are
-                        "192.168.1.1/24" or "2001:db9::/64".
-                      items:
-                        description: CIDR defines a IP block. TODO(sugangli) Modify
-                          the validation to include IPv6 CIDRs with FW 3.0 support.
-                        pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/(3[0-2]|2[0-9]|1[0-9]|[0-9]))?$
-                        type: string
-                      maxItems: 256
-                      minItems: 1
-                      type: array
-                  type: object
-              type: object
-            ports:
-              description: List of protocol/ ports which needs to be selected by this
-                rule. If this field is empty or missing, this rule matches all protocol/
-                ports. If this field is present and contains at least one item, then
-                this rule allows traffic only if the traffic matches at least one
-                port in the list.
-              items:
-                description: ProtocolPort describes the protocol and ports to allow
-                  traffic on.
-                properties:
-                  endPort:
-                    description: EndPort is the last port of the port range that is
-                      selected on the firewall rule targets. If StartPort is not specified
-                      or greater than this value, then this field is ignored.
-                    format: int32
-                    maximum: 65535
-                    minimum: 1
-                    type: integer
-                  protocol:
-                    description: The protocol which the traffic must match.
-                    enum:
-                    - TCP
-                    - UDP
-                    - ICMP
-                    - SCTP
-                    - AH
-                    - ESP
-                    type: string
-                  startPort:
-                    description: StartPort is the starting port of the port range
-                      that is selected on the firewall rule targets for the specified
-                      protocol. If EndPort is not specified, this is the only port
-                      selected. If StartPort is not provided, all ports are matched.
-                    format: int32
-                    maximum: 65535
-                    minimum: 1
-                    type: integer
-                required:
-                - protocol
-                type: object
-              type: array
-          type: object
-        status:
-          description: 'Status is the runtime status of this GCP firewall More info:
-            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          properties:
-            conditions:
-              description: Conditions describe the current condition of the firewall
-                rule.
-              items:
-                description: "Condition contains details for one aspect of the current
-                  state of this API Resource. --- This struct is intended for direct
-                  use as an array at the field path .status.conditions.  For example,
-                  type FooStatus struct{     // Represents the observations of a foo's
-                  current state.     // Known .status.conditions.type are: \"Available\",
-                  \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     //
-                  +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                  \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                  patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                  \n     // other fields }"
-                properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another. This should be when
-                      the underlying condition changed.  If that is not known, then
-                      using the time when the API field changed is acceptable.
-                    format: date-time
-                    type: string
-                  message:
-                    description: message is a human readable message indicating details
-                      about the transition. This may be an empty string.
-                    maxLength: 32768
-                    type: string
-                  observedGeneration:
-                    description: observedGeneration represents the .metadata.generation
-                      that the condition was set based upon. For instance, if .metadata.generation
-                      is currently 12, but the .status.conditions[x].observedGeneration
-                      is 9, the condition is out of date with respect to the current
-                      state of the instance.
-                    format: int64
-                    minimum: 0
-                    type: integer
-                  reason:
-                    description: reason contains a programmatic identifier indicating
-                      the reason for the condition's last transition. Producers of
-                      specific condition types may define expected values and meanings
-                      for this field, and whether the values are considered a guaranteed
-                      API. The value should be a CamelCase string. This field may
-                      not be empty.
-                    maxLength: 1024
-                    minLength: 1
-                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                    type: string
-                  status:
-                    description: status of the condition, one of True, False, Unknown.
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                    type: string
-                  type:
-                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      --- Many .condition.type values are consistent across resources
-                      like Available, but because arbitrary conditions can be useful
-                      (see .node.status.conditions), the ability to deconflict is
-                      important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                    maxLength: 316
-                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                    type: string
-                required:
-                - lastTransitionTime
-                - message
-                - reason
-                - status
-                - type
-                type: object
-              maxItems: 8
-              type: array
-              x-kubernetes-list-map-keys:
-              - type
-              x-kubernetes-list-type: map
-            priority:
-              description: Priority of the GCP firewall rule.
-              format: int32
-              type: integer
-            resourceURL:
-              description: Resource link for the GCE firewall rule. In case of FW
-                3.0, this is the GCE Network Firewall Policy resource.
-              type: string
-            type:
-              description: Type specifies the underlying GCE firewall implementation
-                type. Takes one of the values from [VPC, REGIONAL, GLOBAL]
-              enum:
-              - VPC
-              - REGIONAL
-              - GLOBAL
-              type: string
-          type: object
-      type: object
-  version: v1beta1
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GCPFirewall describes a GCP firewall spec that can be used to
+          configure GCE firewalls. A GCPFirewallSpec will correspond 1:1 with a GCE
+          firewall rule.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Spec is the desired configuration for GCP firewall More
+              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              action:
+                default: ALLOW
+                description: Rule action of the firewall rule. Only allow action is
+                  supported. If not specified, defaults to ALLOW.
+                enum:
+                - ALLOW
+                type: string
+              disabled:
+                description: If set to true, the GCPFirewall is not synced by the
+                  controller.
+                type: boolean
+              ingress:
+                description: A collection of sources and destinations to determine
+                  which ingress traffic is allowed. If source is nil or empty, the
+                  traffic is allowed from all sources (0.0.0.0/0). If destination
+                  is nil or empty, the traffic is allowed to all kubernetes cluster
+                  entities (nodes, pods and services) from the specified sources.
+                  If both are nil, the traffic is allowed from all sources (0.0.00/0)
+                  to the cluster entities.
+                properties:
+                  destination:
+                    description: ' Destination specifies the target of the firewall
+                      rule. If this field is empty, this rule allows traffic from
+                      specified sources to all kubernetes cluster entities.'
+                    properties:
+                      ipBlocks:
+                        description: IPBlocks specify the set of destination CIDRs
+                          that the rule applies to. If this field is present and contains
+                          at least one item, this rule allows traffic only if the
+                          traffic matches at least one item in the list. If this field
+                          is empty, this rule allows all destinations. Valid example
+                          list items are "192.168.1.1/24" or "2001:db9::/64".
+                        items:
+                          description: CIDR defines a IP block. TODO(sugangli) Modify
+                            the validation to include IPv6 CIDRs with FW 3.0 support.
+                          pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/(3[0-2]|2[0-9]|1[0-9]|[0-9]))?$
+                          type: string
+                        maxItems: 256
+                        minItems: 1
+                        type: array
+                    type: object
+                  source:
+                    description: Source describes a peer to allow traffic from.
+                    properties:
+                      ipBlocks:
+                        description: IPBlocks specify the set of source CIDR ranges
+                          that the rule applies to. If this field is present and contains
+                          at least one item, this rule allows traffic only if the
+                          traffic matches at least one item in the list. If this field
+                          is empty, this rule allows all sources. Valid example list
+                          items are "192.168.1.1/24" or "2001:db9::/64".
+                        items:
+                          description: CIDR defines a IP block. TODO(sugangli) Modify
+                            the validation to include IPv6 CIDRs with FW 3.0 support.
+                          pattern: ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/(3[0-2]|2[0-9]|1[0-9]|[0-9]))?$
+                          type: string
+                        maxItems: 256
+                        minItems: 1
+                        type: array
+                    type: object
+                type: object
+              ports:
+                description: List of protocol/ ports which needs to be selected by
+                  this rule. If this field is empty or missing, this rule matches
+                  all protocol/ ports. If this field is present and contains at least
+                  one item, then this rule allows traffic only if the traffic matches
+                  at least one port in the list.
+                items:
+                  description: ProtocolPort describes the protocol and ports to allow
+                    traffic on.
+                  properties:
+                    endPort:
+                      description: EndPort is the last port of the port range that
+                        is selected on the firewall rule targets. If StartPort is
+                        not specified or greater than this value, then this field
+                        is ignored.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                    protocol:
+                      description: The protocol which the traffic must match.
+                      enum:
+                      - TCP
+                      - UDP
+                      - ICMP
+                      - SCTP
+                      - AH
+                      - ESP
+                      type: string
+                    startPort:
+                      description: StartPort is the starting port of the port range
+                        that is selected on the firewall rule targets for the specified
+                        protocol. If EndPort is not specified, this is the only port
+                        selected. If StartPort is not provided, all ports are matched.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - protocol
+                  type: object
+                type: array
+            type: object
+          status:
+            description: 'Status is the runtime status of this GCP firewall More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              conditions:
+                description: Conditions describe the current condition of the firewall
+                  rule.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              priority:
+                description: Priority of the GCP firewall rule.
+                format: int32
+                type: integer
+              resourceURL:
+                description: Resource link for the GCE firewall rule. In case of FW
+                  3.0, this is the GCE Network Firewall Policy resource.
+                type: string
+              type:
+                description: Type specifies the underlying GCE firewall implementation
+                  type. Takes one of the values from [VPC, REGIONAL, GLOBAL]
+                enum:
+                - VPC
+                - REGIONAL
+                - GLOBAL
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
 status:

--- a/crd/go.mod
+++ b/crd/go.mod
@@ -1,12 +1,30 @@
 module k8s.io/cloud-provider-gcp/crd
 
-go 1.16
+go 1.19
 
 require (
-	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
 	k8s.io/api v0.21.1
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1
 	k8s.io/code-generator v0.21.1
 	sigs.k8s.io/controller-tools v0.6.0
+)
+
+require (
+	github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
 )

--- a/crd/hack/update-codegen.sh
+++ b/crd/hack/update-codegen.sh
@@ -126,4 +126,4 @@ codegen_for () {
 }
 
 codegen_for network v1alpha1 v1 v1
-codegen_for gcpfirewall v1beta1 v1beta1
+codegen_for gcpfirewall v1beta1 v1


### PR DESCRIPTION
Per #431, this PR bumps the go version of CRD modules to 1.19 to match ingress-gce version. It also changes gcpfirewall CRD version to v1.  