### PR TITLE
Configure Pod CIDRs based on service CIDRs

### DIFF
--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -4,6 +4,7 @@ load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
+    "go_test",
 )
 load("//defs:version.bzl", "version_x_defs")
 
@@ -53,3 +54,16 @@ go_library(
 load("//defs:container.bzl", "image")
 
 image(binary = ":cloud-controller-manager")
+
+go_test(
+    name = "cloud-controller-manager_test",
+    srcs = ["nodeipamcontroller_test.go"],
+    embed = [":cloud-controller-manager_lib"],
+    deps = [
+        "//pkg/controller/nodeipam/config",
+        "//vendor/k8s.io/cloud-provider",
+        "//vendor/k8s.io/cloud-provider/app/config",
+        "//vendor/k8s.io/cloud-provider/config",
+        "//vendor/k8s.io/controller-manager/app",
+    ],
+)

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -78,58 +78,54 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 		return nil, false, fmt.Errorf("the AllocateNodeCIDRs is not enabled")
 	}
 
-	// the CloudAllocator ipam does not need service or cluster cidrs since it obtains the data from the cloud directly
-	// for backward compatiblity reasons we don't fail if there are any of those values configured
-	if ipam.CIDRAllocatorType(ccmConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType) != ipam.CloudAllocatorType {
-		// failure: bad cidrs in config
-		cidrs, dualStack, err := processCIDRs(ccmConfig.ComponentConfig.KubeCloudShared.ClusterCIDR)
+	// failure: bad cidrs in config
+	cidrs, dualStack, err := processCIDRs(ccmConfig.ComponentConfig.KubeCloudShared.ClusterCIDR)
+	if err != nil {
+		return nil, false, err
+	}
+	clusterCIDRs = cidrs
+
+	// failure: more than one cidr but they are not configured as dual stack
+	if len(clusterCIDRs) > 1 && !dualStack {
+		return nil, false, fmt.Errorf("len of ClusterCIDRs==%v and they are not configured as dual stack (at least one from each IPFamily", len(clusterCIDRs))
+	}
+
+	// failure: more than 2 cidrs is not allowed even with dual stack
+	if len(clusterCIDRs) > 2 {
+		return nil, false, fmt.Errorf("len of clusters cidrs is:%v > more than max allowed of 2", len(clusterCIDRs))
+	}
+
+	// service cidr processing
+	if len(strings.TrimSpace(nodeIPAMConfig.ServiceCIDR)) != 0 {
+		_, serviceCIDR, err = net.ParseCIDR(nodeIPAMConfig.ServiceCIDR)
 		if err != nil {
-			return nil, false, err
+			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.ServiceCIDR, err)
 		}
-		clusterCIDRs = cidrs
+	}
 
