### PR TITLE
cloudAllocator ipv6 only ipam

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -282,6 +282,45 @@ func TestUpdateCIDRAllocation(t *testing.T) {
 			expectedUpdate: true,
 		},
 		{
+			name: "ipv6 single stack",
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+						},
+						Spec: v1.NodeSpec{
+							ProviderID: "gce://test-project/us-central1-b/test",
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},
+			gceInstance: []*compute.Instance{
+				{
+					Name: "test",
+					NetworkInterfaces: []*compute.NetworkInterface{
+						{
+							Ipv6Address: "2001:db9::110",
+						},
+					},
+				},
+			},
+			nodeChanges: func(node *v1.Node) {
+				node.Spec.PodCIDR = "2001:db9::/112"
+				node.Spec.PodCIDRs = []string{"2001:db9::/112"}
+				node.Status.Conditions = []v1.NodeCondition{
+					{
+						Type:    "NetworkUnavailable",
+						Status:  "False",
+						Reason:  "RouteCreated",
+						Message: "NodeController create implicit route",
+					},
+				}
+			},
+			expectedUpdate: true,
+		},
+		{
 			name: "want error - incorrect cidr",
 			fakeNodeHandler: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{


### PR DESCRIPTION
Add support for IPv6 only Nodes to the CloudAllocator IPAM controller

Change-Id: Ibaaefb7024e83fe0b5a16b1519aa7acd918027ac