### PR TITLE
update go version to 1.20.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.20.4",
+    version = "1.20.5",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
1.20.5 has fixes for CVE-2023-29402 CVE-2023-29403 CVE-2023-29404 CVE-2023-29405