### PR TITLE
README: fix push image doc, and add push-image tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Publishing cloud-controller-manager image
 
 This command will build and publish cloud-controller-manager
-`gcr.io/k8s-image-staging/cloud-controller-manager:latest`:
+`registry.k8s.io/k8s-image-staging/cloud-controller-manager:latest`:
 
 ```
 bazel run //cmd/cloud-controller-manager:publish
@@ -13,11 +13,17 @@ Environment variables `IMAGE_REGISTRY`, `IMAGE_REPO` and `IMAGE_TAG` can be
 used to override destination GCR repository and tag.
 
 This command will build and publish
-`example.com/my-repo/gcp-controller-manager:v1`:
+`example.com/my-repo/cloud-controller-manager:v1`:
 
 
 ```
 IMAGE_REGISTRY=example.com IMAGE_REPO=my-repo IMAGE_TAG=v1 bazel run //cmd/cloud-controller-manager:publish
+```
+
+Alternatively, you can run [push-images tool](https://github.com/kubernetes/cloud-provider-gcp/blob/master/tools/push-images). The tool is built from [ko](https://github.com/ko-build/ko) that does not depend on bazel, for example this command pushes image to Google Artifact Registry under project `my-project` and existing repository `my-repo`:
+
+```
+IMAGE_REPO=us-central1-docker.pkg.dev/my-project/my-repo IMAGE_TAG=v0 ./tools/push-images
 ```
 
 # Cross-compiling


### PR DESCRIPTION
The default registry is changed from `gcr.io` to `registry.k8s.io`

https://github.com/kubernetes/cloud-provider-gcp/commit/131cd79e47a50626910b895359ce456be783c1b8

---------------

Verified the up the `push-images` command:
```
IMAGE_REPO=us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test IMAGE_TAG=v0 ./tools/push-images

 Published us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test/gcp-controller-manager:v0@sha256:fea460f6a2d11fb5a7e0172ba46665481bca4e555d8b65c91d930b0ee30058b4
us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test/gcp-controller-manager:v0@sha256:fea460f6a2d11fb5a7e0172ba46665481bca4e555d8b65c91d930b0ee30058b4
```

Also the purpose is to encourage people to use artifact registry. Container registry is deprecated and is on migration. See https://github.com/kubernetes/cloud-provider-gcp/issues/289