### PR TITLE
Support owner references that point directly to instanceGroupManagers.

### DIFF
--- a/cmd/gcp-controller-manager/node_csr_approver.go
+++ b/cmd/gcp-controller-manager/node_csr_approver.go
@@ -743,9 +743,11 @@ func checkInstanceReferrers(ctx *controllerContext, instance *compute.Instance, 
 	for _, ig := range clusterInstanceGroupUrls {
 		// GKE's cluster.NodePools[].instanceGroupUrls are of the form:
 		// https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instanceGroupManagers/instance-group-1.
-		// Where as instance referrers are of the form:
+		// Where as instance referrers are one of the forms:
+		// https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instanceGroupManagers/instance-group-1.
 		// https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instanceGroups/instance-group-1.
-		// With the string replace below we convert them to the same form.
+		// We pass the string as it is for the first kind and use a string replace below we convert them to the second form.
+		clusterInstanceGroupMap[ig] = true
 		clusterInstanceGroupMap[strings.Replace(ig, "/instanceGroupManagers/", "/instanceGroups/", 1)] = true
 	}
 

--- a/cmd/gcp-controller-manager/node_csr_approver_test.go
+++ b/cmd/gcp-controller-manager/node_csr_approver_test.go
@@ -1462,6 +1462,29 @@ func TestCheckInstanceReferrersBackOff(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			desc: "match found for instanceGroupManagers",
+			clusterInstanceGroupUrls: []string{
+				"https://www.googleapis.com/compute/v1/projects/p1/zones/z1/instanceGroupManagers/ig1",
+			},
+			instance: &compute.Instance{
+				Name: "i1",
+				Zone: "https://www.googleapis.com/compute/v1/projects/p1/zones/z1",
+			},
+			projectID: "z1",
+			gceClientHandler: func() func(rw http.ResponseWriter, req *http.Request) {
+				return func(rw http.ResponseWriter, req *http.Request) {
+					json.NewEncoder(rw).Encode(compute.InstanceListReferrers{
+						Items: []*compute.Reference{
+							{
+								Referrer: "https://www.googleapis.com/compute/v1/projects/p1/zones/z1/instanceGroupManagers/ig1",
+							},
+						},
+					})
+				}
+			},
+			wantOK: true,
+		},
+		{
 			desc: "match not found",
 			clusterInstanceGroupUrls: []string{
 				"https://www.googleapis.com/compute/v1/projects/p1/zones/z1/instanceGroupManagers/ig1",


### PR DESCRIPTION
Support owner references that point directly to the `instanceGroupManagers` objects in the API.