### PR TITLE
Use protobuf encoding by default in K8s client in gcp-controller-manager

### DIFF
--- a/cmd/gcp-controller-manager/main.go
+++ b/cmd/gcp-controller-manager/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -121,6 +122,8 @@ func main() {
 	// bump the QPS limits per controller up from defaults of 5 qps / 10 burst
 	s.informerKubeconfig.QPS = *kubeconfigQPS
 	s.informerKubeconfig.Burst = *kubeconfigBurst
+	// use protobuf encoding which is more efficient than default JSON encoding
+	s.informerKubeconfig.ContentType = runtime.ContentTypeProtobuf
 	// kubeconfig for controllers is the same, plus it has a client timeout for
 	// API requests. Informers shouldn't have a timeout because that breaks
 	// watch requests.


### PR DESCRIPTION
If not specified explicitly, JSON encoding is used by default when talking to kube-apiserver.

For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.