### PR TITLE
Remove expiry checking from access tokens returned from gcloud tool

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred.go
@@ -253,7 +253,7 @@ func (p *plugin) accessToken() (string, *metav1.Time, error) {
 		return "", nil, fmt.Errorf("Failed to retrieve access token:: %w", err)
 	}
 
-	if useCache {
+	if useCache && !expiry.IsZero() {
 		if err := p.writeGcloudAccessTokenToCache(token, *expiry); err != nil {
 			// log and ignore error as writing to cache is best effort
 			klog.V(4).Infof("Failed to write gcloud access token to cache with error: %v", err)

--- a/cmd/gke-gcloud-auth-plugin/cred_test.go
+++ b/cmd/gke-gcloud-auth-plugin/cred_test.go
@@ -506,6 +506,21 @@ func TestExecCredential(t *testing.T) {
 			wantCacheFile: wantCacheFileWithAuthzToken,
 		},
 		{
+			testName: "GcloudAccessTokenFromAccessTokenFile",
+			p: &plugin{
+				k8sStartingConfig: fakeK8sStartingConfig,
+				getCacheFilePath:  fakeGetCacheFilePath,
+				readFile:          fakeReadFile,
+				timeNow:           fakeTimeNow,
+				tokenProvider: &gcloudTokenProvider{
+					readGcloudConfigRaw: fakeGcloudConfigWithAccessTokenFileOutput,
+					readFile:            fakeReadFile,
+				},
+			},
+			wantToken:     fakeExecCredential("ya29.token_from_file", nil),
+			wantCacheFile: "",
+		},
+		{
 			testName: "CachedFileWithAuthzTokenFilePathChanged",
 			p: &plugin{
 				k8sStartingConfig: fakeK8sStartingConfig,
@@ -649,7 +664,7 @@ func TestExecCredential(t *testing.T) {
 			// Run
 			ec, err := tc.p.execCredential()
 			if err != nil {
-				t.Fatalf("err should be nil")
+				t.Fatalf("err should be nil: %v", err)
 			}
 
 			if diff := cmp.Diff(tc.wantToken, ec); diff != "" {
@@ -754,6 +769,41 @@ func fakeGcloudConfigWithAuthzTokenOutput(extraArgs []string) ([]byte, error) {
   "credential": {
     "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z"
+  }
+}
+`), nil
+}
+
+func fakeGcloudConfigWithAccessTokenFileOutput(extraArgs []string) ([]byte, error) {
+	return []byte(`
+{
+  "configuration": {
+    "active_configuration": "default",
+    "properties": {
+      "auth": {
+        "access_token_file": "/usr/local/google/home/username/Desktop/gcloud_test_token"
+      },
+      "compute": {
+        "zone": "us-central1-c"
+      },
+      "container": {
+        "cluster": "username-cluster",
+        "use_application_default_credentials": "false"
+      },
+      "core": {
+        "account": "username@google.com",
+        "disable_usage_reporting": "False",
+        "project": "username-gke-dev"
+      }
+    }
+  },
+  "credential": {
+    "access_token": "ya29.token_from_file",
+    "id_token": null,
+    "token_expiry": null
+  },
+  "sentinels": {
+    "config_sentinel": "/usr/local/google/home/username/.config/gcloud/config_sentinel"
   }
 }
 `), nil

--- a/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
+++ b/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
@@ -62,9 +62,6 @@ func (p *gcloudTokenProvider) token() (string, *time.Time, error) {
 	if gc.Credential.AccessToken == "" {
 		return "", nil, fmt.Errorf("gcloud config config-helper returned an empty access token")
 	}
-	if gc.Credential.TokenExpiry.IsZero() {
-		return "", nil, fmt.Errorf("failed to retrieve expiry time from gcloud config json object")
-	}
 
 	// Authorization Token File is not commonly used. Currently, this is for specific internal debugging scenarios.
 	token := gc.Credential.AccessToken


### PR DESCRIPTION
Remove expiry checking from access tokens returned from gcloud tool. This will allow for gcloud access token retrievals where there is no expiry time stamp. But, this also means, we are not able to verify validity of these tokens when cached. So, we are not caching these tokens.