### PR TITLE
[1.32 backport]fix publish image cloudbuild job failure docker not found, unknown flag: --push 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'golang:1.23.3'
+  - name: 'gcr.io/cloud-builders/docker'
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}

--- a/tools/push-images
+++ b/tools/push-images
@@ -45,7 +45,8 @@ else
 fi
 
 if [[ "${COMPONENT:-ccm}" == "ccm" ]]; then
-  docker build --push -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
+  docker build -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
+  docker push ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}
 else
   echo "Skipping CCM build, because component is ${COMPONENT}"
 fi


### PR DESCRIPTION
backport of change: https://github.com/kubernetes/cloud-provider-gcp/pull/829

----------------
The image is probably still not really usable see comments: https://github.com/kubernetes/cloud-provider-gcp/pull/830

/assign @mmamczur 

cc. @aojea 