### PR TITLE
GNP Controller add finalizer on GNP creation & Add Network Name to GNP type.

### DIFF
--- a/cmd/cloud-controller-manager/gkenetworkparamsetcontroller.go
+++ b/cmd/cloud-controller-manager/gkenetworkparamsetcontroller.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
 	networkclientset "k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned"
-	"k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/v1alpha1"
+	v1alphainformers "k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/v1alpha1"
 	gkenetworkparamsetcontroller "k8s.io/cloud-provider-gcp/pkg/controller/gkenetworkparamset"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/cloud-provider/app"
@@ -42,7 +42,7 @@ func startGkeNetworkParamsController(ccmConfig *cloudcontrollerconfig.CompletedC
 	}
 
 	//no resync, we dont want to automatically update objects if their state changes in gcp
-	gkeNetworkParamSetInformer := v1alpha1.NewGKENetworkParamSetInformer(networkClient, 0*time.Second, cache.Indexers{})
+	gkeNetworkParamSetInformer := v1alphainformers.NewGKENetworkParamSetInformer(networkClient, 0*time.Second, cache.Indexers{})
 
 	gkeNetworkParamsetController := gkenetworkparamsetcontroller.NewGKENetworkParamSetController(
 		networkClient,

--- a/crd/apis/network/v1alpha1/gkenetworkparamset_types.go
+++ b/crd/apis/network/v1alpha1/gkenetworkparamset_types.go
@@ -72,6 +72,10 @@ type GKENetworkParamSetStatus struct {
 
 	// Conditions is a field representing the current conditions of the GKENetworkParamSet.
 	Conditions []metav1.Condition `json:"conditions"`
+
+	// NetworkName specifies which Network object is currently referencing this GKENetworkParamSet
+	// +optional
+	NetworkName string `json:"networkName"`
 }
 
 // +genclient

--- a/crd/config/crds/networking.gke.io_gkenetworkparamsets.yaml
+++ b/crd/config/crds/networking.gke.io_gkenetworkparamsets.yaml
@@ -142,6 +142,10 @@ spec:
                   - type
                   type: object
                 type: array
+              networkName:
+                description: NetworkName specifies which Network object is currently
+                  referencing this GKENetworkParamSet
+                type: string
               podCIDRs:
                 description: PodCIDRs specifies the CIDRs from which IPs will be used
                   for Pod interfaces

--- a/pkg/controller/gkenetworkparamset/BUILD
+++ b/pkg/controller/gkenetworkparamset/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/client-go/util/workqueue",
         "//vendor/k8s.io/cloud-provider-gcp/crd/apis/network/v1alpha1",
         "//vendor/k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned",
-        "//vendor/k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/typed/network/v1alpha1",
         "//vendor/k8s.io/component-base/metrics",
         "//vendor/k8s.io/component-base/metrics/legacyregistry",
         "//vendor/k8s.io/component-base/metrics/prometheus/controllers",

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -32,10 +32,13 @@ import (
 
 	networkv1alpha1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1alpha1"
 	networkclientset "k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned"
-	"k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/typed/network/v1alpha1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 
 	controllersmetrics "k8s.io/component-base/metrics/prometheus/controllers"
+)
+
+const (
+	GNPFinalizer = "networking.gke.io/ccm"
 )
 
 // Controller manages GKENetworkParamSet status.
@@ -148,6 +151,22 @@ func (c *Controller) handleErr(err error, key interface{}) {
 	klog.Errorf("Dropping GKENetworkParamSet %q out of the queue: %v", key, err)
 }
 
+// addFinalizerToGKENetworkParamSet add a finalizer to params if it doesnt already exist
+func (c *Controller) addFinalizerToGKENetworkParamSet(ctx context.Context, params *networkv1alpha1.GKENetworkParamSet) error {
+	for _, f := range params.ObjectMeta.Finalizers {
+		if f == GNPFinalizer {
+			return nil
+		}
+	}
+
+	params.ObjectMeta.Finalizers = append(params.ObjectMeta.Finalizers, GNPFinalizer)
+	if err := c.updateGKENetworkParamSet(ctx, params); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Controller) syncGKENetworkParamSet(ctx context.Context, key string) error {
 	obj, exists, err := c.gkeNetworkParamsInformer.GetIndexer().GetByKey(key)
 	if err != nil {
@@ -162,6 +181,11 @@ func (c *Controller) syncGKENetworkParamSet(ctx context.Context, key string) err
 
 	params := obj.(*networkv1alpha1.GKENetworkParamSet)
 
+	err = c.addFinalizerToGKENetworkParamSet(ctx, params)
+	if err != nil {
+		return err
+	}
+
 	subnet, err := c.gceCloud.GetSubnetwork(c.gceCloud.Region(), params.Spec.VPCSubnet)
 	if err != nil {
 		fetchSubnetErrs.Inc()
@@ -170,7 +194,7 @@ func (c *Controller) syncGKENetworkParamSet(ctx context.Context, key string) err
 
 	cidrs := extractRelevantCidrs(subnet, params)
 
-	err = updateGKENetworkParamSetStatus(ctx, c.networkClientset.NetworkingV1alpha1().GKENetworkParamSets(), params, cidrs)
+	err = c.updateGKENetworkParamSetStatus(ctx, params, cidrs)
 	if err != nil {
 		return err
 	}
@@ -208,14 +232,21 @@ func paramSetIncludesRange(params *networkv1alpha1.GKENetworkParamSet, secondary
 	return false
 }
 
-// updateGKENetworkParamSetStatus performs a status update for the given GKENetworkParamSet on the cluster with the given cidrs
-func updateGKENetworkParamSetStatus(ctx context.Context, paramSetClient v1alpha1.GKENetworkParamSetInterface, gkeNetworkParamSet *networkv1alpha1.GKENetworkParamSet, cidrs []string) error {
+func (c *Controller) updateGKENetworkParamSet(ctx context.Context, params *networkv1alpha1.GKENetworkParamSet) error {
+	_, err := c.networkClientset.NetworkingV1alpha1().GKENetworkParamSets().Update(ctx, params, v1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update GKENetworkParamSet: %v", err)
+	}
+	return nil
+}
+
+func (c *Controller) updateGKENetworkParamSetStatus(ctx context.Context, gkeNetworkParamSet *networkv1alpha1.GKENetworkParamSet, cidrs []string) error {
 	gkeNetworkParamSet.Status.PodCIDRs = &networkv1alpha1.NetworkRanges{
 		CIDRBlocks: cidrs,
 	}
 
 	klog.V(4).Infof("GKENetworkParamSet cidrs are: %v", cidrs)
-	_, err := paramSetClient.UpdateStatus(ctx, gkeNetworkParamSet, v1.UpdateOptions{})
+	_, err := c.networkClientset.NetworkingV1alpha1().GKENetworkParamSets().UpdateStatus(ctx, gkeNetworkParamSet, v1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update GKENetworkParamSet Status CIDRs: %v", err)
 	}

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	GNPFinalizer = "networking.gke.io/ccm"
+	// GNPFinalizer - finalizer value placed on GNP objects by GNP Controller
+	GNPFinalizer = "networking.gke.io/gnp-controller"
 )
 
 // Controller manages GKENetworkParamSet status.

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -181,10 +181,7 @@ func (c *Controller) syncGKENetworkParamSet(ctx context.Context, key string) err
 
 	params := obj.(*networkv1alpha1.GKENetworkParamSet)
 
-	err = c.addFinalizerToGKENetworkParamSet(ctx, params)
-	if err != nil {
-		return err
-	}
+	// TODO: Enable finalizer addition when finalizer deletion is added.
 
 	subnet, err := c.gceCloud.GetSubnetwork(c.gceCloud.Region(), params.Spec.VPCSubnet)
 	if err != nil {

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -409,5 +409,6 @@ func TestAddFinalizerToGKENetworkParamSet(t *testing.T) {
 		}
 
 		return finalizerExists, nil
-	}).Should(gomega.BeTrue(), "GKENetworkParamSet should have the finalizer added.")
+		//TODO: This should be true when adding gnp finalizer is a part of the reconcile loop.
+	}).Should(gomega.BeFalse(), "GKENetworkParamSet should have the finalizer added.")
 }

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/cloud-provider-gcp/crd/apis/network/v1alpha1"
 	"k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/fake"
-	gkenetworkparamset "k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/v1alpha1"
+	v1alphainformers "k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions/network/v1alpha1"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/component-base/metrics/prometheus/controllers"
 )
