### PR TITLE
Use cluster stack type to correctly configure Pod CIDRs.

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -283,6 +283,11 @@ func (g *Cloud) ContainerService() *container.Service {
 	return g.containerService
 }
 
+// StackType returns the type of the IP protocol stack.
+func (g *Cloud) StackType() StackType {
+	return g.stackType
+}
+
 // newGCECloud creates a new instance of Cloud.
 func newGCECloud(config io.Reader) (gceCloud *Cloud, err error) {
 	var cloudConfig *CloudConfig

--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -40,6 +40,7 @@ type TestClusterValues struct {
 	Regional          bool
 	NetworkURL        string
 	SubnetworkURL     string
+	StackType	  StackType
 }
 
 // DefaultTestClusterValues Creates a reasonable set of default cluster values
@@ -52,6 +53,7 @@ func DefaultTestClusterValues() TestClusterValues {
 		SecondaryZoneName: "us-central1-c",
 		ClusterID:         "test-cluster-id",
 		ClusterName:       "Test-Cluster-Name",
+		StackType:	   NetworkStackIPV4,
 	}
 }
 
@@ -86,6 +88,7 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		regional:            vals.Regional,
 		networkURL:          vals.NetworkURL,
 		unsafeSubnetworkURL: vals.SubnetworkURL,
+		stackType:	     vals.StackType,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c


### PR DESCRIPTION
Bug fix: the cluster and network stack type can be different, e. g. a
single-stack IPv4 cluster can use a dual-stack network. For this reason,
add an IPv6 Pod CIDR not just when it is present on the network
interface, but only when also required by the cluster (cluster is
dual-stack).
    
Implement support for single-stack IPv6 clusters, which - irrespective
of the CIDRs on the network interface - only use IPv6 Pod CIDRs.