### PR TITLE
Duplicate DPWI Related Code into a new folder dpwi as Refactor Preparation

### DIFF
--- a/cmd/gcp-controller-manager/dpwi/configmap/BUILD
+++ b/cmd/gcp-controller-manager/dpwi/configmap/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "configmap",
+    srcs = ["configmap.go"],
+    importpath = "k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/dpwi/configmap",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/gcp-controller-manager/dpwi/hms",
+        "//cmd/gcp-controller-manager/dpwi/serviceaccounts",
+        "//vendor/google.golang.org/api/compute/v1:compute",
+        "//vendor/k8s.io/api/core/v1:core",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait",
+        "//vendor/k8s.io/client-go/informers/core/v1:core",
+        "//vendor/k8s.io/client-go/kubernetes",
+        "//vendor/k8s.io/client-go/tools/cache",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api",
+        "//vendor/k8s.io/client-go/util/workqueue",
+        "//vendor/k8s.io/klog/v2:klog",
+    ],
+)

--- a/cmd/gcp-controller-manager/dpwi/hms/BUILD
+++ b/cmd/gcp-controller-manager/dpwi/hms/BUILD
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "hms",
+    srcs = ["hms.go"],
+    importpath = "k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/dpwi/hms",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer",
+        "//vendor/k8s.io/apiserver/pkg/server/options",
+        "//vendor/k8s.io/apiserver/pkg/util/webhook",
+        "//vendor/k8s.io/client-go/rest",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api",
+    ],
+)

--- a/cmd/gcp-controller-manager/dpwi/serviceaccounts/BUILD
+++ b/cmd/gcp-controller-manager/dpwi/serviceaccounts/BUILD
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "serviceaccounts",
+    srcs = ["types.go"],
+    importpath = "k8s.io/cloud-provider-gcp/cmd/gcp-controller-manager/dpwi/serviceaccounts",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
We plan to refactor DPWI (Direct Path via ALTS with Workload Identity). The new code path will be inside a new folder "dpwi". To mitigate the migration risk, we will keep the old code path and use a flag to switch the old/new code path.

Git doesn't support copy. To preserve the git history, I followed [Record file copy operation with Git](https://stackoverflow.com/questions/1043388/record-file-copy-operation-with-git/46484848#46484848) and achieved it with 4 steps (commits).

* [Move DPWI related code from main into the folder dpwi](https://github.com/kubernetes/cloud-provider-gcp/commit/27f6096386527b12f1a2bd67e2f9b300587a3f51)
* [Restore DPWI related code in main package](https://github.com/kubernetes/cloud-provider-gcp/commit/7ae46bf7040a7657603e8b83ae7ac2bf01bdf63d)
* [Merge branch to include all DPWI related code from step 1 and 2](https://github.com/kubernetes/cloud-provider-gcp/commit/06b43c04d2ee9b99310e00ed7fa23a63a20a1c6c)
* [make new dpwi code buildable](https://github.com/kubernetes/cloud-provider-gcp/commit/3b66843e81e13d4d5ec1620b5322d5425857b37c)

For approvers, please preserve all the commits when merging. Thanks.