### PR TITLE
e2e: update path to kOps marker files (1.30 backport)

### DIFF
--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -83,7 +83,8 @@ fi
 
 # Download latest prebuilt kOps
 if [[ -z "${KOPS_BASE_URL:-}" ]]; then
-  KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt)"
+  KOPS_BRANCH="master"
+  KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/${KOPS_BRANCH}/latest-ci-updown-green.txt)"
 fi
 export KOPS_BASE_URL
 


### PR DESCRIPTION
Updating after the move to community infrastructure.

-----------------
backport of https://github.com/kubernetes/cloud-provider-gcp/pull/766