### PR TITLE
Add constants to Network CRD

### DIFF
--- a/crd/apis/network/v1/gkenetworkparamset_types.go
+++ b/crd/apis/network/v1/gkenetworkparamset_types.go
@@ -118,6 +118,9 @@ const (
 	// GNPParamsReady indicates that the referenced GNP resource
 	// has been successfully validated for use with this Network resource and ParamsReady=True
 	GNPParamsReady GNPNetworkParamsReadyConditionReason = "GNPParamsReady"
+	// GNPParamsNotReady indicates that the referenced GNP resource
+	// needs to be updated and triggers Network resource to update
+	GNPParamsNotReady GNPNetworkParamsReadyConditionReason = "GNPParamsNotReady"
 )
 
 // GKENetworkParamSetStatus contains the status information related to the network.


### PR DESCRIPTION
This PR is for supporting Multi Pod CIDR with Multi-networking clusters. 
GNP controller will use the added constants.