### PR TITLE
Forward individual ports for NetLB with 5 or less service ports

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -202,6 +202,10 @@ type Cloud struct {
 	//
 	// Enable this ony when the Node's .spec.providerID can be fully trusted.
 	projectFromNodeProviderID bool
+
+	// enableDiscretePortForwarding enables forwarding of individual ports
+	// instead of port ranges in Forwarding Rules for external load balancers.
+	enableDiscretePortForwarding bool
 }
 
 // ConfigGlobal is the in memory representation of the gce.conf config data
@@ -852,6 +856,11 @@ func (g *Cloud) HasClusterID() bool {
 // Enable this ony when the Node's .spec.providerID can be fully trusted.
 func (g *Cloud) SetProjectFromNodeProviderID(enabled bool) {
 	g.projectFromNodeProviderID = enabled
+}
+
+// SetEnableDiscretePortForwarding configures enableDiscretePortForwarding option.
+func (g *Cloud) SetEnableDiscretePortForwarding(enabled bool) {
+	g.enableDiscretePortForwarding = enabled
 }
 
 // getProjectsBasePath returns the compute API endpoint with the `projects/` element.


### PR DESCRIPTION
GCE forwarding rules have a limit of 5 forwarding ports. In the external L4 load balancer, we currently turn a set of exposed ports into a port range from minPort to maxPort and forward all ports in the range. With this change we match the service definition better to forward individual ports when possible.