-		// failure: more than one cidr but they are not configured as dual stack
-		if len(clusterCIDRs) > 1 && !dualStack {
-			return nil, false, fmt.Errorf("len of ClusterCIDRs==%v and they are not configured as dual stack (at least one from each IPFamily", len(clusterCIDRs))
-		}
-
-		// failure: more than cidrs is not allowed even with dual stack
-		if len(clusterCIDRs) > 2 {
-			return nil, false, fmt.Errorf("len of clusters is:%v > more than max allowed of 2", len(clusterCIDRs))
-		}
-
-		// service cidr processing
-		if len(strings.TrimSpace(nodeIPAMConfig.ServiceCIDR)) != 0 {
-			_, serviceCIDR, err = net.ParseCIDR(nodeIPAMConfig.ServiceCIDR)
-			if err != nil {
-				klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.ServiceCIDR, err)
-			}
-		}
-
-		if len(strings.TrimSpace(nodeIPAMConfig.SecondaryServiceCIDR)) != 0 {
-			_, secondaryServiceCIDR, err = net.ParseCIDR(nodeIPAMConfig.SecondaryServiceCIDR)
-			if err != nil {
-				klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.SecondaryServiceCIDR, err)
-			}
-		}
-
-		// the following checks are triggered if both serviceCIDR and secondaryServiceCIDR are provided
-		if serviceCIDR != nil && secondaryServiceCIDR != nil {
-			// should be dual stack (from different IPFamilies)
-			dualstackServiceCIDR, err := netutils.IsDualStackCIDRs([]*net.IPNet{serviceCIDR, secondaryServiceCIDR})
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to perform dualstack check on serviceCIDR and secondaryServiceCIDR error:%v", err)
-			}
-			if !dualstackServiceCIDR {
-				return nil, false, fmt.Errorf("serviceCIDR and secondaryServiceCIDR are not dualstack (from different IPfamiles)")
-			}
-		}
-
-		// get list of node cidr mask sizes
-		nodeCIDRMaskSizes, err = setNodeCIDRMaskSizes(nodeIPAMConfig, clusterCIDRs)
+	if len(strings.TrimSpace(nodeIPAMConfig.SecondaryServiceCIDR)) != 0 {
+		_, secondaryServiceCIDR, err = net.ParseCIDR(nodeIPAMConfig.SecondaryServiceCIDR)
 		if err != nil {
-			return nil, false, err
+			klog.Warningf("Unsuccessful parsing of service CIDR %v: %v", nodeIPAMConfig.SecondaryServiceCIDR, err)
 		}
+	}
+
+	// the following checks are triggered if both serviceCIDR and secondaryServiceCIDR are provided
+	if serviceCIDR != nil && secondaryServiceCIDR != nil {
+		// should be dual stack (from different IPFamilies)
+		dualstackServiceCIDR, err := netutils.IsDualStackCIDRs([]*net.IPNet{serviceCIDR, secondaryServiceCIDR})
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to perform dualstack check on serviceCIDR and secondaryServiceCIDR error:%v", err)
+		}
+		if !dualstackServiceCIDR {
+			return nil, false, fmt.Errorf("serviceCIDR and secondaryServiceCIDR are not dualstack (from different IPfamiles)")
+		}
+	}
+
+	// get list of node cidr mask sizes
+	nodeCIDRMaskSizes, err = setNodeCIDRMaskSizes(nodeIPAMConfig, clusterCIDRs)
+	if err != nil {
+		return nil, false, err
 	}
 
 	kubeConfig := ccmConfig.Complete().Kubeconfig

