### PR TITLE
Adding API support for nic-info annotation

### DIFF
--- a/crd/apis/network/v1/annotations.go
+++ b/crd/apis/network/v1/annotations.go
@@ -44,6 +44,8 @@ const (
 	AutoGenAnnotationValTrue = "true"
 	// NorthInterfacesAnnotationKey is the annotation key used to hold interfaces data per node.
 	NorthInterfacesAnnotationKey = "networking.gke.io/north-interfaces"
+	// NICInfoAnnotationKey specifies the mapping between the fist IP addresse and the PCI BDF number on the node.
+	NICInfoAnnotationKey = "networking.gke.io/nic-info"
 )
 
 // InterfaceAnnotation is the value of the interface annotation.
@@ -62,6 +64,22 @@ type InterfaceRef struct {
 	Network *string `json:"network,omitempty"`
 	// Interface reference the NetworkInterface object within the namespace.
 	Interface *string `json:"interface,omitempty"`
+}
+
+// NICInfoAnnotation is the value of the nic-info annotation
+// +kubebuilder:object:generate:=false
+type NICInfoAnnotation []NICInfoRef
+
+// NICInfoRef specifies the mapping between a NIC's first IP and its
+// PCI address on the node.
+// +kubebuilder:object:generate:=false
+type NICInfoRef struct {
+	// First IP address of the interface.
+	BirthIP string `json:"birthIP,omitempty"`
+	// PCI address of this device on the node.
+	PCIAddress string `json:"pciAddress,omitempty"`
+	// Name is the birth name of this interface at node boot time.
+	BirthName string `json:"birthName,omitempty"`
 }
 
 // ParseInterfaceAnnotation parses the given annotation.
@@ -168,6 +186,13 @@ func ParseNorthInterfacesAnnotation(annotation string) (NorthInterfacesAnnotatio
 	return *ret, err
 }
 
+// ParseNICInfoAnnotation parses given annotation to NicInfoAnnotation
+func ParseNICInfoAnnotation(annotation string) (NICInfoAnnotation, error) {
+	ret := &NICInfoAnnotation{}
+	err := json.Unmarshal([]byte(annotation), ret)
+	return *ret, err
+}
+
 // MarshalNodeNetworkAnnotation marshals a NodeNetworkAnnotation into string.
 func MarshalNodeNetworkAnnotation(a NodeNetworkAnnotation) (string, error) {
 	return MarshalAnnotation(a)
@@ -175,5 +200,10 @@ func MarshalNodeNetworkAnnotation(a NodeNetworkAnnotation) (string, error) {
 
 // MarshalNorthInterfacesAnnotation marshals a NorthInterfacesAnnotation into string.
 func MarshalNorthInterfacesAnnotation(a NorthInterfacesAnnotation) (string, error) {
+	return MarshalAnnotation(a)
+}
+
+// MarshalNICInfoAnnotation marshals a NICInfoAnnotation into string.
+func MarshalNICInfoAnnotation(a NICInfoAnnotation) (string, error) {
 	return MarshalAnnotation(a)
 }

--- a/crd/apis/network/v1/annotations_test.go
+++ b/crd/apis/network/v1/annotations_test.go
@@ -219,3 +219,51 @@ func TestParseNorthInterfacesAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNICInfoAnnotation(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    NICInfoAnnotation
+		expected string
+	}{
+		{
+			name:     "nil",
+			input:    nil,
+			expected: "null",
+		},
+		{
+			name:     "empty list",
+			input:    NICInfoAnnotation{},
+			expected: "[]",
+		},
+		{
+			name: "list with items",
+			input: NICInfoAnnotation{
+				{BirthIP: "10.0.0.1", PCIAddress: "0000:00:05.0", BirthName: "eth1"},
+				{BirthIP: "20.0.0.1", PCIAddress: "0000:00:06.0", BirthName: "eth2"},
+			},
+			expected: `[{"birthIP":"10.0.0.1","pciAddress":"0000:00:05.0","birthName":"eth1"},{"birthIP":"20.0.0.1","pciAddress":"0000:00:06.0","birthName":"eth2"}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			marshalled, err := MarshalAnnotation(tc.input)
+			if err != nil {
+				t.Fatalf("MarshalAnnotation(%+v) failed with error: %v", tc.input, err)
+			}
+			if marshalled != tc.expected {
+				t.Fatalf("MarshalAnnotation(%+v) returns %q but want %q", tc.input, marshalled, tc.expected)
+			}
+
+			parsed, err := ParseNICInfoAnnotation(marshalled)
+			if err != nil {
+				t.Fatalf("ParseNICInfoAnnotation(%s) failed with error: %v", marshalled, err)
+			}
+
+			if diff := cmp.Diff(parsed, tc.input); diff != "" {
+				t.Fatalf("ParseNICInfoAnnotation(%s)  returns diff: (-got +want): %s", marshalled, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding API support for nic-info annotation. nic-info holds the mapping between the NIC's first v4 IP and its PCI address on the node, along with interface's birth name.