### PR TITLE
Bump Go version to 1.23.1 (CVE-2024-34156, CVE-2024-34155, CVE-2024-34158, CVE-2024-24791)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.22.4",
+    version = "1.23.1",
 )
 
 go_register_toolchains()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'golang:1.22.4'
+  - name: 'golang:1.23.1'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}


### PR DESCRIPTION
Bump Go version to fix CVEs.