### PR TITLE
Use simpler build in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,22 +4,11 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: 'golang:1.20.8'
     env:
-      - IMAGE_REGISTRY=gcr.io
-      - IMAGE_REPO=k8s-staging-cloud-provider-gcp
+      - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}
-    args:
-      - run
-      - //cmd/cloud-controller-manager:publish
-  - name: 'gcr.io/cloud-builders/bazel'
-    env:
-      - IMAGE_REGISTRY=gcr.io
-      - IMAGE_REPO=k8s-staging-cloud-provider-gcp
-      - IMAGE_TAG=${_PULL_BASE_REF}
-    args:
-      - run
-      - //cmd/gcp-controller-manager:publish
+    entrypoint: tools/push-images
   # build gke-exec-auth-plugin binary
   - name: 'gcr.io/cloud-builders/bazel'
     args:
@@ -138,4 +127,4 @@ steps:
 substitutions:
   _PULL_BASE_REF: 'master'
   _GIT_TAG: '12345'
-  
+  _IMAGE_REPO: 'gcr.io/k8s-staging-cloud-provider-gcp'


### PR DESCRIPTION
This plugs in our simpler (bazel-free) scripts into the release build.