### PR TITLE
Fixes bug where node name is set to gcp-zone

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -400,7 +400,7 @@ function detect-node-names() {
     for group in "${INSTANCE_GROUPS[@]}"; do
       kube::util::read-array NODE_NAMES < <(gcloud compute instance-groups managed list-instances \
         "${group}" --zone "${ZONE}" --project "${PROJECT}" \
-        --format='value(instance)')
+        --format='value(name)')
     done
   fi
   # Add heapster node name to the list too (if it exists).


### PR DESCRIPTION
* Fixes bug in e2e tests where the NODE_NAMES environment variable is erroneously set to the `gcp zone`

/kind bug
/sig testing

When running e2e test, we see the numerous instances of the following error
```
ERROR: (gcloud.compute.scp) Could not fetch resource:
 - The resource 'projects/seans-devel/zones/us-central1-c/instances/us-central1-c' was not found
```
Notice the final field is `us-central1-c`, when it should be the node name
```
INSTANCE_GROUPS=kt2-e8fb43c5-57f5-minion-group
NODE_NAMES=us-central1-c us-central1-c us-central1-c
```

After the fix
```
INSTANCE_GROUPS=kt2-e8fb43c5-57f5-minion-group
NODE_NAMES=kt2-e8fb43c5-57f5-minion-group-52km kt2-e8fb43c5-57f5-minion-group-chfc kt2-e8fb43c5-57f5-minion-group-sgqw
```

This error blocks node logs from being downloaded when running the e2e test (even though the master logs are correctly downloaded).