### PR TITLE
Change clearStalePodsOnNodeRegistration flag default to true

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -78,7 +78,7 @@ var (
 	hmsSyncNodeURL                         = pflag.String("hms-sync-node-url", "", "URL for reaching the Hosted Master Service SyncNode API.")
 	kubeletReadOnlyCSRApprover             = pflag.Bool("kubelet-read-only-csr-approver", false, "Enable kubelet readonly csr approver or not")
 	autopilotEnabled                       = pflag.Bool("autopilot", false, "Is this a GKE Autopilot cluster.")
-	clearStalePodsOnNodeRegistration       = pflag.Bool("clearStalePodsOnNodeRegistration", false, "If true, after node registration, delete pods bound to old node.")
+	clearStalePodsOnNodeRegistration       = pflag.Bool("clearStalePodsOnNodeRegistration", true, "If true, after node registration, delete pods bound to old node.")
 )
 
 func main() {


### PR DESCRIPTION
Change the flag default as true to enable logic clean up stale pods bounds to the old node after node preempted. 
Clean pods logics were introduced in: https://github.com/kubernetes/cloud-provider-gcp/pull/368 & https://github.com/kubernetes/cloud-provider-gcp/pull/416