### PR TITLE
Allow ContainerRegistryProvider to skip Match ContainerRegistryUrls when query the token

### DIFF
--- a/cmd/auth-provider-gcp/provider/provider.go
+++ b/cmd/auth-provider-gcp/provider/provider.go
@@ -43,7 +43,8 @@ const (
 func MakeRegistryProvider(transport *http.Transport) *gcpcredential.ContainerRegistryProvider {
 	httpClient := makeHTTPClient(transport)
 	provider := &gcpcredential.ContainerRegistryProvider{
-		MetadataProvider: gcpcredential.MetadataProvider{Client: httpClient},
+		MetadataProvider:     gcpcredential.MetadataProvider{Client: httpClient},
+		UseRegistryFromImage: true,
 	}
 	return provider
 }

--- a/cmd/auth-provider-gcp/provider/provider_test.go
+++ b/cmd/auth-provider-gcp/provider/provider_test.go
@@ -44,8 +44,9 @@ func hasURL(url string, response *credentialproviderapi.CredentialProviderRespon
 }
 
 func TestContainerRegistry(t *testing.T) {
+	registryURL := strings.Split(dummyImage, "/")[0]
 	// Taken from from pkg/credentialprovider/gcp/metadata_test.go in kubernetes/kubernetes
-	registryURL := "container.cloud.google.com"
+	gcpRegistryURL := "container.cloud.google.com"
 	token := &gcpcredential.TokenBlob{AccessToken: dummyToken} // Fake value for testing.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defaultPrefix := "/computeMetadata/v1/instance/service-accounts/default/"
@@ -85,8 +86,14 @@ func TestContainerRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
 	}
-	if hasURL(registryURL, response) == false {
-		t.Errorf("URL %s expected in response, not found (response: %s)", registryURL, response.Auth)
+
+	if !hasURL(registryURL, response) || !hasURL(gcpRegistryURL, response) {
+		if !hasURL(registryURL, response) {
+			t.Errorf("URL %s expected in response, not found (response: %s)", registryURL, response.Auth)
+		}
+		if !hasURL(gcpRegistryURL, response) {
+			t.Errorf("URL %s expected in response, not found (response: %s)", gcpRegistryURL, response.Auth)
+		}
 	}
 	if expectedCacheKey != response.CacheKeyType {
 		t.Errorf("Expected %s as cache key (found %s instead)", expectedCacheKey, response.CacheKeyType)

--- a/pkg/gcpcredential/gcpcredential.go
+++ b/pkg/gcpcredential/gcpcredential.go
@@ -82,6 +82,7 @@ type DockerConfigURLKeyProvider struct {
 //	Password: "{access token from metadata}"
 type ContainerRegistryProvider struct {
 	MetadataProvider
+	UseRegistryFromImage bool
 }
 
 // Returns true if it finds a local GCE VM.
@@ -257,6 +258,14 @@ func (g *ContainerRegistryProvider) Provide(image string) credentialconfig.Docke
 		Username: "_token",
 		Password: parsedBlob.AccessToken,
 		Email:    string(email),
+	}
+
+	// If UseRegistryFromImage is true, we will directly give the credential to the registry of the image.
+	// Currently, this is only used by auth-provider-gcp.
+	if g.UseRegistryFromImage {
+		if registry, _, found := strings.Cut(image, "/"); found {
+			cfg[registry] = entry
+		}
 	}
 
 	// Add our entry for each of the supported container registry URLs


### PR DESCRIPTION
We will have the credential provider unconditionally attach the the access token to the registry in the image request, and then rely on the Kubelet config to restrict which registries the access token will be sent to