### PR TITLE
Fix cloudbuild tag cause push OSS image job failure

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'golang:1.23.3'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
-      - IMAGE_TAG=${_PULL_BASE_REF}
+      - IMAGE_TAG=${_GIT_TAG}
     entrypoint: tools/push-images
   # build gke-gcloud-auth-plugin binary
   - name: 'gcr.io/cloud-builders/bazel'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   - name: 'golang:1.23.3'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
-      - IMAGE_TAG=${_GIT_TAG}
+      - IMAGE_TAG=${_PULL_BASE_REF}
     entrypoint: tools/push-images
   # build gke-gcloud-auth-plugin binary
   - name: 'gcr.io/cloud-builders/bazel'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -93,4 +93,3 @@ substitutions:
 tags:
   - 'cloud-provider-gcp'
   - ${_GIT_TAG}
-  - ${_PULL_BASE_REF}


### PR DESCRIPTION
[Job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images/1894330882576093184) failed to push image, error
```
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: invalid build tag "ccm/v32.2.0": must match format "^[\\w][\\w.-]{0,127}$"
2025/02/25 10:17:53 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes/cloud-provider-gcp/cloudbuild.yaml --substitutions _PULL_BASE_REF=ccm/v32.2.0,_GIT_TAG=v20250225-ccmv32.2.0 --project k8s-staging-cloud-provider-gcp --gcs-log-dir gs://k8s-staging-cloud-provider-gcp-gcb/logs --gcs-source-staging-dir gs://k8s-staging-cloud-provider-gcp-gcb/source gs://k8s-staging-cloud-provider-gcp-gcb/source/25081eab-adf5-49a0-bac5-8f6d730c9bc9.tgz]: exit status 1]

```

Introduced from https://github.com/kubernetes/cloud-provider-gcp/pull/620. This will only be trigger from tagging a git commit.

----------
Distinguish

* Cloud Build Tag
For [build filter](https://cloud.google.com/build/docs/build-config-file-schema#tags)

* Image Tag
Image tag [${_PULL_BASE_REF}](https://github.com/kubernetes/cloud-provider-gcp/blob/master/cloudbuild.yaml#L10) is either tag name(ccm/v32.2.0) or branch name(release-1.32).
And [push image script handles forward slash case](https://github.com/kubernetes/cloud-provider-gcp/blob/master/tools/push-images#L35)

-------------
Reproduction:
Cloud Build tag:


```
$ cat cloudbuild.yaml 
timeout: 3600s
options:
  substitution_option: ALLOW_LOOSE
steps:
  - name: 'golang:1.23.3'
    env:
      - IMAGE_REPO=${_IMAGE_REPO}
      - IMAGE_TAG=${_PULL_BASE_REF}
    entrypoint: tools/push-images
tags:
  - 'cloud-provider-gcp'
  - 'ccm/v32.2.0'
```

For the above invalid tag, see error:
```
$ gcloud builds submit --config cloudbuild.yaml
Creating temporary archive of 10658 file(s) totalling 306.4 MiB before compression.
Uploading tarball of [.] to [gs://zivy-gke-dev-2_cloudbuild/source/1740704899.081494-2826a0d4d528479792643aca01de99a4.tgz]
ERROR: (gcloud.builds.submit) INVALID_ARGUMENT: invalid build: invalid build tag "ccm/v32.2.0": must match format "^[\\w][\\w.-]{0,127}$"
```



* Push Image Tag
```
IMAGE_REPO=us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test IMAGE_TAG="ccm/v32.2.0 ./tools/push-images
...
+ echo 'COMPONENT=ccm, IMAGE_TAG=v32.2.0'
COMPONENT=ccm, IMAGE_TAG=v32.2.0
+ [[ ccm == \c\c\m ]]
+ go run github.com/google/ko@v0.14.1 build --tags=v32.2.0 --base-import-paths --push=true ./cmd/cloud-controller-manager/
us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test/cloud-controller-manager:v32.2.0@sha256:0eabccd8d6be63f3f7ff2013cab7b4ed3bee016ebe543ab4fcbd1c8cdd688bc7
```





