### PR TITLE
e2e tests for network tiers

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,12 +5,14 @@ go 1.22.0
 toolchain go1.22.1
 
 require (
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.0
 	google.golang.org/api v0.151.0
 	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
+	k8s.io/cloud-provider v0.30.0
 	k8s.io/cloud-provider-gcp/providers v0.0.0-00010101000000-000000000000
 	k8s.io/kubernetes v1.30.0
 	k8s.io/pod-security-admission v0.30.0
@@ -19,7 +21,6 @@ require (
 require (
 	cloud.google.com/go/compute v1.23.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
@@ -115,7 +116,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
-	k8s.io/cloud-provider v0.30.0 // indirect
 	k8s.io/component-base v0.30.0 // indirect
 	k8s.io/component-helpers v0.30.0 // indirect
 	k8s.io/controller-manager v0.30.0 // indirect

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.1
 
 require (
-	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0
+	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.0
 	google.golang.org/api v0.151.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -4,8 +4,8 @@ cloud.google.com/go/compute v1.23.1/go.mod h1:CqB3xpmPKKt3OJpW2ndFIXnA9A4xAy/F3X
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 h1:lwL1vLWmdBJ5h+StMEN6+GMz1J/Y0yUU3RDv+QBy+Q4=
-github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0/go.mod h1:UTfhBnADaj2rybPT049NScSh7Eall3u2ib43wmz3deg=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0 h1:5slI4ZAsvkgpVEfrKZGlvcpeYTv2roIbDzK6zvJYhwY=
+github.com/GoogleCloudPlatform/k8s-cloud-provider v1.27.0/go.mod h1:TFNxHb9YGSjLB86UWy5BQCgVTXQscyy/X5tC/2olieA=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=

--- a/test/e2e/network_tiers.go
+++ b/test/e2e/network_tiers.go
@@ -38,6 +38,9 @@ import (
 	admissionapi "k8s.io/pod-security-admission/api"
 )
 
+// Migrated from k/k in-tree at:
+//
+//	https://github.com/kubernetes/kubernetes/blob/release-1.30/test/e2e/network/network_tiers.go
 var _ = ginkgo.Describe("[cloud-provider-gcp-e2e] Network Tiers", func() {
 	f := framework.NewDefaultFramework("network-tiers")
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged

--- a/test/e2e/network_tiers.go
+++ b/test/e2e/network_tiers.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	compute "google.golang.org/api/compute/v1"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	cloudprovider "k8s.io/cloud-provider"
+	gcecloud "k8s.io/cloud-provider-gcp/providers/gce"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("[cloud-provider-gcp-e2e] Network Tiers", func() {
+	f := framework.NewDefaultFramework("network-tiers")
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	var cs clientset.Interface
+	serviceLBNames := []string{}
+
+	ginkgo.BeforeEach(func() {
+		cs = f.ClientSet
+	})
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		if ginkgo.CurrentSpecReport().Failed() {
+			DescribeSvc(f.Namespace.Name)
+		}
+		for _, lb := range serviceLBNames {
+			framework.Logf("cleaning gce resource for %s", lb)
+			framework.TestContext.CloudConfig.Provider.CleanupServiceResources(ctx, cs, lb, framework.TestContext.CloudConfig.Region, framework.TestContext.CloudConfig.Zone)
+		}
+		//reset serviceLBNames
+		serviceLBNames = []string{}
+	})
+
+	f.It("should be able to create and tear down a standard-tier load balancer", f.WithSlow(), func(ctx context.Context) {
+		lagTimeout := e2eservice.LoadBalancerLagTimeoutDefault
+		createTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs)
+
+		svcName := "net-tiers-svc"
+		ns := f.Namespace.Name
+		jig := e2eservice.NewTestJig(cs, ns, svcName)
+
+		ginkgo.By("creating a pod to be part of the service " + svcName)
+		_, err := jig.Run(ctx, nil)
+		framework.ExpectNoError(err)
+
+		// Test 1: create a standard tiered LB for the Service.
+		ginkgo.By("creating a Service of type LoadBalancer using the standard network tier")
+		svc, err := jig.CreateTCPService(ctx, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeLoadBalancer
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
+		})
+		framework.ExpectNoError(err)
+		// Verify that service has been updated properly.
+		svcTier, err := gcecloud.GetServiceNetworkTier(svc)
+		framework.ExpectNoError(err)
+		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierStandard))
+		// Record the LB name for test cleanup.
+		serviceLBNames = append(serviceLBNames, cloudprovider.DefaultLoadBalancerName(svc))
+
+		// Wait and verify the LB.
+		ingressIP := waitAndVerifyLBWithTier(ctx, jig, "", createTimeout, lagTimeout)
+
+		// Test 2: re-create a LB of a different tier for the updated Service.
+		ginkgo.By("updating the Service to use the premium (default) tier")
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationPremium))
+		})
+		framework.ExpectNoError(err)
+		// Verify that service has been updated properly.
+		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
+		framework.ExpectNoError(err)
+		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierDefault))
+
+		// Wait until the ingress IP changes. Each tier has its own pool of
+		// IPs, so changing tiers implies changing IPs.
+		ingressIP = waitAndVerifyLBWithTier(ctx, jig, ingressIP, createTimeout, lagTimeout)
+
+		// Test 3: create a standard-tierd LB with a user-requested IP.
+		ginkgo.By("reserving a static IP for the load balancer")
+		requestedAddrName := fmt.Sprintf("e2e-ext-lb-net-tier-%s", framework.RunID)
+		gceCloud, err := GetGCECloud()
+		framework.ExpectNoError(err)
+		requestedIP, err := reserveRegionalAddress(gceCloud, requestedAddrName, cloud.NetworkTierStandard)
+		framework.ExpectNoError(err, "failed to reserve a STANDARD tiered address")
+		defer func() {
+			if requestedAddrName != "" {
+				// Release GCE static address - this is not kube-managed and will not be automatically released.
+				if err := gceCloud.DeleteRegionAddress(requestedAddrName, gceCloud.Region()); err != nil {
+					framework.Logf("failed to release static IP address %q: %v", requestedAddrName, err)
+				}
+			}
+		}()
+		framework.ExpectNoError(err)
+		framework.Logf("Allocated static IP to be used by the load balancer: %q", requestedIP)
+
+		ginkgo.By("updating the Service to use the standard tier with a requested IP")
+		svc, err = jig.UpdateService(ctx, func(svc *v1.Service) {
+			svc.Spec.LoadBalancerIP = requestedIP
+			setNetworkTier(svc, string(gcecloud.NetworkTierAnnotationStandard))
+		})
+		framework.ExpectNoError(err)
+		// Verify that service has been updated properly.
+		gomega.Expect(svc.Spec.LoadBalancerIP).To(gomega.Equal(requestedIP))
+		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
+		framework.ExpectNoError(err)
+		gomega.Expect(svcTier).To(gomega.Equal(cloud.NetworkTierStandard))
+
+		// Wait until the ingress IP changes and verifies the LB.
+		waitAndVerifyLBWithTier(ctx, jig, ingressIP, createTimeout, lagTimeout)
+	})
+})
+
+func waitAndVerifyLBWithTier(ctx context.Context, jig *e2eservice.TestJig, existingIP string, waitTimeout, checkTimeout time.Duration) string {
+	// If existingIP is "" this will wait for any ingress IP to show up. Otherwise
+	// it will wait for the ingress IP to change to something different.
+	svc, err := jig.WaitForNewIngressIP(ctx, existingIP, waitTimeout)
+	framework.ExpectNoError(err)
+
+	svcPort := int(svc.Spec.Ports[0].Port)
+	lbIngress := &svc.Status.LoadBalancer.Ingress[0]
+	ingressIP := e2eservice.GetIngressPoint(lbIngress)
+
+	ginkgo.By("running sanity and reachability checks")
+	if svc.Spec.LoadBalancerIP != "" {
+		// Verify that the new ingress IP is the requested IP if it's set.
+		gomega.Expect(ingressIP).To(gomega.Equal(svc.Spec.LoadBalancerIP))
+	}
+	// If the IP has been used by previous test, sometimes we get the lingering
+	// 404 errors even after the LB is long gone. Tolerate and retry until the
+	// new LB is fully established.
+	e2eservice.TestReachableHTTPWithRetriableErrorCodes(ctx, ingressIP, svcPort, []int{http.StatusNotFound}, checkTimeout)
+
+	// Verify the network tier matches the desired.
+	svcNetTier, err := gcecloud.GetServiceNetworkTier(svc)
+	framework.ExpectNoError(err)
+	netTier, err := getLBNetworkTierByIP(ingressIP)
+	framework.ExpectNoError(err, "failed to get the network tier of the load balancer")
+	gomega.Expect(netTier).To(gomega.Equal(svcNetTier))
+
+	return ingressIP
+}
+
+func getLBNetworkTierByIP(ip string) (cloud.NetworkTier, error) {
+	var rule *compute.ForwardingRule
+	// Retry a few times to tolerate flakes.
+	err := wait.PollImmediate(5*time.Second, 15*time.Second, func() (bool, error) {
+		obj, err := getGCEForwardingRuleByIP(ip)
+		if err != nil {
+			return false, err
+		}
+		rule = obj
+		return true, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return cloud.NetworkTierGCEValueToType(rule.NetworkTier), nil
+}
+
+func getGCEForwardingRuleByIP(ip string) (*compute.ForwardingRule, error) {
+	cloud, err := GetGCECloud()
+	if err != nil {
+		return nil, err
+	}
+	ruleList, err := cloud.ListRegionForwardingRules(cloud.Region())
+	if err != nil {
+		return nil, err
+	}
+	for _, rule := range ruleList {
+		if rule.IPAddress == ip {
+			return rule, nil
+		}
+	}
+	return nil, fmt.Errorf("forwarding rule with ip %q not found", ip)
+}
+
+func setNetworkTier(svc *v1.Service, tier string) {
+	key := gcecloud.NetworkTierAnnotationKey
+	if svc.ObjectMeta.Annotations == nil {
+		svc.ObjectMeta.Annotations = map[string]string{}
+	}
+	svc.ObjectMeta.Annotations[key] = tier
+}
+
+// TODO: add retries if this turns out to be flaky.
+func reserveRegionalAddress(cloud *gcecloud.Cloud, name string, netTier cloud.NetworkTier) (string, error) {
+	Addr := &compute.Address{
+		Name:        name,
+		NetworkTier: netTier.ToGCEValue(),
+	}
+
+	if err := cloud.ReserveRegionAddress(Addr, cloud.Region()); err != nil {
+		return "", err
+	}
+
+	addr, err := cloud.GetRegionAddress(name, cloud.Region())
+	if err != nil {
+		return "", err
+	}
+
+	return addr.Address, nil
+}
+
+// DescribeSvc logs the output of kubectl describe svc for the given namespace
+func DescribeSvc(ns string) {
+	framework.Logf("\nOutput of kubectl describe svc:\n")
+	desc, _ := e2ekubectl.RunKubectl(
+		ns, "describe", "svc", fmt.Sprintf("--namespace=%v", ns))
+	framework.Logf(desc)
+}


### PR DESCRIPTION
* Migrates e2e tests for service network tiers from in-tree to `cloud-provider-gcp`
* Previous file location (at `v1.30`): https://github.com/kubernetes/kubernetes/blob/release-1.30/test/e2e/network/network_tiers.go