### PR TITLE
Extend gceRateLimiter to satisfy cloud.RateLimiter

### DIFF
--- a/providers/gce/support.go
+++ b/providers/gce/support.go
@@ -66,6 +66,9 @@ func (l *gceRateLimiter) Accept(ctx context.Context, key *cloud.RateLimitKey) er
 	return nil
 }
 
+// Observe is a no-op func to satisfy cloud.RateLimiter
+func (*gceRateLimiter) Observe(context.Context, error, *cloud.RateLimitKey) {}
+
 // CreateGCECloudWithCloud is a helper function to create an instance of Cloud with the
 // given Cloud interface implementation. Typical usage is to use cloud.NewMockGCE to get a
 // handle to a mock Cloud instance and then use that for testing.


### PR DESCRIPTION
* adds support for a new cloud.RateLimiter interface func so that gceRateLimiter can continue to satisfy the interface.
* This unblocks importers of legacy-cloud-provider (i.e. kubernetes/ingress-gce) from updating their k8s-cloud-provider version.

This PR replaces https://github.com/kubernetes/kubernetes/pull/116448

/assign @aojea 