### PR TITLE
Conditionally add the graceful shutdown Kubelet flags

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -807,6 +807,15 @@ function construct-linux-kubelet-flags {
       flags+=" --resolv-conf=/run/systemd/resolve/resolv.conf"
     fi
   fi
+  
+  # Conditionally add the graceful shutdown flags
+  if [[ -n "${SHUTDOWN_GRACE_PERIOD:-}" ]]; then
+    flags+=" --shutdown-grace-period=${SHUTDOWN_GRACE_PERIOD}"
+  fi
+  if [[ -n "${SHUTDOWN_GRACE_PERIOD_CRITICAL_PODS:-}" ]]; then
+    flags+=" --shutdown-grace-period-critical-pods=${SHUTDOWN_GRACE_PERIOD_CRITICAL_PODS}"
+  fi
+
   flags+=" --volume-plugin-dir=${VOLUME_PLUGIN_DIR}"
   local node_labels
   node_labels="$(build-linux-node-labels "${node_type}")"


### PR DESCRIPTION
This PR introduces changes to conditionally add the graceful shutdown Kubelet flags `shutdown-grace-period` and `shutdown-grace-period-critical-pods`.

This change is necessary to facilitate the testing of the graceful shutdown feature in Kubernetes e2e tests.