--- a/cmd/cloud-controller-manager/nodeipamcontroller_test.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller_test.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"testing"
+
+	cloudprovider "k8s.io/cloud-provider"
+	nodeipamconfig "k8s.io/cloud-provider-gcp/pkg/controller/nodeipam/config"
+	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
+	"k8s.io/cloud-provider/config"
+	genericcontrollermanager "k8s.io/controller-manager/app"
+)
+
+type fakeCloudProvider struct{}
+
+// Implements cloudprovider.Interface.
+var _ cloudprovider.Interface = &fakeCloudProvider{}
+
+func (f *fakeCloudProvider) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
+}
+
+func (f *fakeCloudProvider) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) Instances() (cloudprovider.Instances, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) InstancesV2() (cloudprovider.InstancesV2, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) Zones() (cloudprovider.Zones, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) Routes() (cloudprovider.Routes, bool) {
+	return nil, false
+}
+
+func (f *fakeCloudProvider) ProviderName() string {
+	return "fake"
+}
+
+func (f *fakeCloudProvider) HasClusterID() bool {
+	return false
+}
+
+func TestStartNodeIpamController(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		ccmConfig      *cloudcontrollerconfig.Config
+		nodeIPAMConfig nodeipamconfig.NodeIPAMControllerConfiguration
+		wantErr        bool
+	}{
+		{
+			desc: "Allocate node CIDRs disabled",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: false,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Unparseable cluster CIDRs",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "invalid",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Multiple same stack type cluster CIDRs - ipv4",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16,10.1.0.0/16",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Multiple same stack type cluster CIDRs - ipv6",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "2001:db8::/112,2001:db9::/112",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "More than 2 cluster CIDRs",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16,10.1.0.0/16,10.2.0.0/16",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Primary and secondary service CIDR same stack type - ipv4",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16",
+					},
+				},
+			},
+			nodeIPAMConfig: nodeipamconfig.NodeIPAMControllerConfiguration{
+				ServiceCIDR:          "10.0.0.0/16",
+				SecondaryServiceCIDR: "10.1.0.0/16",
+			},
+			wantErr: true,
+		},
+		{
+			desc: "Primary and secondary service CIDR same stack type - ipv6",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16",
+					},
+				},
+			},
+			nodeIPAMConfig: nodeipamconfig.NodeIPAMControllerConfiguration{
+				ServiceCIDR:          "2001:db8::/112",
+				SecondaryServiceCIDR: "2001:db9::/112",
+			},
+			wantErr: true,
+		},
+		{
+			desc: "NodeCIDRMaskSize used with a dual stack cluster",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16,2001:aa::/112",
+					},
+				},
+			},
+			nodeIPAMConfig: nodeipamconfig.NodeIPAMControllerConfiguration{
+				NodeCIDRMaskSize: 10,
+			},
+			wantErr: true,
+		},
+		{
+			desc: "NodeCIDRMaskSize and NodeCIDRMaskSizeIPv4 used together",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16",
+					},
+				},
+			},
+			nodeIPAMConfig: nodeipamconfig.NodeIPAMControllerConfiguration{
+				NodeCIDRMaskSize:     10,
+				NodeCIDRMaskSizeIPv4: 4,
+			},
+			wantErr: true,
+		},
+		{
+			desc: "NodeCIDRMaskSize and NodeCIDRMaskSizeIPv6 used together",
+			ccmConfig: &cloudcontrollerconfig.Config{
+				ComponentConfig: config.CloudControllerManagerConfiguration{
+					KubeCloudShared: config.KubeCloudSharedConfiguration{
+						AllocateNodeCIDRs: true,
+						ClusterCIDR:       "10.0.0.0/16",
+					},
+				},
+			},
+			nodeIPAMConfig: nodeipamconfig.NodeIPAMControllerConfiguration{
+				NodeCIDRMaskSize:     10,
+				NodeCIDRMaskSizeIPv6: 4,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := genericcontrollermanager.ControllerContext{}
+			_, _, err := startNodeIpamController(tc.ccmConfig.Complete(), tc.nodeIPAMConfig, ctx, &fakeCloudProvider{})
+
+			if err == nil && tc.wantErr {
+				t.Fatalf("startNodeIpamController succeeded, want error")
+			}
+			if err != nil && !tc.wantErr {
+				t.Fatalf("startNodeIpamController(): %v", err)
+			}
+		})
+	}
+}

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -118,7 +118,7 @@ func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInfo
 	case RangeAllocatorType:
 		return NewCIDRRangeAllocator(kubeClient, nodeInformer, allocatorParams, nodeList)
 	case CloudAllocatorType:
