### PR TITLE
Add another valid container repository to our list.

### DIFF
--- a/providers/gce/gcpcredential/gcpcredential.go
+++ b/providers/gce/gcpcredential/gcpcredential.go
@@ -48,7 +48,7 @@ var GCEProductNameFile = "/sys/class/dmi/id/product_name"
 
 // For these urls, the parts of the host name can be glob, for example '*.gcr.io" will match
 // "foo.gcr.io" and "bar.gcr.io".
-var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.gcr.io", "*.pkg.dev"}
+var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.gcr.io", "*.pkg.dev", "docker.*.goog"}
 
 var metadataHeader = &http.Header{
 	"Metadata-Flavor": []string{"Google"},


### PR DESCRIPTION
There are valid docker repositories at "docker.UNIVERSE_NAME.goog" that are valid and we have had a request to add those to our list of repo urls. 