### PR TITLE
Return NetworkProjectID() as a project ID for Subnetworks resource

### DIFF
--- a/providers/gce/support.go
+++ b/providers/gce/support.go
@@ -34,7 +34,7 @@ type gceProjectRouter struct {
 // ProjectID returns the project ID to be used for the given operation.
 func (r *gceProjectRouter) ProjectID(ctx context.Context, version meta.Version, service string) string {
 	switch service {
-	case "Firewalls", "Routes":
+	case "Firewalls", "Routes", "Subnetworks":
 		return r.gce.NetworkProjectID()
 	default:
 		return r.gce.projectID


### PR DESCRIPTION
I added simple call to Subnetworks.Get to ingress-gce https://github.com/kubernetes/ingress-gce/blob/4e0e607834fd40a18d74e9241ba0a28e237f1875/pkg/utils/utils.go#L934 and found on tests that it fails on xpn scenario. Which makes sense -- project id of subnetwork in case of XPN is different, than just project ID

Looks like we never called Subnetworks.Get before (at least I could not find usages)

This PR should fix this, and give ability to get Subnetwork from the NetworkProject

