### PR TITLE
fix cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,10 +41,10 @@ steps:
     args:
       - build
       - //cmd/auth-provider-gcp
-  # upload auth-provider-gcp binary
-    artifacts:
-      objects:
-        location: 'gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp-linux-amd64#$_PULL_BASE_REF'
-        paths: ['bazel-bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp']
+# upload auth-provider-gcp binary
+artifacts:
+  objects:
+    location: 'gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp-linux-amd64#$_PULL_BASE_REF'
+    paths: ['bazel-bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp']
 substitutions:
   _PULL_BASE_REF: 'master'


### PR DESCRIPTION
Artifacts is a global option


https://cloud.google.com/build/docs/building/store-artifacts-in-cloud-storage

the job fails because the current config is wrong https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cloud-provider-gcp-push-images/1660833522828447744