### PR TITLE
Update to go1.20.12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,8 @@ container_pull(
 
 container_pull(
     name = "go-runner",
-    digest = "sha256:07ae0b21ca58c7f11c80f3b25398a24be1cb5e691d934b6b8d934ff4ba5a65dd",
+    # this digest is actually go-runner-amd64
+    digest = "sha256:ff9d9b20255f11611cdcaf3ccd6f395ce2fa02a78c546ec93b4e06eb77359d46",
     registry = "registry.k8s.io",
     repository = "build-image/go-runner",
     # 'tag' is also supported, but digest is encouraged for reproducibility.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,7 +47,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.20.10",
+    version = "1.20.12",
 )
 
 go_register_toolchains()
@@ -77,11 +77,11 @@ container_pull(
 
 container_pull(
     name = "go-runner",
-    digest = "sha256:b564abe1d4bd3a7e227971530fbc8e3906671c94350706df5244c1deb6edcef4",
+    digest = "sha256:07ae0b21ca58c7f11c80f3b25398a24be1cb5e691d934b6b8d934ff4ba5a65dd",
     registry = "registry.k8s.io",
     repository = "build-image/go-runner",
     # 'tag' is also supported, but digest is encouraged for reproducibility.
-    tag = "v2.3.1-go1.20.4-bullseye.0",
+    tag = "v2.3.1-go1.20.12-bullseye.0",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'golang:1.20.10'
+  - name: 'golang:1.20.12'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}


### PR DESCRIPTION
Scanners detect, e.g., CVE-2023-45285 and CVE-2023-39326 in go1.20.10, irrespective of their applicability to this binary.