### PR TITLE
Introduce DefaultPodNetworkName constant

### DIFF
--- a/crd/apis/network/v1/network.go
+++ b/crd/apis/network/v1/network.go
@@ -6,7 +6,14 @@ package v1
 // the same as the default. Use before comparisons of networks.
 func DefaultNetworkIfEmpty(s string) string {
 	if s == "" {
-		return DefaultNetworkName
+		return DefaultPodNetworkName
 	}
 	return s
+}
+
+// IsDefaultNetwork takes a network name and returns if it is a default network.
+// Both DefaultNetworkName and DefaultPodNetworkName are considered as default network for compatibility purposes.
+// DefaultNetworkName will eventually be removed.
+func IsDefaultNetwork(networkName string) bool {
+	return networkName == DefaultNetworkName || networkName == DefaultPodNetworkName
 }

--- a/crd/apis/network/v1/network_types.go
+++ b/crd/apis/network/v1/network_types.go
@@ -5,6 +5,9 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 const (
 	// DefaultNetworkName is the network used by the VETH interface.
 	DefaultNetworkName = "pod-network"
+	// DefaultPodNetworkName is the network used by the VETH interface.
+	// This is same as DefaultNetworkName except for a different name. DefaultNetworkName will be eventually deprecated.
+	DefaultPodNetworkName = "default"
 	// NetworkResourceKeyPrefix is the prefix for extended resource
 	// name corresponding to the network.
 	// e.g. "networking.gke.io.networks/my-network.IP"


### PR DESCRIPTION
Existing DefaultNetworkName will be deprecated in favour of this new constant. We plan to support both `pod-network` and `default` values until we come up with a migration plan.

Importing libraries/files should use the new `IsDefaultNetwork` which will return true if network is default instead of directly comparing the constants.