### PR TITLE
Additional fixes for Multi-Network handling.

### DIFF
--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -128,9 +128,13 @@ func updateAnnotations(node *v1.Node, northInterfaces networkv1.NorthInterfacesA
 		node.Annotations = make(map[string]string)
 	}
 	node.Annotations[networkv1.NorthInterfacesAnnotationKey] = northInterfaceAnn
+	capacity, err := allocateIPCapacity(node, additionalNodeNetworks)
+	if err != nil {
+		return err
+	}
+	node.Status.Capacity = capacity
 	node.Annotations[networkv1.MultiNetworkAnnotationKey] = additionalNodeNwAnn
-	node.Status.Capacity, err = allocateIPCapacity(node, additionalNodeNetworks)
-	return err
+	return nil
 }
 
 // allocateIPCapacity updates the extended IP resource capacity for every non-default network on the node.

--- a/pkg/util/node/BUILD
+++ b/pkg/util/node/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:meta",
         "//vendor/k8s.io/apimachinery/pkg/types",
         "//vendor/k8s.io/client-go/kubernetes",
+        "//vendor/k8s.io/cloud-provider-gcp/crd/apis/network/v1:network",
         "//vendor/k8s.io/klog/v2:klog",
     ],
 )

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/klog/v2"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
+	networkv1 "k8s.io/cloud-provider-gcp/crd/apis/network/v1"
+	"k8s.io/klog/v2"
 )
 
 type nodeForConditionPatch struct {
@@ -95,13 +95,25 @@ func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) 
 
 // PatchNodeMultiNetwork patches the Node's annotations and capacity for MN.
 func PatchNodeMultiNetwork(c clientset.Interface, node *v1.Node) error {
+	annotation := make(map[string]string)
+	if val, ok := node.Annotations[networkv1.NorthInterfacesAnnotationKey]; ok {
+		annotation[networkv1.NorthInterfacesAnnotationKey] = val
+	}
+	if val, ok := node.Annotations[networkv1.MultiNetworkAnnotationKey]; ok {
+		annotation[networkv1.MultiNetworkAnnotationKey] = val
+	}
+
+	if len(annotation) > 0 {
+		raw, err := json.Marshal(annotation)
+		if err != nil {
+			return fmt.Errorf("failed to build patch bytes for multi-networking: %w", err)
+		}
+		if _, err := c.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw)), metav1.PatchOptions{}); err != nil {
+			return fmt.Errorf("unable to apply patch for multi-network annotation: %v", err)
+		}
+	}
 	// Prepare patch bytes for the node update.
 	patchBytes, err := json.Marshal([]interface{}{
-		map[string]interface{}{
-			"op":    "replace",
-			"path":  "/metadata/annotations",
-			"value": node.Annotations,
-		},
 		map[string]interface{}{
 			"op":    "add",
 			"path":  "/status/capacity",


### PR DESCRIPTION
* Updated event triggers for Network updates to handle the new Conditions introduced. When Condition Ready becomes `true` it should be treated same as Network added.
* Small update to when we update the Node for network annotation and Capacity, it should only be done when there are no errors.
* changed API updates for annotations, separated from Capacity updates, and created additional API call so that we could perform StrategicMergePatchType for annotations.