-		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeInformer)
+		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeInformer, allocatorParams)
 	default:
 		return nil, fmt.Errorf("invalid CIDR allocator type: %v", allocatorType)
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -68,7 +68,7 @@ func newTestNodeIpamController(clusterCIDR []*net.IPNet, serviceCIDR *net.IPNet,
 // TestNewNodeIpamControllerWithCIDRMasks tests if the controller can be
 // created with combinations of network CIDRs and masks.
 func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
-	emptyServiceCIDR := ""
+	emptyCIDR := ""
 	for _, tc := range []struct {
 		desc                 string
 		clusterCIDR          string
@@ -78,20 +78,132 @@ func TestNewNodeIpamControllerWithCIDRMasks(t *testing.T) {
 		allocatorType        ipam.CIDRAllocatorType
 		wantFatal            bool
 	}{
-		{"valid_range_allocator", "10.0.0.0/21", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.RangeAllocatorType, false},
-
-		{"valid_range_allocator_dualstack", "10.0.0.0/21,2000::/10", "10.1.0.0/21", emptyServiceCIDR, []int{24, 98}, ipam.RangeAllocatorType, false},
-		{"valid_range_allocator_dualstack_dualstackservice", "10.0.0.0/21,2000::/10", "10.1.0.0/21", "3000::/10", []int{24, 98}, ipam.RangeAllocatorType, false},
-
-		{"valid_cloud_allocator", "10.0.0.0/21", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.CloudAllocatorType, false},
-		{"valid_ipam_from_cluster", "10.0.0.0/21", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.IPAMFromClusterAllocatorType, false},
-		{"valid_ipam_from_cloud", "10.0.0.0/21", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.IPAMFromCloudAllocatorType, false},
-		{"valid_skip_cluster_CIDR_validation_for_cloud_allocator", "invalid", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.CloudAllocatorType, false},
-		{"invalid_cluster_CIDR", "invalid", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.IPAMFromClusterAllocatorType, true},
-		{"valid_CIDR_smaller_than_mask_cloud_allocator", "10.0.0.0/26", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.CloudAllocatorType, false},
-		{"invalid_CIDR_smaller_than_mask_other_allocators", "10.0.0.0/26", "10.1.0.0/21", emptyServiceCIDR, []int{24}, ipam.IPAMFromCloudAllocatorType, true},
-		{"invalid_serviceCIDR_contains_clusterCIDR", "10.0.0.0/23", "10.0.0.0/21", emptyServiceCIDR, []int{24}, ipam.IPAMFromClusterAllocatorType, true},
-		{"invalid_CIDR_mask_size", "10.0.0.0/24,2000::/64", "10.1.0.0/21", emptyServiceCIDR, []int{24, 48}, ipam.IPAMFromClusterAllocatorType, true},
+		{
+			"valid_range_allocator",
+			"10.0.0.0/21",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.RangeAllocatorType,
+			false,
+		},
+		{
+			"valid_range_allocator_dualstack",
+			"10.0.0.0/21,2000::/10",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24, 98},
+			ipam.RangeAllocatorType,
+			false,
+		},
+		{
+			"valid_range_allocator_dualstack_dualstackservice",
+			"10.0.0.0/21,2000::/10",
+			"10.1.0.0/21",
+			"3000::/10",
+			[]int{24, 98},
+			ipam.RangeAllocatorType,
+			false,
+		},
+		{
+			"valid_cloud_allocator_ipv4",
+			"10.0.0.0/21",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.CloudAllocatorType,
+			false,
+		},
+		{
+			"valid_cloud_allocator_dualstack",
+			"10.0.0.0/21,2000::/10",
+			"10.1.0.0/21",
+			"3000::/10",
+			[]int{24},
+			ipam.CloudAllocatorType,
+			false,
+		},
+		{
+			"valid_cloud_allocator_ipv6",
+			"2000::/10",
+			"3000::/10",
+			emptyCIDR,
+			[]int{24},
+			ipam.CloudAllocatorType,
+			false,
+		},
+		{
+			"valid_ipam_from_cluster",
+			"10.0.0.0/21",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.IPAMFromClusterAllocatorType,
+			false,
+		},
+		{
+			"valid_ipam_from_cloud",
+			"10.0.0.0/21",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.IPAMFromCloudAllocatorType,
+			false,
+		},
+		{
+			"valid_skip_cluster_CIDR_validation_for_cloud_allocator",
+			"invalid",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.CloudAllocatorType,
+			false,
+		},
+		{
+			"invalid_cluster_CIDR",
+			"invalid",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.IPAMFromClusterAllocatorType,
+			true,
+		},
+		{
+			"valid_CIDR_smaller_than_mask_cloud_allocator",
+			"10.0.0.0/26",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.CloudAllocatorType,
+			false,
+		},
+		{
+			"invalid_CIDR_smaller_than_mask_other_allocators",
+			"10.0.0.0/26",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.IPAMFromCloudAllocatorType,
+			true,
+		},
+		{
+			"invalid_serviceCIDR_contains_clusterCIDR",
+			"10.0.0.0/23",
+			"10.0.0.0/21",
+			emptyCIDR,
+			[]int{24},
+			ipam.IPAMFromClusterAllocatorType,
+			true,
+		},
+		{
+			"invalid_CIDR_mask_size",
+			"10.0.0.0/24,2000::/64",
+			"10.1.0.0/21",
+			emptyCIDR,
+			[]int{24, 48},
+			ipam.IPAMFromClusterAllocatorType,
+			true,
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			clusterCidrs, _ := netutils.ParseCIDRs(strings.Split(tc.clusterCIDR, ","))


### PR DESCRIPTION
Use service CIDR flag to determine the right cluster stack type, and assign the right PodCIDRs to the node object.

This fixes a problem where a single-stack IPv4 cluster on a dual-stack GCE network actually gets both IPv4 and IPv6 Pod CIDRs. Additionally, single-stack IPv6 clusters are now supported.