### PR TITLE
don't build auth-provider-gcp iamges

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -19,14 +19,6 @@ steps:
     - IMAGE_TAG=${_PULL_BASE_REF}
     args:
       - run
-      - //cmd/auth-provider-gcp:publish
-  - name: 'gcr.io/cloud-builders/bazel'
-    env:
-    - IMAGE_REGISTRY=gcr.io
-    - IMAGE_REPO=k8s-staging-cloud-provider-gcp
-    - IMAGE_TAG=${_PULL_BASE_REF}
-    args:
-      - run
       - //cmd/gcp-controller-manager:publish
   - name: 'gcr.io/cloud-builders/bazel'
     env:


### PR DESCRIPTION
it only allows to build a binary `bazel build //cmd/auth-provider-gcp`

it makes the job to fail https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cloud-provider-gcp-push-images/1660778860817420288