### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/cluster/addons/pdcsi-driver/pd-csi.yaml
+++ b/cluster/addons/pdcsi-driver/pd-csi.yaml
@@ -24,7 +24,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
         name: csi-driver-registrar
         volumeMounts:
         - mountPath: /csi
@@ -35,7 +35,7 @@ spec:
         - --v=5
         - --endpoint=unix:/csi/csi.sock
         - --run-controller-service=false
-        image: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
+        image: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
         name: gce-pd-driver
         securityContext:
           privileged: true
@@ -122,7 +122,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+        image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
         name: csi-driver-registrar
         volumeMounts:
         - mountPath: /csi
@@ -133,7 +133,7 @@ spec:
         - --v=5
         - --endpoint=unix:/csi/csi.sock
         - --run-controller-service=false
-        image: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
+        image: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
         name: gce-pd-driver
         volumeMounts:
         - mountPath: C:\var\lib\kubelet

--- a/cluster/gce/manifests/pdcsi-controller.yaml
+++ b/cluster/gce/manifests/pdcsi-controller.yaml
@@ -29,7 +29,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+    image: registry.k8s.io/sig-storage/csi-provisioner:v3.1.0
     livenessProbe:
       failureThreshold: 1
       httpGet:
@@ -62,7 +62,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+    image: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
     livenessProbe:
       failureThreshold: 1
       httpGet:
@@ -95,7 +95,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+    image: registry.k8s.io/sig-storage/csi-resizer:v1.4.0
     livenessProbe:
       failureThreshold: 1
       httpGet:
@@ -128,7 +128,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.0.1
+    image: registry.k8s.io/sig-storage/csi-snapshotter:v4.0.1
     name: csi-snapshotter
     volumeMounts:
     - mountPath: /csi
@@ -141,7 +141,7 @@ spec:
     - --endpoint=unix:/csi/csi.sock
     - --cloud-config=/etc/gce.conf
     - --run-node-service=false
-    image: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
+    image: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.4.0
     name: gce-pd-driver
     volumeMounts:
     - mountPath: /csi

--- a/cmd/auth-provider-gcp/provider/provider_test.go
+++ b/cmd/auth-provider-gcp/provider/provider_test.go
@@ -35,7 +35,7 @@ const (
 	email            = "1234@project.gserviceaccount.com"
 	expectedUsername = "_token"
 	expectedCacheKey = credentialproviderapi.ImagePluginCacheKeyType
-	dummyImage       = "k8s.gcr.io/pause"
+	dummyImage       = "registry.k8s.io/pause"
 )
 
 func hasURL(url string, response *credentialproviderapi.CredentialProviderResponse) bool {


### PR DESCRIPTION
This PR will update the uses of deprecating `[k8s.gcr.io](http://k8s.gcr.io/)` registry to `[registry.k8s.io](http://registry.k8s.io/)` prior to the planned April freeze.

Tracking Issue: https://github.com/kubernetes/k8s.io/issues/4738
Search results: https://cs.k8s.io/?q=k8s.gcr.io&i=nope&files=&excludeFiles=vendor%2F&repos=kubernetes/cloud-provider-gcp