### PR TITLE
Simple build scripts for cloud-controller-manager

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,44 @@
+defaultPlatforms:
+- linux/arm64
+- linux/amd64
+
+builds:
+- id: cloud-controller-manager
+  dir: .
+  main: cmd/cloud-controller-manager
+  ldflags:
+  - -X k8s.io/component-base/version/verflag.programName=cloud-controller-manager
+
+  - -X k8s.io/component-base/version.buildDate={{.Env.BUILD_DATE}}
+  - -X k8s.io/component-base/version.gitCommit={{.Env.KUBE_GIT_COMMIT}}
+  - -X k8s.io/component-base/version.gitMajor={{.Env.KUBE_GIT_MAJOR}}
+  - -X k8s.io/component-base/version.gitMinor={{.Env.KUBE_GIT_MINOR}}
+  - -X k8s.io/component-base/version.gitTreeState={{.Env.KUBE_GIT_TREE_STATE}}
+  - -X k8s.io/component-base/version.gitVersion={{.Env.KUBE_GIT_VERSION}}
+
+  - -X k8s.io/client-go/pkg/version.buildDate={{.Env.BUILD_DATE}}
+  - -X k8s.io/client-go/pkg/version.gitCommit={{.Env.KUBE_GIT_COMMIT}}
+  - -X k8s.io/client-go/pkg/version.gitMajor={{.Env.KUBE_GIT_MAJOR}}
+  - -X k8s.io/client-go/pkg/version.gitMinor={{.Env.KUBE_GIT_MINOR}}
+  - -X k8s.io/client-go/pkg/version.gitTreeState={{.Env.KUBE_GIT_TREE_STATE}}
+  - -X k8s.io/client-go/pkg/version.gitVersion={{.Env.KUBE_GIT_VERSION}}
+
+- id: gcp-controller-manager
+  dir: .
+  main: cmd/gcp-controller-manager
+  ldflags:
+  - -X k8s.io/component-base/version/verflag.programName=gcp-controller-manager
+
+  - -X k8s.io/component-base/version.buildDate={{.Env.BUILD_DATE}}
+  - -X k8s.io/component-base/version.gitCommit={{.Env.KUBE_GIT_COMMIT}}
+  - -X k8s.io/component-base/version.gitMajor={{.Env.KUBE_GIT_MAJOR}}
+  - -X k8s.io/component-base/version.gitMinor={{.Env.KUBE_GIT_MINOR}}
+  - -X k8s.io/component-base/version.gitTreeState={{.Env.KUBE_GIT_TREE_STATE}}
+  - -X k8s.io/component-base/version.gitVersion={{.Env.KUBE_GIT_VERSION}}
+
+  - -X k8s.io/client-go/pkg/version.buildDate={{.Env.BUILD_DATE}}
+  - -X k8s.io/client-go/pkg/version.gitCommit={{.Env.KUBE_GIT_COMMIT}}
+  - -X k8s.io/client-go/pkg/version.gitMajor={{.Env.KUBE_GIT_MAJOR}}
+  - -X k8s.io/client-go/pkg/version.gitMinor={{.Env.KUBE_GIT_MINOR}}
+  - -X k8s.io/client-go/pkg/version.gitTreeState={{.Env.KUBE_GIT_TREE_STATE}}
+  - -X k8s.io/client-go/pkg/version.gitVersion={{.Env.KUBE_GIT_VERSION}}

--- a/tools/common
+++ b/tools/common
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd ${REPO_ROOT}
+cd ..
+WORKSPACE=$(pwd)
+cd ${REPO_ROOT}
+
+# Create bindir
+BINDIR=${WORKSPACE}/bin
+export PATH=${BINDIR}:${PATH}
+mkdir -p "${BINDIR}"
+
+export KUBE_ROOT=${REPO_ROOT}
+source "${REPO_ROOT}/tools/version.sh"
+get_version_vars
+unset KUBE_ROOT
+export KUBE_GIT_COMMIT
+export KUBE_GIT_MAJOR
+export KUBE_GIT_MINOR
+export KUBE_GIT_TREE_STATE
+export KUBE_GIT_VERSION
+
+BUILD_DATE=$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')
+export BUILD_DATE

--- a/tools/push-images
+++ b/tools/push-images
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+source $(git rev-parse --show-toplevel)/tools/common
+
+# IMAGE_REPO is used to upload images
+if [[ -z "${IMAGE_REPO:-}" ]]; then
+  echo "IMAGE_REPO must be set"
+  exit 1
+fi
+echo "IMAGE_REPO=${IMAGE_REPO}"
+export KO_DOCKER_REPO="${IMAGE_REPO}"
+
+# We default IMAGE_TAG to a unique value that combines the sha and the (real) build date
+if [[ -z "${IMAGE_TAG:-}" ]]; then
+  IMAGE_TAG=$(git rev-parse --short HEAD)-$(date +%Y%m%dT%H%M%S)
+fi
+echo "IMAGE_TAG=${IMAGE_TAG}"
+
+go run github.com/google/ko@v0.14.1 build --tags=${IMAGE_TAG} --base-import-paths --push=true ./cmd/cloud-controller-manager/
+go run github.com/google/ko@v0.14.1 build --tags=${IMAGE_TAG} --base-import-paths --push=true ./cmd/gcp-controller-manager/


### PR DESCRIPTION
As a safe way of removing bazel, start creating a parallel build
environment that is more amenable to the normal k8s release process.
