### PR TITLE
change image tag, forward slash is not allowed

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'golang:1.23.3'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
-      - IMAGE_TAG=${_PULL_BASE_REF}
+      - IMAGE_TAG=${_GIT_TAG}
     entrypoint: tools/push-images
   # build gke-gcloud-auth-plugin binary
   - name: 'gcr.io/cloud-builders/bazel'


### PR DESCRIPTION
[Job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images/1894330882576093184) failed to push image, error
```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: invalid build tag "ccm/v32.2.0": must match format "^[\\w][\\w.-]{0,127}$"
2025/02/25 10:17:53 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes/cloud-provider-gcp/cloudbuild.yaml --substitutions _PULL_BASE_REF=ccm/v32.2.0,_GIT_TAG=v20250225-ccmv32.2.0 --project k8s-staging-cloud-provider-gcp --gcs-log-dir gs://k8s-staging-cloud-provider-gcp-gcb/logs --gcs-source-staging-dir gs://k8s-staging-cloud-provider-gcp-gcb/source gs://k8s-staging-cloud-provider-gcp-gcb/source/25081eab-adf5-49a0-bac5-8f6d730c9bc9.tgz]: exit status 1]

```

The log indicates the `_GIT_TAG=v20250225-ccmv32.2.0` that matches `"^[\\w][\\w.-]{0,127}$"`

--------------------
Suggested by the test-infra [build example](https://github.com/kubernetes/test-infra/tree/a96c5d60b64b09b5b5f7817745477d0af3122aa1/config/jobs/image-pushing#custom-substitutions)
