### PR TITLE
Update Node pod CIDR in ipam controller for for Multi Pod CIDR suppor…

### DIFF
--- a/pkg/controller/nodeipam/ipam/BUILD
+++ b/pkg/controller/nodeipam/ipam/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//pkg/controller/nodeipam/ipam/cidrset",
         "//pkg/controller/nodeipam/ipam/test",
         "//pkg/controller/testutil",
+        "//pkg/util/node",
         "//providers/gce",
         "//vendor/github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta",
         "//vendor/github.com/google/go-cmp/cmp",

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -311,13 +311,7 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 
 	cidrStrings := make([]string, 0)
 
-	// if there are no interfaces or there is 1 interface
-	// but does not have IP alias or IPv6 ranges no CIDR
-	// can be allocated
-	if len(instance.NetworkInterfaces) == 0 ||
-		(len(instance.NetworkInterfaces) == 1 &&
-			len(instance.NetworkInterfaces[0].AliasIpRanges) == 0 &&
-			ca.cloud.GetIPV6Address(instance.NetworkInterfaces[0]) == nil) {
+	if len(instance.NetworkInterfaces) == 0 || (len(instance.NetworkInterfaces) == 1 && len(instance.NetworkInterfaces[0].AliasIpRanges) == 0) {
 		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
 		return fmt.Errorf("failed to allocate cidr: Node %v has no ranges from which CIDRs can be allocated", node.Name)
 	}
@@ -325,17 +319,9 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 	// sets the v1.NodeNetworkUnavailable condition to False
 	ca.setNetworkCondition(node)
 
-	// nodes in clusters WITHOUT multi-networking are expected to have
-	// only 1 network-interface and 1 alias IPv4 range or/and 1 IPv6 address
-	// multi-network cluster may have 1 interface with multiple alias
-	if len(instance.NetworkInterfaces) == 1 &&
-		(len(instance.NetworkInterfaces[0].AliasIpRanges) == 1 ||
-			ca.cloud.GetIPV6Address(instance.NetworkInterfaces[0]) != nil) {
-		// with 1 alias IPv4 range on single IPv4 or dual stack clusters
-		if len(instance.NetworkInterfaces[0].AliasIpRanges) == 1 {
-			cidrStrings = append(cidrStrings, instance.NetworkInterfaces[0].AliasIpRanges[0].IpCidrRange)
-		}
-		// with 1 IPv6 range on single IPv6 or dual stack cluster
+	// nodes in clusters WITHOUT multi-networking are expected to have only 1 network-interface with 1 alias IP range.
+	if len(instance.NetworkInterfaces) == 1 && len(instance.NetworkInterfaces[0].AliasIpRanges) == 1 {
+		cidrStrings = append(cidrStrings, instance.NetworkInterfaces[0].AliasIpRanges[0].IpCidrRange)
 		ipv6Addr := ca.cloud.GetIPV6Address(instance.NetworkInterfaces[0])
 		if ipv6Addr != nil {
 			cidrStrings = append(cidrStrings, ipv6Addr.String())

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -283,45 +283,6 @@ func TestUpdateCIDRAllocation(t *testing.T) {
 			expectedUpdate: true,
 		},
 		{
-			name: "ipv6 single stack",
-			fakeNodeHandler: &testutil.FakeNodeHandler{
-				Existing: []*v1.Node{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "test",
-						},
-						Spec: v1.NodeSpec{
-							ProviderID: "gce://test-project/us-central1-b/test",
-						},
-					},
-				},
-				Clientset: fake.NewSimpleClientset(),
-			},
-			gceInstance: []*compute.Instance{
-				{
-					Name: "test",
-					NetworkInterfaces: []*compute.NetworkInterface{
-						{
-							Ipv6Address: "2001:db9::110",
-						},
-					},
-				},
-			},
-			nodeChanges: func(node *v1.Node) {
-				node.Spec.PodCIDR = "2001:db9::/112"
-				node.Spec.PodCIDRs = []string{"2001:db9::/112"}
-				node.Status.Conditions = []v1.NodeCondition{
-					{
-						Type:    "NetworkUnavailable",
-						Status:  "False",
-						Reason:  "RouteCreated",
-						Message: "NodeController create implicit route",
-					},
-				}
-			},
-			expectedUpdate: true,
-		},
-		{
 			name: "want error - incorrect cidr",
 			fakeNodeHandler: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -40,6 +40,7 @@ import (
 	clSetFake "k8s.io/cloud-provider-gcp/crd/client/network/clientset/versioned/fake"
 	networkinformers "k8s.io/cloud-provider-gcp/crd/client/network/informers/externalversions"
 	"k8s.io/cloud-provider-gcp/pkg/controller/testutil"
+	utilnode "k8s.io/cloud-provider-gcp/pkg/util/node"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	metricsUtil "k8s.io/component-base/metrics/testutil"
 )
@@ -490,6 +491,64 @@ func TestUpdateCIDRAllocation(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test",
+						},
+						Spec: v1.NodeSpec{
+							ProviderID: "gce://test-project/us-central1-b/test",
+						},
+						Status: v1.NodeStatus{
+							Capacity: v1.ResourceList{},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(),
+			},
+			gceInstance: []*compute.Instance{
+				{
+					Name: "test",
+					NetworkInterfaces: []*compute.NetworkInterface{
+						interfaces(defaultVPCName, defaultVPCSubnetName, "80.1.172.1", []*compute.AliasIpRange{
+							{IpCidrRange: "192.168.1.0/24", SubnetworkRangeName: defaultSecondaryRangeA},
+							{IpCidrRange: "10.11.1.0/24", SubnetworkRangeName: defaultSecondaryRangeB},
+						}),
+					},
+				},
+			},
+			nodeChanges: func(node *v1.Node) {
+				node.Spec.PodCIDR = "192.168.1.0/24"
+				node.Spec.PodCIDRs = []string{"192.168.1.0/24"}
+				node.Status.Conditions = []v1.NodeCondition{
+					{
+						Type:    "NetworkUnavailable",
+						Status:  "False",
+						Reason:  "RouteCreated",
+						Message: "NodeController create implicit route",
+					},
+				}
+				node.Annotations = map[string]string{
+					networkv1.NorthInterfacesAnnotationKey: "[]",
+					networkv1.MultiNetworkAnnotationKey:    "[]",
+				}
+			},
+			expectedUpdate:  true,
+			expectedMetrics: map[string]float64{},
+		},
+		{
+			name: "[mn] default network only, get PodCIDR with node labels",
+			networks: []*networkv1.Network{
+				network(networkv1.DefaultPodNetworkName, defaultGKENetworkParamsName, false),
+			},
+			gkeNwParams: []*networkv1.GKENetworkParamSet{
+				gkeNetworkParams(defaultGKENetworkParamsName, defaultVPCName, defaultVPCSubnetName, nil),
+			},
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test",
+							Labels: map[string]string{
+								utilnode.NodePoolSubnetLabelPrefix:   "default",
+								utilnode.NodePoolPodRangeLabelPrefix: defaultSecondaryRangeA,
+							},
 						},
 						Spec: v1.NodeSpec{
 							ProviderID: "gce://test-project/us-central1-b/test",

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -30,6 +30,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// Labels definitions.
+const (
+	// NodePoolPodRangeLabelPrefix is the prefix for the default Pod range
+	// name for the node and it can be different with cluster Pod range
+	NodePoolPodRangeLabelPrefix = "cloud.google.com/gke-np-default-pod-range"
+	// NodePoolSubnetLabelPrefix is the prefix for the default subnet
+	// name for the node
+	NodePoolSubnetLabelPrefix = "cloud.google.com/gke-np-default-subnet"
+)
+
 type nodeForConditionPatch struct {
 	Status nodeStatusForPatch `json:"status"`
 }


### PR DESCRIPTION
…t with Multi Networking

Depends on whether the node has label for subnet and Pod range:
- if no label, node ipam controller keeps the old way to compare default GNP and Network to get the default CIDRs for the node
- if label exists, node ipam controller use the labels to get the default CIDRs, it will update the node.Spec.PodCIDR then continue to perform the rest node annotations update