### PR TITLE
[Cherrypick #689 to release-1.29] Order node addresses based on cluster stack type

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -96,9 +96,26 @@ var _ cloudprovider.Clusters = (*Cloud)(nil)
 
 type StackType string
 
+// NetworkStackDualStack is deprecated, use `clusterStackDualStack` instead.
 const NetworkStackDualStack StackType = "IPV4_IPV6"
+
+// NetworkStackIPV4 is deprecated, use `clusterStackIPV4` instead.
 const NetworkStackIPV4 StackType = "IPV4"
+
+// NetworkStackIPV6 is deprecated, use `clusterStackIPV6` instead.
 const NetworkStackIPV6 StackType = "IPV6"
+
+// clusterStackDualStack represents a dual stack cluster, i. e. Pods and Services are addressable with both
+// IPv4 and IPv6 addresses. The underlying VPC's stack type must be dual as well.
+const clusterStackDualStack StackType = "IPV4_IPV6"
+
+// clusterStackIPV4 represents a cluster in which Pods and Services are addressable with IPv4 addresses.
+// The underlying VPC's stack type could be either IPV4 or dual stack IPV4_IPV6.
+const clusterStackIPV4 StackType = "IPV4"
+
+// clusterStackIPV6 represents a cluster in which Pods and Services are addressable with IPv6 addresses.
+// The underlying VPC's stack type could be either IPV6 or dual stack IPV4_IPV6.
+const clusterStackIPV6 StackType = "IPV6"
 
 // Cloud is an implementation of Interface, LoadBalancer and Instances for Google Compute Engine.
 type Cloud struct {

--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -40,6 +40,7 @@ type TestClusterValues struct {
 	Regional          bool
 	NetworkURL        string
 	SubnetworkURL     string
+	StackType         StackType
 }
 
 // DefaultTestClusterValues Creates a reasonable set of default cluster values
@@ -52,6 +53,7 @@ func DefaultTestClusterValues() TestClusterValues {
 		SecondaryZoneName: "us-central1-c",
 		ClusterID:         "test-cluster-id",
 		ClusterName:       "Test-Cluster-Name",
+		StackType:         clusterStackIPV4,
 	}
 }
 
@@ -86,6 +88,7 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		regional:            vals.Regional,
 		networkURL:          vals.NetworkURL,
 		unsafeSubnetworkURL: vals.SubnetworkURL,
+		stackType:           vals.StackType,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c
@@ -95,4 +98,9 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 // UpdateFakeGCECloud updates the fake GCE cloud with the specified values. Currently only the onXPN value is updated.
 func UpdateFakeGCECloud(g *Cloud, vals TestClusterValues) {
 	g.onXPN = vals.OnXPN
+}
+
+// SetFakeStackType updates the fake GCE cloud with the specified stack type.
+func SetFakeStackType(g *Cloud, stackType StackType) {
+	g.stackType = stackType
 }

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
+	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -92,6 +93,34 @@ func (g *Cloud) ToInstanceReferences(zone string, instanceNames []string) (refs 
 	return refs
 }
 
+// orderAddresses orders node IP addresses:
+//   - In single-stack IPv6 clusters IPv6 addresses before the IPv4 addresses.
+//   - In other clusters IPv4 addresses before IPv6 addresses.
+func (g *Cloud) orderAddresses(addresses []v1.NodeAddress) []v1.NodeAddress {
+	preferIPv6 := g.stackType == clusterStackIPV6
+	sortedAddresses := make([]v1.NodeAddress, 0, len(addresses))
+
+	// Add the IP addresses with the preferred ip family first.
+	for _, address := range addresses {
+		ip := net.ParseIP(address.Address)
+		// Non IP addresses as hostname will get a nil ip.
+		if ip == nil || utilnet.IsIPv6(ip) == preferIPv6 {
+			sortedAddresses = append(sortedAddresses, address)
+		}
+	}
+
+	// Add the addresses that are not of the prefered ip family.
+	for _, address := range addresses {
+		ip := net.ParseIP(address.Address)
+		// Non IP addresses as hostname will get a nil ip.
+		if ip != nil && utilnet.IsIPv6(ip) != preferIPv6 {
+			sortedAddresses = append(sortedAddresses, address)
+		}
+	}
+
+	return sortedAddresses
+}
+
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
@@ -100,6 +129,7 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 	instanceName := string(nodeName)
 
 	if g.useMetadataServer {
+
 		// Use metadata server if possible
 		if g.isCurrentInstance(instanceName) {
 
@@ -121,12 +151,17 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 				if err != nil {
 					return nil, fmt.Errorf("couldn't get internal IP: %v", err)
 				}
-				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
+
+				if internalIP == "" {
+					klog.Infof("No internal IPv4 address found for node %v.", nodeName)
+				} else {
+					nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIP})
+				}
 
 				// Both internal and external IPv6 addresses are written to this array
 				ipv6s, err := metadata.Get(fmt.Sprintf(networkInterfaceIPV6, nic))
 				if err != nil || ipv6s == "" {
-					klog.Infof("no internal IPV6 addresses found for node %v: %v", nodeName, err)
+					klog.Infof("No internal IPV6 addresses found for node %v: %v.", nodeName, err)
 				} else {
 					ipv6Arr := strings.Split(ipv6s, "/\n")
 					var internalIPV6 string
@@ -140,7 +175,7 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 					if internalIPV6 != "" {
 						nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: internalIPV6})
 					} else {
-						klog.Warningf("internal IPV6 range is empty for node %v", nodeName)
+						klog.Warningf("Internal IPv6 range is empty for node %v.", nodeName)
 					}
 				}
 
@@ -170,14 +205,14 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 
 			internalDNSFull, err := metadata.Get("instance/hostname")
 			if err != nil {
-				klog.Warningf("couldn't get full internal DNS name: %v", err)
+				klog.Warningf("Couldn't get full internal DNS name: %v.", err)
 			} else {
 				nodeAddresses = append(nodeAddresses,
 					v1.NodeAddress{Type: v1.NodeInternalDNS, Address: internalDNSFull},
 					v1.NodeAddress{Type: v1.NodeHostName, Address: internalDNSFull},
 				)
 			}
-			return nodeAddresses, nil
+			return g.orderAddresses(nodeAddresses), nil
 		}
 	}
 
@@ -249,7 +284,9 @@ func (g *Cloud) nodeAddressesFromInstance(instance *compute.Instance) ([]v1.Node
 	}
 	nodeAddresses := []v1.NodeAddress{}
 	for _, nic := range instance.NetworkInterfaces {
-		nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nic.NetworkIP})
+		if nic.NetworkIP != "" {
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeInternalIP, Address: nic.NetworkIP})
+		}
 		for _, config := range nic.AccessConfigs {
 			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: config.NatIP})
 		}
@@ -259,7 +296,7 @@ func (g *Cloud) nodeAddressesFromInstance(instance *compute.Instance) ([]v1.Node
 		}
 	}
 
-	return nodeAddresses, nil
+	return g.orderAddresses(nodeAddresses), nil
 }
 
 func getIPV6AddressFromInterface(nic *compute.NetworkInterface) string {


### PR DESCRIPTION
[Cherrypick #689] Order node addresses based on cluster stack type

(cherry picked from commit 1dc6be82077dfc161167be71ad6fe306080a389c)