### PR TITLE
Remove expiry checking from access tokens returned from

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
+++ b/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
@@ -62,9 +62,6 @@ func (p *gcloudTokenProvider) token() (string, *time.Time, error) {
 	if gc.Credential.AccessToken == "" {
 		return "", nil, fmt.Errorf("gcloud config config-helper returned an empty access token")
 	}
-	if gc.Credential.TokenExpiry.IsZero() {
-		return "", nil, fmt.Errorf("failed to retrieve expiry time from gcloud config json object")
-	}
 
 	// Authorization Token File is not commonly used. Currently, this is for specific internal debugging scenarios.
 	token := gc.Credential.AccessToken


### PR DESCRIPTION
Remove expiry checking from access tokens returned from
    gcloud tool. This will allow for gcloud access token
    retrievals where there is no expiry time stamp. But,
    this also means, we are not able to verify validity
    of these tokens when cached. We are heuristically caching
    the token for 10 seconds to limit gcloud reuse to every
    10 seconds.