### PR TITLE
[Cherry-pick #679 to release-1.30] L4 ILB - skip nodes from the non default network if multi subnet is turned on.

### DIFF
--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -114,6 +114,10 @@ func createAndInsertNodes(gce *Cloud, nodeNames []string, zoneName string) ([]*v
 						v1.LabelTopologyZone: zoneName,
 					},
 				},
+				Spec: v1.NodeSpec{
+					// Add PodCIDR for multi subnet purpose. Nodes need to have PodCIDR to be regarded as nodes from the default subnet (unless they have the subnet label).
+					PodCIDR: "192.168.0.0/0",
+				},
 			},
 		)
 


### PR DESCRIPTION
Cherry-pick #679

L4 ILB - skip nodes from the non default network if multi subnet is turned on.

(cherry picked from commit 543f0b63c987c1775892859a8b82e1d7ebbdd19d)