### PR TITLE
disable gkenetworkparamset controller by default

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	controllerInitializers := app.DefaultInitFuncConstructors
 
+	// add new controllers and initializers
 	nodeIpamController := nodeIPAMController{}
 	nodeIpamController.nodeIPAMControllerOptions.NodeIPAMControllerConfiguration = &nodeIpamController.nodeIPAMControllerConfiguration
 	fss := cliflag.NamedFlagSets{}
@@ -62,6 +63,9 @@ func main() {
 	controllerInitializers["gkenetworkparamset"] = app.ControllerInitFuncConstructor{
 		Constructor: startGkeNetworkParamSetControllerWrapper,
 	}
+
+	// add controllers disabled by default
+	app.ControllersDisabledByDefault.Insert("gkenetworkparamset")
 
 	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, controllerInitializers, fss, wait.NeverStop)
 


### PR DESCRIPTION
With this changes
```
     --controllers strings                                                                                                                                                
                A list of controllers to enable. '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named
                'foo'.
                All controllers: cloud-node, cloud-node-lifecycle, gkenetworkparamset, nodeipam, route, service
                Disabled-by-default controllers: gkenetworkparamset (default [*])
```

Fixes: https://github.com/kubernetes/cloud-provider-gcp/issues/459
