### PR TITLE
Trigger node reconciliation if MultiNetwork info changed

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -155,7 +155,7 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 				return ca.AllocateOrOccupyCIDR(newNode)
 			}
 
-			// Process Node if multi-netowrk related information changed
+			// Process Node if multi-network related information changed
 			if nodeMultiNetworkChanged(oldNode, newNode) {
 				return ca.AllocateOrOccupyCIDR(newNode)
 			}
@@ -531,8 +531,8 @@ func isIP6(ipnet *net.IPNet) bool {
 	return ipnet.IP.To4() == nil && ipnet.IP.To16() != nil
 }
 
-// filterMultiNetworkAnnotaion filteres a node annotation with all multi-network annotations that is watched/updated by CCM
-func filterMultiNetworkAnnotaion(annotations map[string]string) map[string]string {
+// filterMultiNetworkAnnotations filters a node annotation with all multi-network annotations that is watched/updated by CCM
+func filterMultiNetworkAnnotations(annotations map[string]string) map[string]string {
 	if annotations == nil {
 		return nil
 	}
@@ -565,7 +565,7 @@ func filterMultiNetworkCapacity(capacity v1.ResourceList) v1.ResourceList {
 }
 
 func nodeMultiNetworkChanged(oldNode *v1.Node, newNode *v1.Node) bool {
-	if !reflect.DeepEqual(filterMultiNetworkAnnotaion(oldNode.GetAnnotations()), filterMultiNetworkAnnotaion(newNode.GetAnnotations())) {
+	if !reflect.DeepEqual(filterMultiNetworkAnnotations(oldNode.GetAnnotations()), filterMultiNetworkAnnotations(newNode.GetAnnotations())) {
 		return true
 	}
 	if !reflect.DeepEqual(filterMultiNetworkCapacity(oldNode.Status.Capacity), filterMultiNetworkCapacity(newNode.Status.Capacity)) {

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -75,7 +75,7 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 				continue
 			}
 
-			klog.V(4).InfoS("allotting pod CIDRs", "nodeName", node.Name, "networkName", network.Name)
+			klog.V(4).InfoS("allotting pod CIDRs", "nodeName", node.Name, "networkName", network.Name, "networkInterface", inf.Name)
 			gnp, err := ca.gnpLister.Get(network.Spec.ParametersRef.Name)
 			if err != nil {
 				return nil, err
@@ -100,7 +100,7 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 				if _, ok := upStatusNetworks[network.Name]; ok {
 					additionalNodeNetworks = append(additionalNodeNetworks, networkv1.NodeNetwork{Name: network.Name, Scope: "host-local", Cidrs: []string{inf.NetworkIP + "/32"}})
 				} else {
-					klog.V(2).InfoS("skipping network %s on node %s in networking.gke.io/networks annotation due to missing network-status", network.Name, node.Name)
+					klog.V(2).Infof("skipping network %s on node %s in networking.gke.io/networks annotation due to missing network-status", network.Name, node.Name)
 				}
 				continue
 			}
@@ -139,7 +139,7 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 					if _, ok := upStatusNetworks[network.Name]; ok {
 						additionalNodeNetworks = append(additionalNodeNetworks, networkv1.NodeNetwork{Name: network.Name, Scope: "host-local", Cidrs: []string{ipRange.IpCidrRange}})
 					} else {
-						klog.V(2).InfoS("skipping network %s on node %s in networking.gke.io/networks annotation due to missing network-status", network.Name, node.Name)
+						klog.V(2).Infof("skipping network %s on node %s in networking.gke.io/networks annotation due to missing network-status", network.Name, node.Name)
 					}
 				}
 				break

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -121,6 +121,7 @@ func PatchNodeMultiNetwork(c clientset.Interface, node *v1.Node) error {
 		if _, err := c.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata":{"annotations":%s}}`, raw)), metav1.PatchOptions{}); err != nil {
 			return fmt.Errorf("unable to apply patch for multi-network annotation: %v", err)
 		}
+		klog.V(4).Infof("Patched multi-network annotation of node %q to %s", node.Name, raw)
 	}
 	// Prepare patch bytes for the node update.
 	patchBytes, err := json.Marshal([]interface{}{
@@ -138,5 +139,6 @@ func PatchNodeMultiNetwork(c clientset.Interface, node *v1.Node) error {
 	if _, err = c.CoreV1().Nodes().Patch(context.TODO(), node.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
 		return fmt.Errorf("failed to patch node for multi-networking: %w", err)
 	}
+	klog.V(4).Infof("Patched capacity of node %q to %s", node.Name, patchBytes)
 	return nil
 }


### PR DESCRIPTION
CCM watches and updates Multi-Network annotations and resources. It should trigger node reconciliation whenever those fields changes

Also add logs to show actual patches applied when updating multi-network information