### PR TITLE
Add VM termination annotation; switch to Compute Beta API

### DIFF
--- a/cmd/gcp-controller-manager/loops.go
+++ b/cmd/gcp-controller-manager/loops.go
@@ -108,7 +108,7 @@ func loops() map[string]func(context.Context, *controllerContext) error {
 			nodeAnnotateController, err := newNodeAnnotator(
 				controllerCtx.client,
 				controllerCtx.sharedInformers.Core().V1().Nodes(),
-				controllerCtx.gcpCfg.Compute,
+				controllerCtx.gcpCfg.BetaCompute,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
All of the VMs provisioned by Provisioning Requests have bounded TTL, which is 7 days by default and can be lowered by users via `maxRunDurationSeconds` in Provisioning Request (https://cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest).

We would like to surface information about TTL to the GKE users using k8s API, as it is not presented to them directly.


