### PR TITLE
Configure Dependabot for automatic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,66 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: /cluster/gce/gci/mounter
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+- package-ecosystem: docker
+  directory: /cluster/addons/addon-manager
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+- package-ecosystem: gomod
+  directory: /providers
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: gomod
+  directory: /crd
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*'
+- package-ecosystem: gomod
+  directory: /crd/hack
+  schedule:
+    interval: weekly
+  labels:
+  - 'area/dependency'
+  - 'release-note-none'
+  - 'ok-to-test'
+  groups:
+    gomod-dependencies:
+      patterns:
+      - '*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,4 +63,4 @@ updates:
   groups:
     gomod-dependencies:
       patterns:
-      - '*
+      - '*'


### PR DESCRIPTION
Enable Dependabot for Dockerfile and go.mod updates.
This will update images in Dockerfile `FROM` statements, and go modules.

The purpose is to drastically reduce number of vulnerabilities that affect this repo, 
by keeping dependencies up-to-date. 

This PR is created by a script. Please let me know if we should modify any values.