### PR TITLE
Add a multiProject option to GCE Cloud Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bazel-*
 cluster/bin
 MERGED_LICENSES
+go.work
+go.work.sum

--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -42,8 +42,8 @@ import (
 )
 
 // enableMultiProject is bound to a command-line flag. When true, it enables the
-// multiProject option of the GCE cloud provider, instructing it to use the
-// project specified in the Node's providerID for GCE API calls.
+// projectFromNodeProviderID option of the GCE cloud provider, instructing it to
+// use the project specified in the Node's providerID for GCE API calls.
 //
 // This flag should only be enabled when the Node's providerID can be fully
 // trusted.
@@ -122,7 +122,7 @@ func cloudInitializer(config *config.CompletedConfig) cloudprovider.Interface {
 			// we never expect this to be executed.
 			klog.Fatalf("multi-project mode requires GCE cloud provider, but got %T", cloud)
 		}
-		gceCloud.EnableMultiProject()
+		gceCloud.SetProjectFromNodeProviderID(true)
 	}
 
 	return cloud

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -43,7 +43,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -195,6 +195,13 @@ type Cloud struct {
 	// stackType indicates whether the cluster is a single stack IPv4, single
 	// stack IPv6 or a dual stack cluster
 	stackType StackType
+
+	// multiProject determines whether the project derived through the Node's
+	// .spec.providerID can be used to change the project used when making GCE
+	// API calls.
+	//
+	// Enable this ony when the Node's .spec.providerID can be fully trusted.
+	multiProject bool
 }
 
 // ConfigGlobal is the in memory representation of the gce.conf config data
@@ -838,6 +845,18 @@ func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
 // HasClusterID returns true if the cluster has a clusterID
 func (g *Cloud) HasClusterID() bool {
 	return true
+}
+
+// EnableMultiProject enables multiProject option.
+//
+// Enable this ony when the Node's .spec.providerID can be fully trusted.
+func (g *Cloud) EnableMultiProject() {
+	g.multiProject = true
+}
+
+// DisableMultiProject disables multiProject option.
+func (g *Cloud) DisableMultiProject() {
+	g.multiProject = false
 }
 
 // getProjectsBasePath returns the compute API endpoint with the `projects/` element.

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -196,12 +196,12 @@ type Cloud struct {
 	// stack IPv6 or a dual stack cluster
 	stackType StackType
 
-	// multiProject determines whether the project derived through the Node's
-	// .spec.providerID can be used to change the project used when making GCE
-	// API calls.
+	// projectFromNodeProviderID determines whether the project derived through
+	// the Node's .spec.providerID can be used to change the project used when
+	// making GCE API calls.
 	//
 	// Enable this ony when the Node's .spec.providerID can be fully trusted.
-	multiProject bool
+	projectFromNodeProviderID bool
 }
 
 // ConfigGlobal is the in memory representation of the gce.conf config data
@@ -847,16 +847,11 @@ func (g *Cloud) HasClusterID() bool {
 	return true
 }
 
-// EnableMultiProject enables multiProject option.
+// SetProjectFromNodeProviderID configures projectFromNodeProviderID option.
 //
 // Enable this ony when the Node's .spec.providerID can be fully trusted.
-func (g *Cloud) EnableMultiProject() {
-	g.multiProject = true
-}
-
-// DisableMultiProject disables multiProject option.
-func (g *Cloud) DisableMultiProject() {
-	g.multiProject = false
+func (g *Cloud) SetProjectFromNodeProviderID(enabled bool) {
+	g.projectFromNodeProviderID = enabled
 }
 
 // getProjectsBasePath returns the compute API endpoint with the `projects/` element.

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -236,12 +236,12 @@ func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
-	_, zone, name, err := splitProviderID(providerID)
+	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return []v1.NodeAddress{}, err
 	}
 
-	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	if err != nil {
 		return []v1.NodeAddress{}, fmt.Errorf("error while querying for providerID %q: %v", providerID, err)
 	}
@@ -365,7 +365,7 @@ func (g *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 		}
 	}
 
