### PR TITLE
Reuse shared informers in nodeipam and gkenetworkparamset controllers

### DIFF
--- a/cmd/cloud-controller-manager/gkenetworkparamsetcontroller.go
+++ b/cmd/cloud-controller-manager/gkenetworkparamsetcontroller.go
@@ -56,7 +56,7 @@ func startGkeNetworkParamsController(ccmConfig *cloudcontrollerconfig.CompletedC
 	gnpInformer := nwInfFactory.Networking().V1().GKENetworkParamSets()
 
 	gkeNetworkParamsetController := gkenetworkparamsetcontroller.NewGKENetworkParamSetController(
-		controllerCtx.InformerFactory.Core().V1().Nodes(),
+		ccmConfig.SharedInformers.Core().V1().Nodes(),
 		networkClient,
 		gnpInformer,
 		nwInformer,

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -138,9 +138,9 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 	nwInformer := nwInfFactory.Networking().V1().Networks()
 	gnpInformer := nwInfFactory.Networking().V1().GKENetworkParamSets()
 	nodeIpamController, err := nodeipamcontroller.NewNodeIpamController(
-		ctx.InformerFactory.Core().V1().Nodes(),
+		ccmConfig.SharedInformers.Core().V1().Nodes(),
 		cloud,
-		ctx.ClientBuilder.ClientOrDie("node-controller"),
+		ccmConfig.ClientBuilder.ClientOrDie("node-controller"),
 		nwInformer,
 		gnpInformer,
 		clusterCIDRs,


### PR DESCRIPTION
For core K8s APIs, `cloud-node`, `cloud-node-lifecycle`, `service` and `route` controllers fetch informers from the completed config rather than from the controller context (e.g. [here](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/cloud-provider/app/core.go#L45)), so we basically mimic that behavior with this change.

This gives us two small performance gains:
- We deduplicate the API traffic by opening less watches from the CCM,
- Shared informers from the completed config use protobuf encoding instead of the (less efficient) JSON encoding.
  - The fact that these informers use protobuf comes from the  that CCM's config defaulting runs defaulting for [generic CM config](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/cloud-provider/config/v1alpha1/defaults.go#L49-L50) that runs defaulting for the [client connection config](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/controller-manager/config/v1alpha1/defaults.go#L48-L49) that [sets the content type to protobuf](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L66-L68).
  - That content type is passed to "kubeconfig" [here](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/cloud-provider/options/options.go#L185) and used for creating the client builder and the shared informers [here](https://github.com/kubernetes/kubernetes/blob/283ff763b3fd82c831f1f45efa87fb2aa518d184/staging/src/k8s.io/cloud-provider/options/options.go#L228-L240).
  - Apparently, we don't run analogous defaulting for the fields of controller context - but I didn't delve deeper into understanding that given we have simpler solution at hand here 🤷.

I didn't find an elegant way to dedupe `NetworkInformer` and `GKENetworkParamSetInformer` informers used by both of these controllers, though, so I left it out of this PR.