### PR TITLE
L4 ILB - skip nodes from the non default network if multi subnet is t…

### DIFF
--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -114,6 +114,10 @@ func createAndInsertNodes(gce *Cloud, nodeNames []string, zoneName string) ([]*v
 						v1.LabelTopologyZone: zoneName,
 					},
 				},
+				Spec: v1.NodeSpec{
+					// Add PodCIDR for multi subnet purpose. Nodes need to have PodCIDR to be regarded as nodes from the default subnet (unless they have the subnet label).
+					PodCIDR: "192.168.0.0/0",
+				},
 			},
 		)
 


### PR DESCRIPTION
…urned on.

This will just skip nodes that are not on the default network when creating the instance group.