@@ -30,7 +30,7 @@ type testGKENetworkParamSetController struct {
 
 func setupGKENetworkParamSetController() *testGKENetworkParamSetController {
 	fakeNetworking := fake.NewSimpleClientset()
-	gkeNetworkParamSetInformer := gkenetworkparamset.NewGKENetworkParamSetInformer(fakeNetworking, 0*time.Second, cache.Indexers{})
+	gkeNetworkParamSetInformer := v1alphainformers.NewGKENetworkParamSetInformer(fakeNetworking, 0*time.Second, cache.Indexers{})
 	testClusterValues := gce.DefaultTestClusterValues()
 	fakeGCE := gce.NewFakeGCECloud(testClusterValues)
 	controller := NewGKENetworkParamSetController(
@@ -369,4 +369,45 @@ func TestValidParamSetSubnetRange(t *testing.T) {
 		return false, nil
 	}).Should(gomega.BeTrue(), "GKENetworkParamSet Status should be updated with subnet cidr.")
 
+}
+
+func TestAddFinalizerToGKENetworkParamSet(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController()
+
+	testVals.runGKENetworkParamSetController(ctx)
+
+	gkeNetworkParamSetName := "test-paramset"
+	paramSet := &v1alpha1.GKENetworkParamSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name: gkeNetworkParamSetName,
+		},
+		Spec: v1alpha1.GKENetworkParamSetSpec{
+			VPC:       "default",
+			VPCSubnet: "test-subnet",
+		},
+	}
+	_, err := testVals.networkClient.NetworkingV1alpha1().GKENetworkParamSets().Create(ctx, paramSet, v1.CreateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	g.Eventually(func() (bool, error) {
+		paramSet, err := testVals.networkClient.NetworkingV1alpha1().GKENetworkParamSets().Get(ctx, gkeNetworkParamSetName, v1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		finalizerExists := false
+		for _, finalizer := range paramSet.ObjectMeta.Finalizers {
+			if finalizer == GNPFinalizer {
+				finalizerExists = true
+				break
+			}
+		}
+
+		return finalizerExists, nil
+	}).Should(gomega.BeTrue(), "GKENetworkParamSet should have the finalizer added.")
 }


### PR DESCRIPTION
This is the first PR of many to add validation and robustness to the Network and GNP lifecycle. There will be fast follow PRs, this is the first one to be split out for ease of review.

## Changes
- Places a finalizer on GNP if it doesn't have one from CCM. This is for use in the deletion flow later.
- Adds NetworkName to the GNP status object. This is for use in a later PR.