### PR TITLE
Print logs when adding a node in unmanaged zone

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -827,6 +828,9 @@ func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
 				g.nodeZones[newZone] = sets.NewString()
 			}
 			g.nodeZones[newZone].Insert(newNode.ObjectMeta.Name)
+			if !slices.Contains(g.managedZones, newZone) {
+				klog.Warningf("Initializing node %s in an unmanaged zone %s. Managed zones: %v", newNode.ObjectMeta.Name, newZone, g.managedZones)
+			}
 		}
 	}
 }

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -739,6 +739,8 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 
 // Gets the named instance, returning cloudprovider.InstanceNotFound if the instance is not found
 func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
+	klog.Infof("Searching node %s in managed zones %v", name, g.managedZones)
+
 	// Avoid changing behaviour when not managing multiple zones
 	for _, zone := range g.managedZones {
 		instance, err := g.getInstanceFromProjectInZoneByName(g.projectID, zone, name)


### PR DESCRIPTION
Solves #758

If we add a new node from another zone in single zone mode (without multizone=true in cloud config), the CCM can't find it because CCM searches for it only in one zone where CCM runs. Then after one minute of trying CCM removes the new uninitialised node from the cluster.

I propose to add some logs to make it clear what happens.
