### PR TITLE
use docker build to generate images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG GOARCH="amd64"
+
+FROM golang:1.24 AS builder
+# golang envs
+ARG GOARCH="amd64"
+ARG GOOS=linux
+ENV CGO_ENABLED=0
+
+WORKDIR /go/src/app
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o /go/bin/cloud-controller-manager ./cmd/cloud-controller-manager
+
+FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.0-bookworm.0
+COPY --from=builder --chown=root:root /go/bin/cloud-controller-manager /cloud-controller-manager
+CMD ["/cloud-controller-manager"]

--- a/tools/push-images
+++ b/tools/push-images
@@ -17,7 +17,11 @@
 set -e
 set -x
 
-source $(git rev-parse --show-toplevel)/tools/common
+# Find the top-level directory.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "${REPO_ROOT}"
+
+source ${REPO_ROOT}/tools/common
 
 # IMAGE_REPO is used to upload images
 if [[ -z "${IMAGE_REPO:-}" ]]; then
@@ -25,7 +29,6 @@ if [[ -z "${IMAGE_REPO:-}" ]]; then
   exit 1
 fi
 echo "IMAGE_REPO=${IMAGE_REPO}"
-export KO_DOCKER_REPO="${IMAGE_REPO}"
 
 # We default IMAGE_TAG to a unique value that combines the sha and the (real) build date
 if [[ -z "${IMAGE_TAG:-}" ]]; then
@@ -42,7 +45,7 @@ else
 fi
 
 if [[ "${COMPONENT:-ccm}" == "ccm" ]]; then
-  go run github.com/google/ko@v0.14.1 build --tags=${IMAGE_TAG} --base-import-paths --push=true ./cmd/cloud-controller-manager/
+  docker build --push -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
 else
   echo "Skipping CCM build, because component is ${COMPONENT}"
 fi


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/cloud-provider-gcp/issues/821

/assign @cpanato @YifeiZhuang 

This changes the way of building the image from `ko` to `Dockerfile`, despite `ko` is really simple and useful the app path inside the container is hardcoded and this cause conflict with all the existing ecosystem that depend in the app path to work

Instead of using bazel, that is something we'd like to get rid of, let's use a Dockerfile that is the standard and in this is case is very simple

