### PR TITLE
Migrate gce-specific ingress e2e tests from in-tree to cloud-provider-gcp

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -11,11 +11,13 @@ require (
 	google.golang.org/api v0.151.0
 	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0
+	k8s.io/apiserver v0.30.0
 	k8s.io/client-go v0.30.0
 	k8s.io/cloud-provider v0.30.0
 	k8s.io/cloud-provider-gcp/providers v0.0.0-00010101000000-000000000000
 	k8s.io/kubernetes v1.30.0
 	k8s.io/pod-security-admission v0.30.0
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
 
 require (
@@ -124,7 +126,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/kubectl v0.0.0 // indirect
 	k8s.io/kubelet v0.30.0 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -1,0 +1,530 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eauth "k8s.io/kubernetes/test/e2e/framework/auth"
+	e2eingress "k8s.io/kubernetes/test/e2e/framework/ingress"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const (
+	negUpdateTimeout = 2 * time.Minute
+)
+
+var _ = ginkgo.Describe("[cloud-provider-gcp-e2e] Loadbalancing: L7", func() {
+	defer ginkgo.GinkgoRecover()
+	var (
+		ns               string
+		jig              *e2eingress.TestJig
+		conformanceTests []e2eingress.ConformanceTests
+	)
+	f := framework.NewDefaultFramework("ingress")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		jig = e2eingress.NewIngressTestJig(f.ClientSet)
+		ns = f.Namespace.Name
+
+		// this test wants powerful permissions.  Since the namespace names are unique, we can leave this
+		// lying around so we don't have to race any caches
+		err := e2eauth.BindClusterRole(ctx, jig.Client.RbacV1(), "cluster-admin", f.Namespace.Name,
+			rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
+		framework.ExpectNoError(err)
+
+		err = e2eauth.WaitForAuthorizationUpdate(ctx, jig.Client.AuthorizationV1(),
+			serviceaccount.MakeUsername(f.Namespace.Name, "default"),
+			"", "create", schema.GroupResource{Resource: "pods"}, true)
+		framework.ExpectNoError(err)
+	})
+
+	// Before enabling this loadbalancer test in any other test list you must
+	// make sure the associated project has enough quota. At the time of this
+	// writing a GCE project is allowed 3 backend services by default. This
+	// test requires at least 5.
+	//
+	// Slow by design ~10m for each "It" block dominated by loadbalancer setup time
+	// TODO: write similar tests for nginx, haproxy and AWS Ingress.
+	f.Describe("GCE", framework.WithSlow(), func() {
+		var gceController *IngressController
+
+		// Platform specific setup
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ginkgo.By("Initializing gce controller")
+			gceController = &IngressController{
+				Ns:     ns,
+				Client: jig.Client,
+				Cloud:  framework.TestContext.CloudConfig,
+			}
+			err := gceController.Init(ctx)
+			framework.ExpectNoError(err)
+		})
+
+		// Platform specific cleanup
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if ginkgo.CurrentSpecReport().Failed() {
+				e2eingress.DescribeIng(ns)
+			}
+			if jig.Ingress == nil {
+				ginkgo.By("No ingress created, no cleanup necessary")
+				return
+			}
+			ginkgo.By("Deleting ingress")
+			jig.TryDeleteIngress(ctx)
+
+			ginkgo.By("Cleaning up cloud resources")
+			err := gceController.CleanupIngressController(ctx)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should conform to Ingress spec", func(ctx context.Context) {
+			conformanceTests = e2eingress.CreateIngressComformanceTests(ctx, jig, ns, map[string]string{})
+			for _, t := range conformanceTests {
+				ginkgo.By(t.EntryLog)
+				t.Execute()
+				ginkgo.By(t.ExitLog)
+				jig.WaitForIngress(ctx, true)
+			}
+		})
+
+	})
+
+	f.Describe("GCE", framework.WithSlow(), func() {
+		var gceController *IngressController
+
+		// Platform specific setup
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			ginkgo.By("Initializing gce controller")
+			gceController = &IngressController{
+				Ns:     ns,
+				Client: jig.Client,
+				Cloud:  framework.TestContext.CloudConfig,
+			}
+			err := gceController.Init(ctx)
+			framework.ExpectNoError(err)
+		})
+
+		// Platform specific cleanup
+		ginkgo.AfterEach(func(ctx context.Context) {
+			if ginkgo.CurrentSpecReport().Failed() {
+				e2eingress.DescribeIng(ns)
+			}
+			if jig.Ingress == nil {
+				ginkgo.By("No ingress created, no cleanup necessary")
+				return
+			}
+			ginkgo.By("Deleting ingress")
+			jig.TryDeleteIngress(ctx)
+
+			ginkgo.By("Cleaning up cloud resources")
+			err := gceController.CleanupIngressController(ctx)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should conform to Ingress spec", func(ctx context.Context) {
+			jig.PollInterval = 5 * time.Second
+			conformanceTests = e2eingress.CreateIngressComformanceTests(ctx, jig, ns, map[string]string{
+				e2eingress.NEGAnnotation: `{"ingress": true}`,
+			})
+			for _, t := range conformanceTests {
+				ginkgo.By(t.EntryLog)
+				t.Execute()
+				ginkgo.By(t.ExitLog)
+				jig.WaitForIngress(ctx, true)
+				err := gceController.WaitForNegBackendService(ctx, jig.GetServicePorts(ctx, false))
+				framework.ExpectNoError(err)
+			}
+		})
+
+		ginkgo.It("should be able to switch between IG and NEG modes", func(ctx context.Context) {
+			var err error
+			propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, f.ClientSet)
+			ginkgo.By("Create a basic HTTP ingress using NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+			err = gceController.WaitForNegBackendService(ctx, jig.GetServicePorts(ctx, false))
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Switch backend service to use IG")
+			svcList, err := f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				svc.Annotations[e2eingress.NEGAnnotation] = `{"ingress": false}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			err = wait.PollWithContext(ctx, 5*time.Second, propagationTimeout, func(ctx context.Context) (bool, error) {
+				if err := gceController.BackendServiceUsingIG(jig.GetServicePorts(ctx, false)); err != nil {
+					framework.Logf("ginkgo.Failed to verify IG backend service: %v", err)
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "Expect backend service to target IG, but failed to observe")
+			jig.WaitForIngress(ctx, true)
+
+			ginkgo.By("Switch backend service to use NEG")
+			svcList, err = f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				svc.Annotations[e2eingress.NEGAnnotation] = `{"ingress": true}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			err = wait.PollWithContext(ctx, 5*time.Second, propagationTimeout, func(ctx context.Context) (bool, error) {
+				if err := gceController.BackendServiceUsingNEG(jig.GetServicePorts(ctx, false)); err != nil {
+					framework.Logf("ginkgo.Failed to verify NEG backend service: %v", err)
+					return false, nil
+				}
+				return true, nil
+			})
+			framework.ExpectNoError(err, "Expect backend service to target NEG, but failed to observe")
+			jig.WaitForIngress(ctx, true)
+		})
+
+		ginkgo.It("should be able to create a ClusterIP service", func(ctx context.Context) {
+			ginkgo.By("Create a basic HTTP ingress using NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg-clusterip"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+			svcPorts := jig.GetServicePorts(ctx, false)
+			err := gceController.WaitForNegBackendService(ctx, svcPorts)
+			framework.ExpectNoError(err)
+
+			// ClusterIP ServicePorts have no NodePort
+			for _, sp := range svcPorts {
+				gomega.Expect(sp.NodePort).To(gomega.Equal(int32(0)))
+			}
+		})
+
+		ginkgo.It("should sync endpoints to NEG", func(ctx context.Context) {
+			name := "hostname"
+			scaleAndValidateNEG := func(num int) {
+				scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(ctx, name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				if scale.Spec.Replicas != int32(num) {
+					scale.ResourceVersion = "" // indicate the scale update should be unconditional
+					scale.Spec.Replicas = int32(num)
+					_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
+					framework.ExpectNoError(err)
+				}
+				err = wait.Poll(10*time.Second, negUpdateTimeout, func() (bool, error) {
+					res, err := jig.GetDistinctResponseFromIngress(ctx)
+					if err != nil {
+						return false, nil
+					}
+					framework.Logf("Expecting %d backends, got %d", num, res.Len())
+					return res.Len() == num, nil
+				})
+				framework.ExpectNoError(err)
+			}
+
+			ginkgo.By("Create a basic HTTP ingress using NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+			jig.WaitForIngressToStable(ctx)
+			err := gceController.WaitForNegBackendService(ctx, jig.GetServicePorts(ctx, false))
+			framework.ExpectNoError(err)
+			// initial replicas number is 1
+			scaleAndValidateNEG(1)
+
+			ginkgo.By("Scale up number of backends to 5")
+			scaleAndValidateNEG(5)
+
+			ginkgo.By("Scale down number of backends to 3")
+			scaleAndValidateNEG(3)
+
+			ginkgo.By("Scale up number of backends to 6")
+			scaleAndValidateNEG(6)
+
+			ginkgo.By("Scale down number of backends to 2")
+			scaleAndValidateNEG(3)
+		})
+
+		ginkgo.It("rolling update backend pods should not cause service disruption", func(ctx context.Context) {
+			name := "hostname"
+			replicas := 8
+			ginkgo.By("Create a basic HTTP ingress using NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+			jig.WaitForIngressToStable(ctx)
+			err := gceController.WaitForNegBackendService(ctx, jig.GetServicePorts(ctx, false))
+			framework.ExpectNoError(err)
+
+			ginkgo.By(fmt.Sprintf("Scale backend replicas to %d", replicas))
+			scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(ctx, name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			scale.ResourceVersion = "" // indicate the scale update should be unconditional
+			scale.Spec.Replicas = int32(replicas)
+			_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+
+			propagationTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, f.ClientSet)
+			err = wait.Poll(10*time.Second, propagationTimeout, func() (bool, error) {
+				res, err := jig.GetDistinctResponseFromIngress(ctx)
+				if err != nil {
+					return false, nil
+				}
+				return res.Len() == replicas, nil
+			})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Trigger rolling update and observe service disruption")
+			deploy, err := f.ClientSet.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			// trigger by changing graceful termination period to 60 seconds
+			gracePeriod := int64(60)
+			deploy.Spec.Template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+			_, err = f.ClientSet.AppsV1().Deployments(ns).Update(ctx, deploy, metav1.UpdateOptions{})
+			framework.ExpectNoError(err)
+			err = wait.Poll(10*time.Second, propagationTimeout, func() (bool, error) {
+				res, err := jig.GetDistinctResponseFromIngress(ctx)
+				if err != nil {
+					return false, err
+				}
+				deploy, err := f.ClientSet.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				if int(deploy.Status.UpdatedReplicas) == replicas {
+					if res.Len() == replicas {
+						return true, nil
+					}
+					framework.Logf("Expecting %d different responses, but got %d.", replicas, res.Len())
+					return false, nil
+
+				}
+				framework.Logf("Waiting for rolling update to finished. Keep sending traffic.")
+				return false, nil
+			})
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should sync endpoints for both Ingress-referenced NEG and standalone NEG", func(ctx context.Context) {
+			name := "hostname"
+			expectedKeys := []int32{80, 443}
+
+			scaleAndValidateExposedNEG := func(num int) {
+				scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(ctx, name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				if scale.Spec.Replicas != int32(num) {
+					scale.ResourceVersion = "" // indicate the scale update should be unconditional
+					scale.Spec.Replicas = int32(num)
+					_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(ctx, name, scale, metav1.UpdateOptions{})
+					framework.ExpectNoError(err)
+				}
+				err = wait.Poll(10*time.Second, negUpdateTimeout, func() (bool, error) {
+					svc, err := f.ClientSet.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+					framework.ExpectNoError(err)
+
+					var status e2eingress.NegStatus
+					v, ok := svc.Annotations[e2eingress.NEGStatusAnnotation]
+					if !ok {
+						// Wait for NEG sync loop to find NEGs
+						framework.Logf("Waiting for %v, got: %+v", e2eingress.NEGStatusAnnotation, svc.Annotations)
+						return false, nil
+					}
+					err = json.Unmarshal([]byte(v), &status)
+					if err != nil {
+						framework.Logf("Error in parsing Expose NEG annotation: %v", err)
+						return false, nil
+					}
+					framework.Logf("Got %v: %v", e2eingress.NEGStatusAnnotation, v)
+
+					// Expect 2 NEGs to be created based on the test setup (neg-exposed)
+					if len(status.NetworkEndpointGroups) != 2 {
+						framework.Logf("Expected 2 NEGs, got %d", len(status.NetworkEndpointGroups))
+						return false, nil
+					}
+
+					for _, port := range expectedKeys {
+						if _, ok := status.NetworkEndpointGroups[port]; !ok {
+							framework.Logf("Expected ServicePort key %v, but does not exist", port)
+						}
+					}
+
+					if len(status.NetworkEndpointGroups) != len(expectedKeys) {
+						framework.Logf("Expected length of %+v to equal length of %+v, but does not", status.NetworkEndpointGroups, expectedKeys)
+					}
+
+					gceCloud, err := GetGCECloud()
+					framework.ExpectNoError(err)
+					for _, neg := range status.NetworkEndpointGroups {
+						networkEndpoints, err := gceCloud.ListNetworkEndpoints(neg, gceController.Cloud.Zone, false)
+						framework.ExpectNoError(err)
+						if len(networkEndpoints) != num {
+							framework.Logf("Expect number of endpoints to be %d, but got %d", num, len(networkEndpoints))
+							return false, nil
+						}
+					}
+
+					return true, nil
+				})
+				framework.ExpectNoError(err)
+			}
+
+			ginkgo.By("Create a basic HTTP ingress using NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg-exposed"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+			err := gceController.WaitForNegBackendService(ctx, jig.GetServicePorts(ctx, false))
+			framework.ExpectNoError(err)
+			// initial replicas number is 1
+			scaleAndValidateExposedNEG(1)
+
+			ginkgo.By("Scale up number of backends to 5")
+			scaleAndValidateExposedNEG(5)
+
+			ginkgo.By("Scale down number of backends to 3")
+			scaleAndValidateExposedNEG(3)
+
+			ginkgo.By("Scale up number of backends to 6")
+			scaleAndValidateExposedNEG(6)
+
+			ginkgo.By("Scale down number of backends to 2")
+			scaleAndValidateExposedNEG(3)
+		})
+
+		ginkgo.It("should create NEGs for all ports with the Ingress annotation, and NEGs for the standalone annotation otherwise", func(ctx context.Context) {
+			ginkgo.By("Create a basic HTTP ingress using standalone NEG")
+			jig.CreateIngress(ctx, filepath.Join(e2eingress.IngressManifestPath, "neg-exposed"), ns, map[string]string{}, map[string]string{})
+			jig.WaitForIngress(ctx, true)
+
+			name := "hostname"
+			detectNegAnnotation(ctx, f, jig, gceController, ns, name, 2)
+
+			// Add Ingress annotation - NEGs should stay the same.
+			ginkgo.By("Adding NEG Ingress annotation")
+			svcList, err := f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				svc.Annotations[e2eingress.NEGAnnotation] = `{"ingress":true,"exposed_ports":{"80":{},"443":{}}}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			detectNegAnnotation(ctx, f, jig, gceController, ns, name, 2)
+
+			// Modify exposed NEG annotation, but keep ingress annotation
+			ginkgo.By("Modifying exposed NEG annotation, but keep Ingress annotation")
+			svcList, err = f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				svc.Annotations[e2eingress.NEGAnnotation] = `{"ingress":true,"exposed_ports":{"443":{}}}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			detectNegAnnotation(ctx, f, jig, gceController, ns, name, 2)
+
+			// Remove Ingress annotation. Expect 1 NEG
+			ginkgo.By("Disabling Ingress annotation, but keeping one standalone NEG")
+			svcList, err = f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				svc.Annotations[e2eingress.NEGAnnotation] = `{"ingress":false,"exposed_ports":{"443":{}}}`
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			detectNegAnnotation(ctx, f, jig, gceController, ns, name, 1)
+
+			// Remove NEG annotation entirely. Expect 0 NEGs.
+			ginkgo.By("Removing NEG annotation")
+			svcList, err = f.ClientSet.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+			framework.ExpectNoError(err)
+			for _, svc := range svcList.Items {
+				delete(svc.Annotations, e2eingress.NEGAnnotation)
+				// Service cannot be ClusterIP if it's using Instance Groups.
+				svc.Spec.Type = v1.ServiceTypeNodePort
+				_, err = f.ClientSet.CoreV1().Services(ns).Update(ctx, &svc, metav1.UpdateOptions{})
+				framework.ExpectNoError(err)
+			}
+			detectNegAnnotation(ctx, f, jig, gceController, ns, name, 0)
+		})
+	})
+})
+
+func detectNegAnnotation(ctx context.Context, f *framework.Framework, jig *e2eingress.TestJig, gceController *IngressController, ns, name string, negs int) {
+	if err := wait.Poll(5*time.Second, negUpdateTimeout, func() (bool, error) {
+		svc, err := f.ClientSet.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+
+		// if we expect no NEGs, then we should be using IGs
+		if negs == 0 {
+			err := gceController.BackendServiceUsingIG(jig.GetServicePorts(ctx, false))
+			if err != nil {
+				framework.Logf("ginkgo.Failed to validate IG backend service: %v", err)
+				return false, nil
+			}
+			return true, nil
+		}
+
+		var status e2eingress.NegStatus
+		v, ok := svc.Annotations[e2eingress.NEGStatusAnnotation]
+		if !ok {
+			framework.Logf("Waiting for %v, got: %+v", e2eingress.NEGStatusAnnotation, svc.Annotations)
+			return false, nil
+		}
+
+		err = json.Unmarshal([]byte(v), &status)
+		if err != nil {
+			framework.Logf("Error in parsing Expose NEG annotation: %v", err)
+			return false, nil
+		}
+		framework.Logf("Got %v: %v", e2eingress.NEGStatusAnnotation, v)
+
+		if len(status.NetworkEndpointGroups) != negs {
+			framework.Logf("Expected %d NEGs, got %d", negs, len(status.NetworkEndpointGroups))
+			return false, nil
+		}
+
+		gceCloud, err := GetGCECloud()
+		framework.ExpectNoError(err)
+		for _, neg := range status.NetworkEndpointGroups {
+			networkEndpoints, err := gceCloud.ListNetworkEndpoints(neg, gceController.Cloud.Zone, false)
+			framework.ExpectNoError(err)
+			if len(networkEndpoints) != 1 {
+				framework.Logf("Expect NEG %s to exist, but got %d", neg, len(networkEndpoints))
+				return false, nil
+			}
+		}
+
+		err = gceController.BackendServiceUsingNEG(jig.GetServicePorts(ctx, false))
+		if err != nil {
+			framework.Logf("ginkgo.Failed to validate NEG backend service: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		framework.ExpectNoError(err)
+	}
+}

--- a/test/e2e/ingress_controller.go
+++ b/test/e2e/ingress_controller.go
@@ -1,0 +1,685 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	// Name of the config-map and key the ingress controller stores its uid in.
+	uidConfigMap = "ingress-uid"
+	uidKey       = "uid"
+
+	// all cloud resources created by the ingress controller start with this
+	// prefix.
+	k8sPrefix = "k8s-"
+
+	// clusterDelimiter is the delimiter used by the ingress controller
+	// to split uid from other naming/metadata.
+	clusterDelimiter = "--"
+
+	// Cloud resources created by the ingress controller older than this
+	// are automatically purged to prevent running out of quota.
+	// TODO(37335): write soak tests and bump this up to a week.
+	maxAge = 48 * time.Hour
+
+	// GCE only allows names < 64 characters, and the loadbalancer controller inserts
+	// a single character of padding.
+	nameLenLimit = 62
+
+	negBackend = backendType("networkEndpointGroup")
+	igBackend  = backendType("instanceGroup")
+)
+
+type backendType string
+
+// IngressController manages implementation details of Ingress on GCE/GKE.
+type IngressController struct {
+	Ns           string
+	UID          string
+	staticIPName string
+	Client       clientset.Interface
+	Cloud        framework.CloudConfig
+}
+
+// CleanupIngressController calls cont.CleanupIngressControllerWithTimeout with hard-coded timeout
+func (cont *IngressController) CleanupIngressController(ctx context.Context) error {
+	return cont.CleanupIngressControllerWithTimeout(ctx, e2eservice.LoadBalancerCleanupTimeout)
+}
+
+// CleanupIngressControllerWithTimeout calls the IngressController.Cleanup(false)
+// followed with deleting the static ip, and then a final IngressController.Cleanup(true)
+func (cont *IngressController) CleanupIngressControllerWithTimeout(ctx context.Context, timeout time.Duration) error {
+	pollErr := wait.PollWithContext(ctx, 5*time.Second, timeout, func(ctx context.Context) (bool, error) {
+		if err := cont.Cleanup(false); err != nil {
+			framework.Logf("Monitoring glbc's cleanup of gce resources:\n%v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+
+	// Always try to cleanup even if pollErr == nil, because the cleanup
+	// routine also purges old leaked resources based on creation timestamp.
+	ginkgo.By("Performing final delete of any remaining resources")
+	if cleanupErr := cont.Cleanup(true); cleanupErr != nil {
+		ginkgo.By(fmt.Sprintf("WARNING: possibly leaked resources: %v\n", cleanupErr))
+	} else {
+		ginkgo.By("No resources leaked.")
+	}
+
+	// Static-IP allocated on behalf of the test, never deleted by the
+	// controller. Delete this IP only after the controller has had a chance
+	// to cleanup or it might interfere with the controller, causing it to
+	// throw out confusing events.
+	if ipErr := wait.PollWithContext(ctx, 5*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
+		if err := cont.deleteStaticIPs(); err != nil {
+			framework.Logf("Failed to delete static-ip: %v\n", err)
+			return false, nil
+		}
+		return true, nil
+	}); ipErr != nil {
+		// If this is a persistent error, the suite will fail when we run out
+		// of quota anyway.
+		ginkgo.By(fmt.Sprintf("WARNING: possibly leaked static IP: %v\n", ipErr))
+	}
+
+	// Logging that the GLBC failed to cleanup GCE resources on ingress deletion
+	// See kubernetes/ingress#431
+	if pollErr != nil {
+		return fmt.Errorf("error: L7 controller failed to delete all cloud resources on time. %v", pollErr)
+	}
+	return nil
+}
+
+func (cont *IngressController) getL7AddonUID(ctx context.Context) (string, error) {
+	framework.Logf("Retrieving UID from config map: %v/%v", metav1.NamespaceSystem, uidConfigMap)
+	cm, err := cont.Client.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(ctx, uidConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if uid, ok := cm.Data[uidKey]; ok {
+		return uid, nil
+	}
+	return "", fmt.Errorf("Could not find cluster UID for L7 addon pod")
+}
+
+func (cont *IngressController) deleteForwardingRule(del bool) string {
+	msg := ""
+	fwList := []compute.ForwardingRule{}
+	for _, regex := range []string{fmt.Sprintf("%vfw-.*%v.*", k8sPrefix, clusterDelimiter), fmt.Sprintf("%vfws-.*%v.*", k8sPrefix, clusterDelimiter)} {
+		gcloudComputeResourceList("forwarding-rules", regex, cont.Cloud.ProjectID, &fwList)
+		if len(fwList) == 0 {
+			continue
+		}
+		for _, f := range fwList {
+			if !cont.canDelete(f.Name, f.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				GcloudComputeResourceDelete("forwarding-rules", f.Name, cont.Cloud.ProjectID, "--global")
+			} else {
+				msg += fmt.Sprintf("%v (forwarding rule)\n", f.Name)
+			}
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteAddresses(del bool) string {
+	msg := ""
+	ipList := []compute.Address{}
+	regex := fmt.Sprintf("%vfw-.*%v.*", k8sPrefix, clusterDelimiter)
+	gcloudComputeResourceList("addresses", regex, cont.Cloud.ProjectID, &ipList)
+	if len(ipList) != 0 {
+		for _, ip := range ipList {
+			if !cont.canDelete(ip.Name, ip.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				GcloudComputeResourceDelete("addresses", ip.Name, cont.Cloud.ProjectID, "--global")
+			} else {
+				msg += fmt.Sprintf("%v (static-ip)\n", ip.Name)
+			}
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteTargetProxy(del bool) string {
+	msg := ""
+	tpList := []compute.TargetHttpProxy{}
+	regex := fmt.Sprintf("%vtp-.*%v.*", k8sPrefix, clusterDelimiter)
+	gcloudComputeResourceList("target-http-proxies", regex, cont.Cloud.ProjectID, &tpList)
+	if len(tpList) != 0 {
+		for _, t := range tpList {
+			if !cont.canDelete(t.Name, t.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				GcloudComputeResourceDelete("target-http-proxies", t.Name, cont.Cloud.ProjectID)
+			} else {
+				msg += fmt.Sprintf("%v (target-http-proxy)\n", t.Name)
+			}
+		}
+	}
+	tpsList := []compute.TargetHttpsProxy{}
+	regex = fmt.Sprintf("%vtps-.*%v.*", k8sPrefix, clusterDelimiter)
+	gcloudComputeResourceList("target-https-proxies", regex, cont.Cloud.ProjectID, &tpsList)
+	if len(tpsList) != 0 {
+		for _, t := range tpsList {
+			if !cont.canDelete(t.Name, t.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				GcloudComputeResourceDelete("target-https-proxies", t.Name, cont.Cloud.ProjectID)
+			} else {
+				msg += fmt.Sprintf("%v (target-https-proxy)\n", t.Name)
+			}
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteURLMap(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	umList, err := gceCloud.ListURLMaps()
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		return fmt.Sprintf("Failed to list url maps: %v", err)
+	}
+	if len(umList) == 0 {
+		return msg
+	}
+	for _, um := range umList {
+		if !cont.canDelete(um.Name, um.CreationTimestamp, del) {
+			continue
+		}
+		if del {
+			framework.Logf("Deleting url-map: %s", um.Name)
+			if err := gceCloud.DeleteURLMap(um.Name); err != nil &&
+				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+				msg += fmt.Sprintf("Failed to delete url map %v\n", um.Name)
+			}
+		} else {
+			msg += fmt.Sprintf("%v (url-map)\n", um.Name)
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteBackendService(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	beList, err := gceCloud.ListGlobalBackendServices()
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		return fmt.Sprintf("Failed to list backend services: %v", err)
+	}
+	if len(beList) == 0 {
+		framework.Logf("No backend services found")
+		return msg
+	}
+	for _, be := range beList {
+		if !cont.canDelete(be.Name, be.CreationTimestamp, del) {
+			continue
+		}
+		if del {
+			framework.Logf("Deleting backed-service: %s", be.Name)
+			if err := gceCloud.DeleteGlobalBackendService(be.Name); err != nil &&
+				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+				msg += fmt.Sprintf("Failed to delete backend service %v: %v\n", be.Name, err)
+			}
+		} else {
+			msg += fmt.Sprintf("%v (backend-service)\n", be.Name)
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteHTTPHealthCheck(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	hcList, err := gceCloud.ListHTTPHealthChecks()
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		return fmt.Sprintf("Failed to list HTTP health checks: %v", err)
+	}
+	if len(hcList) == 0 {
+		return msg
+	}
+	for _, hc := range hcList {
+		if !cont.canDelete(hc.Name, hc.CreationTimestamp, del) {
+			continue
+		}
+		if del {
+			framework.Logf("Deleting http-health-check: %s", hc.Name)
+			if err := gceCloud.DeleteHTTPHealthCheck(hc.Name); err != nil &&
+				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+				msg += fmt.Sprintf("Failed to delete HTTP health check %v\n", hc.Name)
+			}
+		} else {
+			msg += fmt.Sprintf("%v (http-health-check)\n", hc.Name)
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteSSLCertificate(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	sslList, err := gceCloud.ListSslCertificates()
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		return fmt.Sprintf("Failed to list ssl certificates: %v", err)
+	}
+	if len(sslList) != 0 {
+		for _, s := range sslList {
+			if !cont.canDelete(s.Name, s.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				framework.Logf("Deleting ssl-certificate: %s", s.Name)
+				if err := gceCloud.DeleteSslCertificate(s.Name); err != nil &&
+					!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+					msg += fmt.Sprintf("Failed to delete ssl certificates: %v\n", s.Name)
+				}
+			} else {
+				msg += fmt.Sprintf("%v (ssl-certificate)\n", s.Name)
+			}
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteInstanceGroup(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	// TODO: E2E cloudprovider has only 1 zone, but the cluster can have many.
+	// We need to poll on all IGs across all zones.
+	igList, err := gceCloud.ListInstanceGroups(cont.Cloud.Zone)
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		return fmt.Sprintf("Failed to list instance groups: %v", err)
+	}
+	if len(igList) == 0 {
+		return msg
+	}
+	for _, ig := range igList {
+		if !cont.canDelete(ig.Name, ig.CreationTimestamp, del) {
+			continue
+		}
+		if del {
+			framework.Logf("Deleting instance-group: %s", ig.Name)
+			if err := gceCloud.DeleteInstanceGroup(ig.Name, cont.Cloud.Zone); err != nil &&
+				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+				msg += fmt.Sprintf("Failed to delete instance group %v\n", ig.Name)
+			}
+		} else {
+			msg += fmt.Sprintf("%v (instance-group)\n", ig.Name)
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) deleteNetworkEndpointGroup(del bool) (msg string) {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	// TODO: E2E cloudprovider has only 1 zone, but the cluster can have many.
+	// We need to poll on all NEGs across all zones.
+	negList, err := gceCloud.ListNetworkEndpointGroup(cont.Cloud.Zone)
+	if err != nil {
+		if cont.isHTTPErrorCode(err, http.StatusNotFound) {
+			return msg
+		}
+		// Do not return error as NEG is still alpha.
+		framework.Logf("Failed to list network endpoint group: %v", err)
+		return msg
+	}
+	if len(negList) == 0 {
+		return msg
+	}
+	for _, neg := range negList {
+		if !cont.canDeleteNEG(neg.Name, neg.CreationTimestamp, del) {
+			continue
+		}
+		if del {
+			framework.Logf("Deleting network-endpoint-group: %s", neg.Name)
+			if err := gceCloud.DeleteNetworkEndpointGroup(neg.Name, cont.Cloud.Zone); err != nil &&
+				!cont.isHTTPErrorCode(err, http.StatusNotFound) {
+				msg += fmt.Sprintf("Failed to delete network endpoint group %v\n", neg.Name)
+			}
+		} else {
+			msg += fmt.Sprintf("%v (network-endpoint-group)\n", neg.Name)
+		}
+	}
+	return msg
+}
+
+// canDelete returns true if either the name ends in a suffix matching this
+// controller's UID, or the creationTimestamp exceeds the maxAge and del is set
+// to true. Always returns false if the name doesn't match that we expect for
+// Ingress cloud resources.
+func (cont *IngressController) canDelete(resourceName, creationTimestamp string, delOldResources bool) bool {
+	// ignore everything not created by an ingress controller.
+	splitName := strings.Split(resourceName, clusterDelimiter)
+	if !strings.HasPrefix(resourceName, k8sPrefix) || len(splitName) != 2 {
+		return false
+	}
+
+	// Resources created by the GLBC have a "0"" appended to the end if truncation
+	// occurred. Removing the zero allows the following match.
+	truncatedClusterUID := splitName[1]
+	if len(truncatedClusterUID) >= 1 && strings.HasSuffix(truncatedClusterUID, "0") {
+		truncatedClusterUID = truncatedClusterUID[:len(truncatedClusterUID)-1]
+	}
+
+	// always delete things that are created by the current ingress controller.
+	// Because of resource name truncation, this looks for a common prefix
+	if strings.HasPrefix(cont.UID, truncatedClusterUID) {
+		return true
+	}
+	if !delOldResources {
+		return false
+	}
+	return canDeleteWithTimestamp(resourceName, creationTimestamp)
+}
+
+// canDeleteNEG returns true if either the name contains this controller's UID,
+// or the creationTimestamp exceeds the maxAge and del is set to true.
+func (cont *IngressController) canDeleteNEG(resourceName, creationTimestamp string, delOldResources bool) bool {
+	if !strings.HasPrefix(resourceName, "k8s") {
+		return false
+	}
+
+	if strings.Contains(resourceName, cont.UID) {
+		return true
+	}
+
+	if !delOldResources {
+		return false
+	}
+
+	return canDeleteWithTimestamp(resourceName, creationTimestamp)
+}
+
+func canDeleteWithTimestamp(resourceName, creationTimestamp string) bool {
+	createdTime, err := time.Parse(time.RFC3339, creationTimestamp)
+	if err != nil {
+		framework.Logf("WARNING: Failed to parse creation timestamp %v for %v: %v", creationTimestamp, resourceName, err)
+		return false
+	}
+	if time.Since(createdTime) > maxAge {
+		framework.Logf("%v created on %v IS too old", resourceName, creationTimestamp)
+		return true
+	}
+	return false
+}
+
+func (cont *IngressController) deleteFirewallRule(del bool) (msg string) {
+	fwList := []compute.Firewall{}
+	regex := fmt.Sprintf("%vfw-l7%v.*", k8sPrefix, clusterDelimiter)
+	gcloudComputeResourceList("firewall-rules", regex, cont.Cloud.ProjectID, &fwList)
+	if len(fwList) != 0 {
+		for _, f := range fwList {
+			if !cont.canDelete(f.Name, f.CreationTimestamp, del) {
+				continue
+			}
+			if del {
+				GcloudComputeResourceDelete("firewall-rules", f.Name, cont.Cloud.ProjectID)
+			} else {
+				msg += fmt.Sprintf("%v (firewall rule)\n", f.Name)
+			}
+		}
+	}
+	return msg
+}
+
+func (cont *IngressController) isHTTPErrorCode(err error, code int) bool {
+	apiErr, ok := err.(*googleapi.Error)
+	return ok && apiErr.Code == code
+}
+
+// WaitForNegBackendService waits for the expected backend service to become
+func (cont *IngressController) WaitForNegBackendService(ctx context.Context, svcPorts map[string]v1.ServicePort) error {
+	return wait.PollWithContext(ctx, 5*time.Second, 1*time.Minute, func(ctx context.Context) (bool, error) {
+		err := cont.verifyBackendMode(svcPorts, negBackend)
+		if err != nil {
+			framework.Logf("Err while checking if backend service is using NEG: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// BackendServiceUsingNEG returns true only if all global backend service with matching svcPorts pointing to NEG as backend
+func (cont *IngressController) BackendServiceUsingNEG(svcPorts map[string]v1.ServicePort) error {
+	return cont.verifyBackendMode(svcPorts, negBackend)
+}
+
+// BackendServiceUsingIG returns true only if all global backend service with matching svcPorts pointing to IG as backend
+func (cont *IngressController) BackendServiceUsingIG(svcPorts map[string]v1.ServicePort) error {
+	return cont.verifyBackendMode(svcPorts, igBackend)
+}
+
+func (cont *IngressController) verifyBackendMode(svcPorts map[string]v1.ServicePort, backendType backendType) error {
+	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
+	beList, err := gceCloud.ListGlobalBackendServices()
+	if err != nil {
+		return fmt.Errorf("failed to list backend services: %w", err)
+	}
+
+	hcList, err := gceCloud.ListHealthChecks()
+	if err != nil {
+		return fmt.Errorf("failed to list health checks: %w", err)
+	}
+
+	// Generate short UID
+	uid := cont.UID
+	if len(uid) > 8 {
+		uid = uid[:8]
+	}
+
+	matchingBackendService := 0
+	for svcName, sp := range svcPorts {
+		match := false
+		bsMatch := &compute.BackendService{}
+		// NEG BackendServices' names contain the a sha256 hash of a string.
+		// This logic is copied from the ingress-gce namer.
+		// WARNING: This needs to adapt if the naming convention changed.
+		negString := strings.Join([]string{uid, cont.Ns, svcName, fmt.Sprintf("%v", sp.Port)}, ";")
+		negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))[:8]
+		for _, bs := range beList {
+			// Non-NEG BackendServices are named with the Nodeport in the name.
+			if backendType == igBackend && strings.Contains(bs.Name, strconv.Itoa(int(sp.NodePort))) {
+				match = true
+				bsMatch = bs
+				matchingBackendService++
+				break
+			}
+
+			// NEG BackendServices' names contain the a sha256 hash of a string.
+			if backendType == negBackend && strings.Contains(bs.Name, negHash) {
+				match = true
+				bsMatch = bs
+				matchingBackendService++
+				break
+			}
+		}
+
+		if match {
+			for _, be := range bsMatch.Backends {
+				if !strings.Contains(be.Group, string(backendType)) {
+					return fmt.Errorf("expect to find backends with type %q, but got backend group: %v", backendType, be.Group)
+				}
+			}
+
+			// Check that the correct HealthCheck exists for the BackendService
+			hcMatch := false
+			for _, hc := range hcList {
+				if hc.Name == bsMatch.Name {
+					hcMatch = true
+					break
+				}
+			}
+
+			if !hcMatch {
+				return fmt.Errorf("missing healthcheck for backendservice: %v", bsMatch.Name)
+			}
+		}
+	}
+
+	if matchingBackendService != len(svcPorts) {
+		beNames := []string{}
+		for _, be := range beList {
+			beNames = append(beNames, be.Name)
+		}
+		return fmt.Errorf("expect %d backend service with backend type: %v, but got %d matching backend service. Expect backend services for service ports: %v, but got backend services: %v", len(svcPorts), backendType, matchingBackendService, svcPorts, beNames)
+	}
+
+	return nil
+}
+
+// Cleanup cleans up cloud resources.
+// If del is false, it simply reports existing resources without deleting them.
+// If dle is true, it deletes resources it finds acceptable (see canDelete func).
+func (cont *IngressController) Cleanup(del bool) error {
+	// Ordering is important here because we cannot delete resources that other
+	// resources hold references to.
+	errMsg := cont.deleteForwardingRule(del)
+	// Static IPs are named after forwarding rules.
+	errMsg += cont.deleteAddresses(del)
+
+	errMsg += cont.deleteTargetProxy(del)
+	errMsg += cont.deleteURLMap(del)
+	errMsg += cont.deleteBackendService(del)
+	errMsg += cont.deleteHTTPHealthCheck(del)
+
+	errMsg += cont.deleteInstanceGroup(del)
+	errMsg += cont.deleteNetworkEndpointGroup(del)
+	errMsg += cont.deleteFirewallRule(del)
+	errMsg += cont.deleteSSLCertificate(del)
+
+	// TODO: Verify instance-groups, issue #16636. Gcloud mysteriously barfs when told
+	// to unmarshal instance groups into the current vendored gce-client's understanding
+	// of the struct.
+	if errMsg == "" {
+		return nil
+	}
+	return fmt.Errorf(errMsg)
+}
+
+// Init initializes the IngressController with an UID
+func (cont *IngressController) Init(ctx context.Context) error {
+	uid, err := cont.getL7AddonUID(ctx)
+	if err != nil {
+		return err
+	}
+	cont.UID = uid
+	// There's a name limit imposed by GCE. The controller will truncate.
+	testName := fmt.Sprintf("k8s-fw-foo-app-X-%v--%v", cont.Ns, cont.UID)
+	if len(testName) > nameLenLimit {
+		framework.Logf("WARNING: test name including cluster UID: %v is over the GCE limit of %v", testName, nameLenLimit)
+	} else {
+		framework.Logf("Detected cluster UID %v", cont.UID)
+	}
+	return nil
+}
+
+// deleteStaticIPs deletes all static-ips allocated through calls to
+// CreateStaticIP.
+func (cont *IngressController) deleteStaticIPs() error {
+	if cont.staticIPName != "" {
+		if err := GcloudComputeResourceDelete("addresses", cont.staticIPName, cont.Cloud.ProjectID, "--global"); err == nil {
+			cont.staticIPName = ""
+		} else {
+			return err
+		}
+	} else {
+		e2eIPs := []compute.Address{}
+		gcloudComputeResourceList("addresses", "e2e-.*", cont.Cloud.ProjectID, &e2eIPs)
+		ips := []string{}
+		for _, ip := range e2eIPs {
+			ips = append(ips, ip.Name)
+		}
+		framework.Logf("None of the remaining %d static-ips were created by this e2e: %v", len(ips), strings.Join(ips, ", "))
+	}
+	return nil
+}
+
+// gcloudComputeResourceList unmarshals json output of gcloud into given out interface.
+func gcloudComputeResourceList(resource, regex, project string, out interface{}) {
+	// gcloud prints a message to stderr if it has an available update
+	// so we only look at stdout.
+	command := []string{
+		"compute", resource, "list",
+		fmt.Sprintf("--filter='name ~ \"%q\"'", regex),
+		fmt.Sprintf("--project=%v", project),
+		"-q", "--format=json",
+	}
+	output, err := exec.Command("gcloud", command...).Output()
+	if err != nil {
+		errCode := -1
+		errMsg := ""
+		if exitErr, ok := err.(utilexec.ExitError); ok {
+			errCode = exitErr.ExitStatus()
+			errMsg = exitErr.Error()
+			if osExitErr, ok := err.(*exec.ExitError); ok {
+				errMsg = fmt.Sprintf("%v, stderr %v", errMsg, string(osExitErr.Stderr))
+			}
+		}
+		framework.Logf("Error running gcloud command 'gcloud %s': err: %v, output: %v, status: %d, msg: %v", strings.Join(command, " "), err, string(output), errCode, errMsg)
+	}
+	if err := json.Unmarshal([]byte(output), out); err != nil {
+		framework.Logf("Error unmarshalling gcloud output for %v: %v, output: %v", resource, err, string(output))
+	}
+}
+
+// GcloudComputeResourceDelete deletes the specified compute resource by name and project.
+func GcloudComputeResourceDelete(resource, name, project string, args ...string) error {
+	framework.Logf("Deleting %v: %v", resource, name)
+	argList := append([]string{"compute", resource, "delete", name, fmt.Sprintf("--project=%v", project), "-q"}, args...)
+	output, err := exec.Command("gcloud", argList...).CombinedOutput()
+	if err != nil {
+		framework.Logf("Error deleting %v, output: %v\nerror: %+v", resource, string(output), err)
+	}
+	return err
+}

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/kubernetes/test/e2e/framework"
 	frameworkconfig "k8s.io/kubernetes/test/e2e/framework/config"
+	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 )
 
 const kubeconfigEnvVar = "KUBECONFIG"
@@ -53,6 +54,10 @@ func init() {
 	flag.Parse()
 
 	framework.AfterReadingAllFlags(&framework.TestContext)
+
+	if framework.TestContext.RepoRoot != "" {
+		testfiles.AddFileSource(testfiles.RootFileSource{Root: framework.TestContext.RepoRoot})
+	}
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: echomap
+spec:
+  # kubemci requires a default backend.
+  defaultBackend:
+    service:
+      name: echoheadersx
+      port:
+        number: 80
+  rules:
+  - host: foo.bar.com
+    http:
+      paths:
+      - path: /foo
+        pathType: "ImplementationSpecific"
+        backend:
+          service:
+            name: echoheadersx
+            port:
+              number: 80
+  - host: bar.baz.com
+    http:
+      paths:
+      - path: /bar
+        pathType: "ImplementationSpecific"
+        backend:
+          service:
+            name: echoheadersy
+            port:
+              number: 80
+      - path: /foo
+        pathType: "ImplementationSpecific"
+        backend:
+          service:
+            name: echoheadersx
+            port:
+              number: 80
+

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: echoheaders
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: echoheaders
+    spec:
+      containers:
+      - name: echoheaders
+        image: registry.k8s.io/e2e-test-images/agnhost:2.39
+        command:
+        - /agnhost
+        - netexec
+        - --http-port=8080
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 1
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 10

--- a/test/e2e/testing-manifests/ingress/http/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/svc.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheadersx
+  labels:
+    app: echoheaders
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheadersy
+  labels:
+    app: echoheaders
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders
+

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hostname
+spec:
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/rc.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: hostname
+  name: hostname
+spec:
+  minReadySeconds: 60
+  selector:
+    matchLabels:
+      run: hostname
+  template:
+    metadata:
+      labels:
+        run: hostname
+    spec:
+      containers:
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        command: ["/agnhost", "serve-hostname"]
+        imagePullPolicy: IfNotPresent
+        name: hostname
+      terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hostname
+  annotations:
+    cloud.google.com/neg: '{"ingress":true}'
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 9376
+  selector:
+    run: hostname
+  sessionAffinity: None
+  type: ClusterIP

--- a/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hostname
+spec:
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/rc.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: hostname
+  name: hostname
+spec:
+  selector:
+    matchLabels:
+      run: hostname
+  template:
+    metadata:
+      labels:
+        run: hostname
+    spec:
+      containers:
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        name: host1
+        args: ["serve-hostname", "--http=true", "--udp=false", "--port=8000"]
+        ports:
+        - protocol: TCP
+          containerPort: 8000
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        name: host2
+        args: ["serve-hostname", "--http=true", "--udp=false", "--port=8080"]
+        ports:
+        - protocol: TCP
+          containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/neg-exposed/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hostname
+  annotations:
+    cloud.google.com/neg: '{"ingress":true,"exposed_ports":{"80":{},"443":{}}}'
+spec:
+  ports:
+  - port: 80
+    name: host1
+    protocol: TCP
+    targetPort: 8000
+  - port: 443
+    name: host2
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: hostname
+  sessionAffinity: None
+  type: ClusterIP

--- a/test/e2e/testing-manifests/ingress/neg/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/ing.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hostname
+spec:
+  defaultBackend:
+    service:
+      name: hostname
+      port:
+        number: 80

--- a/test/e2e/testing-manifests/ingress/neg/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/rc.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: hostname
+  name: hostname
+spec:
+  minReadySeconds: 60
+  selector:
+    matchLabels:
+      run: hostname
+  template:
+    metadata:
+      labels:
+        run: hostname
+    spec:
+      containers:
+      - image: registry.k8s.io/e2e-test-images/agnhost:2.32
+        command: ["/agnhost", "serve-hostname"]
+        imagePullPolicy: IfNotPresent
+        name: hostname
+      terminationGracePeriodSeconds: 120

--- a/test/e2e/testing-manifests/ingress/neg/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hostname
+  annotations:
+    cloud.google.com/neg: '{"ingress":true}'
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 9376
+  selector:
+    run: hostname
+  sessionAffinity: None
+  type: NodePort

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -50,6 +50,8 @@ source ${REPO_ROOT}/test/boskos.sh
 VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
 VERBOSITY=2
 DEFAULT_GCP_ZONE="us-central1-b"
+MASTER_SIZE="n1-standard-8"
+NODE_SIZE="n1-standard-4"
 # run-id is set to milliseconds since the unix epoch.
 RUN_ID="$(date +%s%N | cut -b1-13)"
 RUN_DIR="${REPO_ROOT}/_rundir/${RUN_ID}"
@@ -170,6 +172,8 @@ kubetest2 gce \
 	  --up \
 	  --down \
 	  --test ginkgo \
+	  --master-size ${MASTER_SIZE} \
+	  --node-size ${NODE_SIZE} \
 	  --overwrite-logs-dir \
 	  -- \
 	  --use-built-binaries true \


### PR DESCRIPTION
* Migrates the gce-specific e2e ingress tests from k/k in-tree to this `cloud-provider-gcp` repository.
* Previous file location (at `v1.30`): https://github.com/kubernetes/kubernetes/blob/release-1.30/test/e2e/network/ingress_gce.go

#### Status
* 9 out of 10 tests passing (one test is currently commented out--PR on-hold)
```
Running Suite: Cloud Provider GCP End-to-End Tests - /home/prow/go/src/cloud-provider-gcp/_rundir/1716756703765
===============================================================================================================
Random Seed: 1716758095 - will randomize all specs
Will run 9 of 9 specs
Running in parallel across 30 processes
•••••••••
Ran 9 of 9 Specs in 1391.378 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 0 Skipped
```
* Possible resource leakage
