### PR TITLE
use the tag version to build the images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
     env:
     - IMAGE_REGISTRY=gcr.io
     - IMAGE_REPO=k8s-staging-cloud-provider-gcp
-    - IMAGE_TAG=$SHORT_SHA
+    - IMAGE_TAG=$_PULL_BASE_REF
     args:
       - run
       - //cmd/cloud-controller-manager:publish


### PR DESCRIPTION
This allows to build images and tag them with the released version

https://github.com/kubernetes/test-infra/blob/4b2a5cedb3ce0a2ef1148e1831cad5d48334258a/config/jobs/image-pushing/README.md?plain=1#L35-L38

> `_PULL_BASE_REF` will contain the base ref that was pushed to - for instance,
`master` or `release-0.2` for a PR merge, or `v0.2` for a tag. You can use this
for logic in your build process (like deciding whether to update `latest`) if
desired.