### PR TITLE
Update cpcredential.go to include AR endpoints in THP and THQ in containerRegistryUrls

### DIFF
--- a/providers/gce/gcpcredential/gcpcredential.go
+++ b/providers/gce/gcpcredential/gcpcredential.go
@@ -48,7 +48,7 @@ var GCEProductNameFile = "/sys/class/dmi/id/product_name"
 
 // For these urls, the parts of the host name can be glob, for example '*.gcr.io" will match
 // "foo.gcr.io" and "bar.gcr.io".
-var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.gcr.io", "*.pkg.dev", "docker.*.goog"}
+var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.gcr.io", "*.pkg.dev", "docker.*.goog", "*.qs3nsregistry.fr", "*.s3nsregistry.fr"}
 
 var metadataHeader = &http.Header{
 	"Metadata-Flavor": []string{"Google"},


### PR DESCRIPTION
TPC THP and THQ will have different AR endpoints and we will need to update them to allow us to download images from AR in TPC