### PR TITLE
update gke-networking-api in order to use nodetopology CRD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 )
 
 require (
-	github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240703141847-066e11533e15
+	github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240904205008-bc15495fd43f
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/natefinch/atomic v1.0.1
 	k8s.io/cloud-provider v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ cloud.google.com/go/compute/metadata v0.5.2/go.mod h1:C66sj2AluDcIqakBq/M8lw8/yb
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240703141847-066e11533e15 h1:UBDSMOhRBmlQaFwx0zd/yiFXhhJExFl5MIus0DksRAk=
-github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240703141847-066e11533e15/go.mod h1:hngDInU0bLls5Nk7vssNbT6noFXS6ZwldjRhHwu85uE=
+github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240904205008-bc15495fd43f h1:OPE+MYCwdQNms+QAXgHjR03TKCHXoqlurXiuhYDuEdI=
+github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240904205008-bc15495fd43f/go.mod h1:YnoYXo/cwpqFmIXKblHOV5jFEpsSL3PZeo0zaR3oGTI=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0 h1:lwL1vLWmdBJ5h+StMEN6+GMz1J/Y0yUU3RDv+QBy+Q4=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v1.25.0/go.mod h1:UTfhBnADaj2rybPT049NScSh7Eall3u2ib43wmz3deg=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=

--- a/vendor/github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1/annotations.go
+++ b/vendor/github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1/annotations.go
@@ -63,8 +63,12 @@ const (
 	AutoGenAnnotationValTrue = "true"
 	// NorthInterfacesAnnotationKey is the annotation key used to hold interfaces data per node.
 	NorthInterfacesAnnotationKey = "networking.gke.io/north-interfaces"
-	// NICInfoAnnotationKey specifies the mapping between the fist IP addresse and the PCI BDF number on the node.
+	// NICInfoAnnotationKey specifies the mapping between the fist IP address and the PCI BDF number on the node.
 	NICInfoAnnotationKey = "networking.gke.io/nic-info"
+	// InterfaceStatusAnnotationKey is the key of the annotation which shows information of each interface of a pod.
+	InterfaceStatusAnnotationKey = "networking.gke.io/interface-status"
+	// NetworkGatewayIPAnnotationKey is the network annotation key used to hold egress NAT gateway IP.
+	NetworkGatewayIPAnnotationKey = "networking.gke.io/gateway-ip"
 )
 
 // InterfaceAnnotation is the value of the interface annotation.
@@ -125,6 +129,10 @@ type NodeNetworkAnnotation []NodeNetworkStatus
 // +kubebuilder:object:generate:=false
 type PodIPsAnnotation []PodIP
 
+// InterfaceStatusAnnotation is the value of the network interface status annotation.
+// +kubebuilder:object:generate:=false
+type InterfaceStatusAnnotation []InterfaceStatus
+
 // MultiNetworkAnnotation is the value of networks annotation.
 // +kubebuilder:object:generate:=false
 type MultiNetworkAnnotation []NodeNetwork
@@ -177,6 +185,32 @@ type NorthInterface struct {
 	IpAddress string `json:"ipAddress"`
 }
 
+// InterfaceStatus holds information of a NIC of a pod.
+// +kubebuilder:object:generate:=false
+type InterfaceStatus struct {
+	// NetworkName refers to the network object associated with this NIC.
+	NetworkName string `json:"networkName"`
+
+	// IPAddresses are the IP addresses assigned to this NIC.
+	// Can be either IPv4 or IPv6.
+	IPAddresses []string `json:"ipAddresses"`
+
+	// MACAddress is the MAC address assigned to the NIC.
+	MACAddress string `json:"macAddress"`
+
+	// Routes contains a list of routes for the network this interface connects to.
+	Routes []Route `json:"routes,omitempty"`
+
+	// Gateway4 defines the gateway IPv4 address for the network this interface connects to.
+	Gateway4 *string `json:"gateway4,omitempty"`
+
+	// DNSConfig specifies the DNS configuration of the network this interface connects to.
+	DNSConfig *DNSConfig `json:"dnsConfig,omitempty"`
+
+	// DHCPServerIP is the IP of the DHCP server.
+	DHCPServerIP *string `json:"dhcpServerIP,omitempty"`
+}
+
 // ParseNodeNetworkAnnotation parses the given annotation to NodeNetworkAnnotation.
 func ParseNodeNetworkAnnotation(annotation string) (NodeNetworkAnnotation, error) {
 	ret := &NodeNetworkAnnotation{}
@@ -208,6 +242,13 @@ func ParseNorthInterfacesAnnotation(annotation string) (NorthInterfacesAnnotatio
 // ParseNICInfoAnnotation parses given annotation to NicInfoAnnotation
 func ParseNICInfoAnnotation(annotation string) (NICInfoAnnotation, error) {
 	ret := &NICInfoAnnotation{}
+	err := json.Unmarshal([]byte(annotation), ret)
+	return *ret, err
+}
+
+// ParseInterfaceStatusAnnotation parses the given annotation to InterfaceStatusAnnotation
+func ParseInterfaceStatusAnnotation(annotation string) (InterfaceStatusAnnotation, error) {
+	ret := &InterfaceStatusAnnotation{}
 	err := json.Unmarshal([]byte(annotation), ret)
 	return *ret, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ cloud.google.com/go/compute/metadata
 ## explicit; go 1.16
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
-# github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240703141847-066e11533e15
+# github.com/GoogleCloudPlatform/gke-networking-api v0.1.2-0.20240904205008-bc15495fd43f
 ## explicit; go 1.22.0
 github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1
 github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1alpha1


### PR DESCRIPTION
To use nodetopology [CRD](https://github.com/GoogleCloudPlatform/gke-networking-api/pull/22), upgrade `gke-networking-api` version.

`
go get github.com/GoogleCloudPlatform/gke-networking-api@bc15495fd43f01b9d0cc9e244f71d024d81450d4 && ./tools/update_vendor.sh
`

cc. @basantsa1989 @sawsa307