### PR TITLE
Bump go to 1.20.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.20.7",
+    version = "1.20.8",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
Ensure that (overzealous) scanners stay quiet.
