### PR TITLE
Skip the VPC validation for XPN clusters in GNP controller

### DIFF
--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -83,13 +83,15 @@ func (c *Controller) validateGKENetworkParamSet(ctx context.Context, params *net
 		}, nil
 	}
 
-	network, err := c.gceCloud.GetNetwork(params.Spec.VPC)
-	if err != nil || network == nil {
-		return &gnpValidation{
-			IsValid:      false,
-			ErrorReason:  networkv1.VPCNotFound,
-			ErrorMessage: fmt.Sprintf("VPC: %s not found", params.Spec.VPC),
-		}, nil
+	if !c.gceCloud.OnXPN() {
+		network, err := c.gceCloud.GetNetwork(params.Spec.VPC)
+		if err != nil || network == nil {
+			return &gnpValidation{
+				IsValid:      false,
+				ErrorReason:  networkv1.VPCNotFound,
+				ErrorMessage: fmt.Sprintf("VPC: %s not found", params.Spec.VPC),
+			}, nil
+		}
 	}
 
 	//check if both deviceMode and secondary ranges are unspecified

--- a/providers/gce/support.go
+++ b/providers/gce/support.go
@@ -34,7 +34,7 @@ type gceProjectRouter struct {
 // ProjectID returns the project ID to be used for the given operation.
 func (r *gceProjectRouter) ProjectID(ctx context.Context, version meta.Version, service string) string {
 	switch service {
-	case "Firewalls", "Routes", "Subnetworks":
+	case "Firewalls", "Routes", "Subnetworks", "Networks":
 		return r.gce.NetworkProjectID()
 	default:
 		return r.gce.projectID


### PR DESCRIPTION
CCM does not have the compute.networks.get permission for the host network. This causes the validation to fail on the GCE call. This can be ignored for XPN clusters