-	_, zone, name, err := splitProviderID(providerID)
+	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func (g *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 
 	var addresses []v1.NodeAddress
 	var instanceType string
-	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	if err != nil {
 		return nil, fmt.Errorf("error while querying for providerID %q: %v", providerID, err)
 	}
@@ -578,13 +578,13 @@ func (g *Cloud) AliasRangesByProviderID(providerID string) (cidrs []string, err 
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	_, zone, name, err := splitProviderID(providerID)
+	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
 
 	var res *compute.Instance
-	res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	if err != nil {
 		return
 	}
@@ -623,12 +623,12 @@ func (g *Cloud) AddAliasToInstanceByProviderID(providerID string, alias *net.IPN
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	_, zone, name, err := splitProviderID(providerID)
+	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return err
 	}
 
-	instance, err := g.c.BetaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	instance, err := g.c.BetaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	if err != nil {
 		return err
 	}
@@ -763,7 +763,7 @@ func (g *Cloud) getInstanceFromProjectInZoneByName(project, zone, name string) (
 
 	name = canonicalizeInstanceName(name)
 	mc := newInstancesMetricContext("get", zone)
-	res, err := g.c.Instances().Get(ctx, meta.ZonalKey(name, zone))
+	res, err := g.c.Instances().Get(ctx, meta.ZonalKey(name, zone), cloud.ForceProjectID(project))
 	mc.Observe(err)
 	if err != nil {
 		return nil, err
@@ -917,12 +917,12 @@ func (g *Cloud) InstanceByProviderID(providerID string) (res *compute.Instance, 
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
-	_, zone, name, err := splitProviderID(providerID)
+	project, zone, name, err := splitProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
+	res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	if err != nil {
 		return nil, err
 	}

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -242,7 +242,7 @@ func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 	}
 
 	var instance *compute.Instance
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		instance, err = g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	} else {
 		instance, err = g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
@@ -384,7 +384,7 @@ func (g *Cloud) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprov
 	var addresses []v1.NodeAddress
 	var instanceType string
 	var instance *compute.Instance
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		instance, err = g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	} else {
 		instance, err = g.c.Instances().Get(timeoutCtx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
@@ -595,7 +595,7 @@ func (g *Cloud) AliasRangesByProviderID(providerID string) (cidrs []string, err 
 	}
 
 	var res *compute.Instance
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	} else {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
@@ -644,7 +644,7 @@ func (g *Cloud) AddAliasToInstanceByProviderID(providerID string, alias *net.IPN
 	}
 
 	var instance *computebeta.Instance
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		instance, err = g.c.BetaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	} else {
 		instance, err = g.c.BetaInstances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))
@@ -671,7 +671,7 @@ func (g *Cloud) AddAliasToInstanceByProviderID(providerID string, alias *net.IPN
 	})
 
 	mc := newInstancesMetricContext("add_alias", zone)
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		err = g.c.BetaInstances().UpdateNetworkInterface(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)), iface.Name, iface, cloud.ForceProjectID(project))
 	} else {
 		err = g.c.BetaInstances().UpdateNetworkInterface(ctx, meta.ZonalKey(instance.Name, lastComponent(instance.Zone)), iface.Name, iface)
@@ -789,7 +789,7 @@ func (g *Cloud) getInstanceFromProjectInZoneByName(project, zone, name string) (
 	mc := newInstancesMetricContext("get", zone)
 	var res *compute.Instance
 	var err error
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(name, zone), cloud.ForceProjectID(project))
 	} else {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(name, zone))
@@ -951,7 +951,7 @@ func (g *Cloud) InstanceByProviderID(providerID string) (res *compute.Instance, 
 	if err != nil {
 		return nil, err
 	}
-	if g.multiProject {
+	if g.projectFromNodeProviderID {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone), cloud.ForceProjectID(project))
 	} else {
 		res, err = g.c.Instances().Get(ctx, meta.ZonalKey(canonicalizeInstanceName(name), zone))


### PR DESCRIPTION
### Proposed change

* Introduce a multiProject option in GCE Cloud Provider, such that when enabled, the project derived by parsing the Node's `.spec.providerID` will be used for subsequent GCE API calls. The option should only be enabled when the `.spec.providerID` can be trusted.
* Introduce a corresponding CLI flag for Cloud Controller Manager command which will control the enablement of multiProject option in the instantiated GCE Cloud Provider.
* **Safeguard:** This is an opt-in change: The default behaviour of ignoring the project value is maintained.

---

(This PR builds on top of the work done in https://github.com/kubernetes/cloud-provider-gcp/pull/779 by @hoskeri)