### PR TITLE
fix publish image cloudbuild job failure docker not found, unknown flag: --push

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'golang:1.23.3'
+  - name: 'gcr.io/cloud-builders/docker'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}

--- a/tools/push-images
+++ b/tools/push-images
@@ -45,7 +45,8 @@ else
 fi
 
 if [[ "${COMPONENT:-ccm}" == "ccm" ]]; then
-  docker build --push -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
+  docker build -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
+  docker push ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}
 else
   echo "Skipping CCM build, because component is ${COMPONENT}"
 fi


### PR DESCRIPTION
1. [post-submit job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images/1906855542492499968) execution failure:
```
Step #0: tools/push-images: line 48: docker: command not found

```
Fix https://github.com/kubernetes/cloud-provider-gcp/pull/825

2. Then, after docker command is fixed in 1, fix error `unknown flag: --push`
```
 docker build --push -t us-central1-docker.pkg.dev/zivy-gke-dev-2/ccm-test/cloud-controller-manager:29387948793 .
 unknown flag: --push
```


--------------
Tested using `gcloud builds submit  --config=cloudbuild1.yaml .` (creating empty `.gcloudignore`)

