### PR TITLE
Define the NetworkValidation interface for replacing the runtime clie…

### DIFF
--- a/crd/apis/network/v1/BUILD
+++ b/crd/apis/network/v1/BUILD
@@ -7,6 +7,7 @@ go_library(
         "doc.go",
         "network.go",
         "network_types.go",
+        "network_validation_interface.go",
         "networkinterface_types.go",
         "zz_generated.deepcopy.go",
         "zz_generated.register.go",

--- a/crd/apis/network/v1/network_validation_interface.go
+++ b/crd/apis/network/v1/network_validation_interface.go
@@ -1,0 +1,15 @@
+package v1
+
+import (
+	"context"
+)
+
+// NetworkValidationClient knows how to get/list network and get/list interface objects.
+type NetworkValidationClient interface {
+	// GetNetworkInterface find the interfaceList object.
+	GetNetworkInterface(ctx context.Context, networkName string, network *Network)
+	// ListNetwork list all the network under the networkName.
+	ListNetworks(ctx context.Context, networkList *NetworkList)
+	// ListNetworkInterface list all the interface resources under the networkinterface namespace
+	ListNetworkInterfaces(ctx context.Context, networkInterfaceList *NetworkInterfaceList)
+}


### PR DESCRIPTION
…nt under anthos_networking-->actions package in order to use it on GKE-common-webhooks.