### PR TITLE
When detecting RBS service, also pay attention to the V3 finalizer th…

### DIFF
--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -647,8 +647,12 @@ func TestEnsureExternalLoadBalancerRBSFinalizer(t *testing.T) {
 		finalizers []string
 		wantError  *error
 	}{
-		"When has ELBRbsFinalizer": {
+		"When has ELBRbsFinalizer V2": {
 			finalizers: []string{NetLBFinalizerV2},
+			wantError:  &cloudprovider.ImplementedElsewhere,
+		},
+		"When has ELBRbsFinalizer V3": {
+			finalizers: []string{NetLBFinalizerV3},
 			wantError:  &cloudprovider.ImplementedElsewhere,
 		},
 		"When has no finalizer": {

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -50,6 +50,9 @@ import (
 const (
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
+
+	// NetLBFinalizerV3 is the finalizer used by newer controllers that manage L4 External LoadBalancer services (similar to V2 but this one is for NEG based LBs).
+	NetLBFinalizerV3 = "gke.networking.io/l4-netlb-v3"
 )
 
 func fakeGCECloud(vals TestClusterValues) (*Cloud, error) {
@@ -406,7 +409,7 @@ func usesL4RBS(service *v1.Service, forwardingRule *compute.ForwardingRule) bool
 		return true
 	}
 	// Detect RBS by finalizer
-	if hasFinalizer(service, NetLBFinalizerV2) {
+	if hasFinalizer(service, NetLBFinalizerV2) || hasFinalizer(service, NetLBFinalizerV3) {
 		return true
 	}
 	// Detect RBS by existing forwarding rule with Backend Service attached


### PR DESCRIPTION
…at will be used by the NEG backed NetLB.

Basically the legacy controller should treat the services with V3 finalizer as it treats services with V2 one.

This is needed for L4 NetLB NEG backed services, an extra check to make sure that if someone removes annotations the legacy controller won't pick it up.