### PR TITLE
Bump Go version to 1.20.7

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.20.6",
+    version = "1.20.7",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
Addresses CVE-2023-39533 and CVE-2023-29409, although neither seem to be exploitable within the context of the GKE components in this repo.