### PR TITLE
Handle missing PodIPv4Ranges in GKENetworkParamSet

### DIFF
--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -44,7 +44,10 @@ func (ca *cloudCIDRAllocator) PerformMultiNetworkCIDRAllocation(node *v1.Node, i
 			}
 			klog.V(2).Infof("interface %s matched, proceeding to find a secondary range", inf.Name)
 			// TODO: Handle IPv6 in future.
-			secondaryRangeNames := gnp.Spec.PodIPv4Ranges.RangeNames
+			var secondaryRangeNames []string
+			if gnp.Spec.PodIPv4Ranges != nil {
+				secondaryRangeNames = gnp.Spec.PodIPv4Ranges.RangeNames
+			}
 			// In case of host networking, the node interfaces do not have the secondary ranges. We still need to update the
 			// north-interface information on the node.
 			if len(secondaryRangeNames) == 0 && !networkv1.IsDefaultNetwork(network.Name) {

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
@@ -56,18 +56,21 @@ func network(name, gkeNetworkParamsName string) *networkv1.Network {
 }
 
 func gkeNetworkParams(name, vpc, subnet string, secRangeNames []string) *networkv1alpha1.GKENetworkParamSet {
-	return &networkv1alpha1.GKENetworkParamSet{
+	gnp := &networkv1alpha1.GKENetworkParamSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: networkv1alpha1.GKENetworkParamSetSpec{
 			VPC:       vpc,
 			VPCSubnet: subnet,
-			PodIPv4Ranges: &networkv1alpha1.SecondaryRanges{
-				RangeNames: secRangeNames,
-			},
 		},
 	}
+	if len(secRangeNames) > 0 {
+		gnp.Spec.PodIPv4Ranges = &networkv1alpha1.SecondaryRanges{
+			RangeNames: secRangeNames,
+		}
+	}
+	return gnp
 }
 
 func interfaces(network, subnetwork, networkIP string, aliasIPRanges []*compute.AliasIpRange) *compute.NetworkInterface {


### PR DESCRIPTION
For host networks, GKENewtorkParamSet will not have any pod ranges configured. This PR adds a nil check on PodIPv4Ranges before going through secondary ranges.