### PR TITLE
update go version to 1.20.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.20.5",
+    version = "1.20.6",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
fixes [CVE-2023-29406](https://security-tracker.debian.org/tracker/CVE-2023-29406)

/cc @aojea 
/cc @mikedanese 