### PR TITLE
Revert GCPFirewall CRD back to Cluster scoped

### DIFF
--- a/crd/apis/gcpfirewall/v1beta1/types.go
+++ b/crd/apis/gcpfirewall/v1beta1/types.go
@@ -26,8 +26,9 @@ type Protocol string
 type CIDR string
 
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=gf,scope=Namespace
+// +kubebuilder:resource:shortName=gf,scope=Cluster
 
 // GCPFirewall describes a GCP firewall spec that can be used to configure GCE
 // firewalls. A GCPFirewallSpec will correspond 1:1 with a GCE firewall rule.

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall.go
@@ -33,7 +33,6 @@ import (
 // FakeGCPFirewalls implements GCPFirewallInterface
 type FakeGCPFirewalls struct {
 	Fake *FakeNetworkingV1beta1
-	ns   string
 }
 
 var gcpfirewallsResource = schema.GroupVersionResource{Group: "networking.gke.io", Version: "v1beta1", Resource: "gcpfirewalls"}
@@ -43,8 +42,7 @@ var gcpfirewallsKind = schema.GroupVersionKind{Group: "networking.gke.io", Versi
 // Get takes name of the gCPFirewall, and returns the corresponding gCPFirewall object, and an error if there is any.
 func (c *FakeGCPFirewalls) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.GCPFirewall, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(gcpfirewallsResource, c.ns, name), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootGetAction(gcpfirewallsResource, name), &v1beta1.GCPFirewall{})
 	if obj == nil {
 		return nil, err
 	}
@@ -54,8 +52,7 @@ func (c *FakeGCPFirewalls) Get(ctx context.Context, name string, options v1.GetO
 // List takes label and field selectors, and returns the list of GCPFirewalls that match those selectors.
 func (c *FakeGCPFirewalls) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.GCPFirewallList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(gcpfirewallsResource, gcpfirewallsKind, c.ns, opts), &v1beta1.GCPFirewallList{})
-
+		Invokes(testing.NewRootListAction(gcpfirewallsResource, gcpfirewallsKind, opts), &v1beta1.GCPFirewallList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,15 +73,13 @@ func (c *FakeGCPFirewalls) List(ctx context.Context, opts v1.ListOptions) (resul
 // Watch returns a watch.Interface that watches the requested gCPFirewalls.
 func (c *FakeGCPFirewalls) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(gcpfirewallsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(gcpfirewallsResource, opts))
 }
 
 // Create takes the representation of a gCPFirewall and creates it.  Returns the server's representation of the gCPFirewall, and an error, if there is any.
 func (c *FakeGCPFirewalls) Create(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.CreateOptions) (result *v1beta1.GCPFirewall, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(gcpfirewallsResource, c.ns, gCPFirewall), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootCreateAction(gcpfirewallsResource, gCPFirewall), &v1beta1.GCPFirewall{})
 	if obj == nil {
 		return nil, err
 	}
@@ -94,8 +89,7 @@ func (c *FakeGCPFirewalls) Create(ctx context.Context, gCPFirewall *v1beta1.GCPF
 // Update takes the representation of a gCPFirewall and updates it. Returns the server's representation of the gCPFirewall, and an error, if there is any.
 func (c *FakeGCPFirewalls) Update(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.UpdateOptions) (result *v1beta1.GCPFirewall, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(gcpfirewallsResource, c.ns, gCPFirewall), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootUpdateAction(gcpfirewallsResource, gCPFirewall), &v1beta1.GCPFirewall{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,8 +100,7 @@ func (c *FakeGCPFirewalls) Update(ctx context.Context, gCPFirewall *v1beta1.GCPF
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeGCPFirewalls) UpdateStatus(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.UpdateOptions) (*v1beta1.GCPFirewall, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(gcpfirewallsResource, "status", c.ns, gCPFirewall), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(gcpfirewallsResource, "status", gCPFirewall), &v1beta1.GCPFirewall{})
 	if obj == nil {
 		return nil, err
 	}
@@ -117,14 +110,13 @@ func (c *FakeGCPFirewalls) UpdateStatus(ctx context.Context, gCPFirewall *v1beta
 // Delete takes name of the gCPFirewall and deletes it. Returns an error if one occurs.
 func (c *FakeGCPFirewalls) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(gcpfirewallsResource, c.ns, name), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootDeleteAction(gcpfirewallsResource, name), &v1beta1.GCPFirewall{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeGCPFirewalls) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(gcpfirewallsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(gcpfirewallsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.GCPFirewallList{})
 	return err
@@ -133,8 +125,7 @@ func (c *FakeGCPFirewalls) DeleteCollection(ctx context.Context, opts v1.DeleteO
 // Patch applies the patch and returns the patched gCPFirewall.
 func (c *FakeGCPFirewalls) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.GCPFirewall, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(gcpfirewallsResource, c.ns, name, pt, data, subresources...), &v1beta1.GCPFirewall{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(gcpfirewallsResource, name, pt, data, subresources...), &v1beta1.GCPFirewall{})
 	if obj == nil {
 		return nil, err
 	}

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall_client.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/fake/fake_gcpfirewall_client.go
@@ -28,8 +28,8 @@ type FakeNetworkingV1beta1 struct {
 	*testing.Fake
 }
 
-func (c *FakeNetworkingV1beta1) GCPFirewalls(namespace string) v1beta1.GCPFirewallInterface {
-	return &FakeGCPFirewalls{c, namespace}
+func (c *FakeNetworkingV1beta1) GCPFirewalls() v1beta1.GCPFirewallInterface {
+	return &FakeGCPFirewalls{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall.go
@@ -33,7 +33,7 @@ import (
 // GCPFirewallsGetter has a method to return a GCPFirewallInterface.
 // A group's client should implement this interface.
 type GCPFirewallsGetter interface {
-	GCPFirewalls(namespace string) GCPFirewallInterface
+	GCPFirewalls() GCPFirewallInterface
 }
 
 // GCPFirewallInterface has methods to work with GCPFirewall resources.
@@ -53,14 +53,12 @@ type GCPFirewallInterface interface {
 // gCPFirewalls implements GCPFirewallInterface
 type gCPFirewalls struct {
 	client rest.Interface
-	ns     string
 }
 
 // newGCPFirewalls returns a GCPFirewalls
-func newGCPFirewalls(c *NetworkingV1beta1Client, namespace string) *gCPFirewalls {
+func newGCPFirewalls(c *NetworkingV1beta1Client) *gCPFirewalls {
 	return &gCPFirewalls{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -68,7 +66,6 @@ func newGCPFirewalls(c *NetworkingV1beta1Client, namespace string) *gCPFirewalls
 func (c *gCPFirewalls) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.GCPFirewall, err error) {
 	result = &v1beta1.GCPFirewall{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -85,7 +82,6 @@ func (c *gCPFirewalls) List(ctx context.Context, opts v1.ListOptions) (result *v
 	}
 	result = &v1beta1.GCPFirewallList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -102,7 +98,6 @@ func (c *gCPFirewalls) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -113,7 +108,6 @@ func (c *gCPFirewalls) Watch(ctx context.Context, opts v1.ListOptions) (watch.In
 func (c *gCPFirewalls) Create(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.CreateOptions) (result *v1beta1.GCPFirewall, err error) {
 	result = &v1beta1.GCPFirewall{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(gCPFirewall).
@@ -126,7 +120,6 @@ func (c *gCPFirewalls) Create(ctx context.Context, gCPFirewall *v1beta1.GCPFirew
 func (c *gCPFirewalls) Update(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.UpdateOptions) (result *v1beta1.GCPFirewall, err error) {
 	result = &v1beta1.GCPFirewall{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		Name(gCPFirewall.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *gCPFirewalls) Update(ctx context.Context, gCPFirewall *v1beta1.GCPFirew
 func (c *gCPFirewalls) UpdateStatus(ctx context.Context, gCPFirewall *v1beta1.GCPFirewall, opts v1.UpdateOptions) (result *v1beta1.GCPFirewall, err error) {
 	result = &v1beta1.GCPFirewall{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		Name(gCPFirewall.Name).
 		SubResource("status").
@@ -155,7 +147,6 @@ func (c *gCPFirewalls) UpdateStatus(ctx context.Context, gCPFirewall *v1beta1.GC
 // Delete takes name of the gCPFirewall and deletes it. Returns an error if one occurs.
 func (c *gCPFirewalls) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		Name(name).
 		Body(&opts).
@@ -170,7 +161,6 @@ func (c *gCPFirewalls) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -183,7 +173,6 @@ func (c *gCPFirewalls) DeleteCollection(ctx context.Context, opts v1.DeleteOptio
 func (c *gCPFirewalls) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.GCPFirewall, err error) {
 	result = &v1beta1.GCPFirewall{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("gcpfirewalls").
 		Name(name).
 		SubResource(subresources...).

--- a/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall_client.go
+++ b/crd/client/gcpfirewall/clientset/versioned/typed/gcpfirewall/v1beta1/gcpfirewall_client.go
@@ -34,8 +34,8 @@ type NetworkingV1beta1Client struct {
 	restClient rest.Interface
 }
 
-func (c *NetworkingV1beta1Client) GCPFirewalls(namespace string) GCPFirewallInterface {
-	return newGCPFirewalls(c, namespace)
+func (c *NetworkingV1beta1Client) GCPFirewalls() GCPFirewallInterface {
+	return newGCPFirewalls(c)
 }
 
 // NewForConfig creates a new NetworkingV1beta1Client for the given config.

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/gcpfirewall.go
@@ -42,33 +42,32 @@ type GCPFirewallInformer interface {
 type gCPFirewallInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewGCPFirewallInformer constructs a new informer for GCPFirewall type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewGCPFirewallInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredGCPFirewallInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewGCPFirewallInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredGCPFirewallInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredGCPFirewallInformer constructs a new informer for GCPFirewall type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredGCPFirewallInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredGCPFirewallInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().GCPFirewalls(namespace).List(context.TODO(), options)
+				return client.NetworkingV1beta1().GCPFirewalls().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.NetworkingV1beta1().GCPFirewalls(namespace).Watch(context.TODO(), options)
+				return client.NetworkingV1beta1().GCPFirewalls().Watch(context.TODO(), options)
 			},
 		},
 		&gcpfirewallv1beta1.GCPFirewall{},
@@ -78,7 +77,7 @@ func NewFilteredGCPFirewallInformer(client versioned.Interface, namespace string
 }
 
 func (f *gCPFirewallInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredGCPFirewallInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredGCPFirewallInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *gCPFirewallInformer) Informer() cache.SharedIndexInformer {

--- a/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/interface.go
+++ b/crd/client/gcpfirewall/informers/externalversions/gcpfirewall/v1beta1/interface.go
@@ -41,5 +41,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // GCPFirewalls returns a GCPFirewallInformer.
 func (v *version) GCPFirewalls() GCPFirewallInformer {
-	return &gCPFirewallInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &gCPFirewallInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/expansion_generated.go
+++ b/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/expansion_generated.go
@@ -21,7 +21,3 @@ package v1beta1
 // GCPFirewallListerExpansion allows custom methods to be added to
 // GCPFirewallLister.
 type GCPFirewallListerExpansion interface{}
-
-// GCPFirewallNamespaceListerExpansion allows custom methods to be added to
-// GCPFirewallNamespaceLister.
-type GCPFirewallNamespaceListerExpansion interface{}

--- a/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/gcpfirewall.go
+++ b/crd/client/gcpfirewall/listers/gcpfirewall/v1beta1/gcpfirewall.go
@@ -31,8 +31,9 @@ type GCPFirewallLister interface {
 	// List lists all GCPFirewalls in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.GCPFirewall, err error)
-	// GCPFirewalls returns an object that can list and get GCPFirewalls.
-	GCPFirewalls(namespace string) GCPFirewallNamespaceLister
+	// Get retrieves the GCPFirewall from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.GCPFirewall, error)
 	GCPFirewallListerExpansion
 }
 
@@ -54,41 +55,9 @@ func (s *gCPFirewallLister) List(selector labels.Selector) (ret []*v1beta1.GCPFi
 	return ret, err
 }
 
-// GCPFirewalls returns an object that can list and get GCPFirewalls.
-func (s *gCPFirewallLister) GCPFirewalls(namespace string) GCPFirewallNamespaceLister {
-	return gCPFirewallNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// GCPFirewallNamespaceLister helps list and get GCPFirewalls.
-// All objects returned here must be treated as read-only.
-type GCPFirewallNamespaceLister interface {
-	// List lists all GCPFirewalls in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.GCPFirewall, err error)
-	// Get retrieves the GCPFirewall from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.GCPFirewall, error)
-	GCPFirewallNamespaceListerExpansion
-}
-
-// gCPFirewallNamespaceLister implements the GCPFirewallNamespaceLister
-// interface.
-type gCPFirewallNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all GCPFirewalls in the indexer for a given namespace.
-func (s gCPFirewallNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.GCPFirewall, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.GCPFirewall))
-	})
-	return ret, err
-}
-
-// Get retrieves the GCPFirewall from the indexer for a given namespace and name.
-func (s gCPFirewallNamespaceLister) Get(name string) (*v1beta1.GCPFirewall, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the GCPFirewall from the index for a given name.
+func (s *gCPFirewallLister) Get(name string) (*v1beta1.GCPFirewall, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/crd/config/crds/networking.gke.io_gcpfirewalls.yaml
+++ b/crd/config/crds/networking.gke.io_gcpfirewalls.yaml
@@ -16,7 +16,7 @@ spec:
     shortNames:
     - gf
     singular: gcpfirewall
-  scope: Namespace
+  scope: Cluster
   versions:
   - name: v1beta1
     schema:


### PR DESCRIPTION
Rollbacking changes in https://github.com/kubernetes/cloud-provider-gcp/pull/477/commits/88497b681ff7f2afb0f78da6b8c9cb8c6d6d3894

This is to avoid creating any resources in customer
namespaces.