### PR TITLE
Fix cloudbuild tag cause push OSS image job failure (1.32 backport)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -93,4 +93,3 @@ substitutions:
 tags:
   - 'cloud-provider-gcp'
   - ${_GIT_TAG}
-  - ${_PULL_BASE_REF}


### PR DESCRIPTION
backport of  https://github.com/kubernetes/cloud-provider-gcp/pull/810