### PR TITLE
Fix ClusterRole Resource Pluralization

### DIFF
--- a/deploy/cloud-node-controller-role.yaml
+++ b/deploy/cloud-node-controller-role.yaml
@@ -8,15 +8,15 @@ rules:
 - apiGroups:
   - networking.gke.io
   resources:
-  - network
+  - networks
   verbs:
   - get
 - apiGroups:
   - networking.gke.io
   resources:
-  - network/status
-  - gkenetworkparamset
-  - gkenetworkparamset/status
+  - networks/status
+  - gkenetworkparamsets
+  - gkenetworkparamsets/status
   verbs:
   - update
   - get


### PR DESCRIPTION
ClusterRole resources should be plural forms, they were singular.