### PR TITLE
don't run go vet in parallel

### DIFF
--- a/tools/verify-govet.sh
+++ b/tools/verify-govet.sh
@@ -40,37 +40,20 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   targets=$(go list ./... | grep -v "vendor")
 fi
 
-# Do this in parallel; results in 5-10x speedup.
-pids=""
-for i in $targets
-  do
-  (
-    # Run go vet using goflags for each target specified.
-    #
-    # Remove any lines go vet or godep outputs with the exit status.
-    # Remove any lines godep outputs about the vendor experiment.
-    #
-    # If go vet fails (produces output), grep will succeed, but if go vet
-    # succeeds (produces no output) grep will fail. Then we just use
-    # PIPESTATUS[0] which is go's exit code.
-    #
-    # The intended result is that each incantation of this line returns
-    # either 0 (pass) or 1 (fail).
-    go vet "${goflags[@]:+${goflags[@]}}" "$i" 2>&1 \
-      | grep -v -E "exit status|GO15VENDOREXPERIMENT=" \
-      || fail=${PIPESTATUS[0]}
-    exit $fail
-  ) &
-  pids+=" $!"
+for i in $targets;do
+  # Run go vet using goflags for each target specified.
+  #
+  # Remove any lines go vet or godep outputs with the exit status.
+  # Remove any lines godep outputs about the vendor experiment.
+  #
+  # If go vet fails (produces output), grep will succeed, but if go vet
+  # succeeds (produces no output) grep will fail. Then we just use
+  # PIPESTATUS[0] which is go's exit code.
+  #
+  # The intended result is that each incantation of this line returns
+  # either 0 (pass) or 1 (fail).
+  echo "running $i"
+  go vet "${goflags[@]:+${goflags[@]}}" "$i"
 done
 
-# Count and return the number of failed files (non-zero is a failed vet run).
-failedfiles=0
-for p in $pids; do
-  wait $p || let "failedfiles+=1"
-done
-
-# hardcode a healthy exit until all vet errors can be fixed
-#exit $failedfiles
-exit 0
 


### PR DESCRIPTION
verify-govet.sh is running in parallel for all targets, resulting in huge resource consumption. There are only 2 cpus and 4GiB memory allocated. The test is actually gettting OOM killed https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-gcp/817/cloud-provider-gcp-verify-all/1899821170069344256

Changed to run go vet in serial, which can finish on my computer in 10 mins