### PR TITLE
Implement loadBalancerClass support for L4 Service selection

### DIFF
--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -56,9 +56,16 @@ const (
 // new load balancers and updating existing load balancers, recognizing when
 // each is needed.
 func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-external-legacy" used for this controller.
+	// LoadBalancerClass can't be updated so we know this controller should process the NetLB.
 	// Skip service handling if it uses Regional Backend Services and handled by other controllers
-	if usesL4RBS(apiService, existingFwdRule) {
+	if (apiService.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(apiService, LegacyRegionalExternalLoadBalancerClass)) || usesL4RBS(apiService, existingFwdRule) {
 		return nil, cloudprovider.ImplementedElsewhere
+	}
+	if hasLoadBalancerClass(apiService, LegacyRegionalExternalLoadBalancerClass) {
+		if apiService.Annotations[ServiceAnnotationLoadBalancerType] == string(LBTypeInternal) {
+			g.eventRecorder.Event(apiService, v1.EventTypeWarning, "ConflictingConfiguration", fmt.Sprintf("loadBalancerClass conflicts with %s: %s annotation. External LoadBalancer Service provisioned.", ServiceAnnotationLoadBalancerType, string(LBTypeInternal)))
+		}
 	}
 
 	if len(nodes) == 0 {
@@ -290,8 +297,10 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 
 // updateExternalLoadBalancer is the external implementation of LoadBalancer.UpdateLoadBalancer.
 func (g *Cloud) updateExternalLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) error {
-	// Skip service update if it uses Regional Backend Services and handled by other controllers
-	if usesL4RBS(service, nil) {
+	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-external-legacy" used for this controller.
+	// LoadBalancerClass can't be updated so we know this controller should process the NetLB.
+	// Skip service handling if it uses Regional Backend Services and handled by other controllers
+	if (service.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(service, LegacyRegionalExternalLoadBalancerClass)) || usesL4RBS(service, nil) {
 		return cloudprovider.ImplementedElsewhere
 	}
 
@@ -306,8 +315,10 @@ func (g *Cloud) updateExternalLoadBalancer(clusterName string, service *v1.Servi
 
 // ensureExternalLoadBalancerDeleted is the external implementation of LoadBalancer.EnsureLoadBalancerDeleted
 func (g *Cloud) ensureExternalLoadBalancerDeleted(clusterName, clusterID string, service *v1.Service) error {
-	// Skip service deletion if it uses Regional Backend Services and handled by other controllers
-	if usesL4RBS(service, nil) {
+	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-external-legacy" used for this controller.
+	// LoadBalancerClass can't be updated so we know this controller should process the NetLB.
+	// Skip service handling if it uses Regional Backend Services and handled by other controllers
+	if (service.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(service, LegacyRegionalExternalLoadBalancerClass)) || usesL4RBS(service, nil) {
 		return cloudprovider.ImplementedElsewhere
 	}
 

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -2264,4 +2265,90 @@ func copyFirewallObj(firewall *compute.Firewall) (*compute.Firewall, error) {
 		return nil, err
 	}
 	return &fw, nil
+}
+
+func TestEnsureExternalLoadBalancerClass(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	for _, tc := range []struct {
+		desc              string
+		loadBalancerClass string
+		shouldProcess     bool
+	}{
+		{
+			desc:              "Custom loadBalancerClass should not process",
+			loadBalancerClass: "customLBClass",
+			shouldProcess:     false,
+		},
+		{
+			desc:              "Use legacy ILB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalInternalLoadBalancerClass,
+			shouldProcess:     false,
+		},
+		{
+			desc:              "Use legacy NetLB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalExternalLoadBalancerClass,
+			shouldProcess:     true,
+		},
+		{
+			desc:              "Unset loadBalancerClass",
+			loadBalancerClass: "",
+			shouldProcess:     true,
+		},
+	} {
+		gce, err := fakeGCECloud(vals)
+		assert.NoError(t, err)
+		recorder := record.NewFakeRecorder(1024)
+		gce.eventRecorder = recorder
+		nodeNames := []string{"test-node-1"}
+
+		svc := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
+		if tc.loadBalancerClass == "" {
+			svc = fakeLoadbalancerService("")
+		}
+		svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// Create NetLB
+		status, err := createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			require.NotNil(t, status)
+			svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			if hasFinalizer(svc, NetLBFinalizerV2) || hasFinalizer(svc, NetLBFinalizerV3) {
+				t.Errorf("Unexpected finalizer found in Finalizer list - %v", svc.Finalizers)
+			}
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+			assert.Empty(t, status)
+		}
+
+		nodeNames = []string{"test-node-1", "test-node-2"}
+		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+		assert.NoError(t, err)
+
+		// Update NetLB
+		err = gce.updateExternalLoadBalancer(vals.ClusterName, svc, nodes)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			if hasFinalizer(svc, NetLBFinalizerV2) || hasFinalizer(svc, NetLBFinalizerV3) {
+				t.Errorf("Unexpected finalizer found in Finalizer list - %v", svc.Finalizers)
+			}
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		}
+
+		// Delete ILB
+		err = gce.ensureExternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			assertExternalLbResourcesDeleted(t, gce, svc, vals, true)
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		}
+	}
 }

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -55,8 +55,14 @@ const (
 )
 
 func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	if existingFwdRule == nil && !hasFinalizer(svc, ILBFinalizerV1) {
+	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-internal-legacy" used for this controller.
+	// LoadBalancerClass can't be updated so we know this controller should process the ILB.
+	if existingFwdRule == nil && !hasFinalizer(svc, ILBFinalizerV1) && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
 		// Neither the forwarding rule nor the V1 finalizer exists. This is most likely a new service.
+		if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
+			klog.V(2).Infof("Skipped ensureInternalLoadBalancer for service %s/%s, as service contains %q loadBalancerClass.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
+			return nil, cloudprovider.ImplementedElsewhere
+		}
 		if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) {
 			// When ILBSubsets is enabled, new ILB services will not be processed here.
 			// Services that have existing GCE resources created by this controller or the v1 finalizer
@@ -331,8 +337,16 @@ func (g *Cloud) clearPreviousInternalResources(svc *v1.Service, loadBalancerName
 // updateInternalLoadBalancer is called when the list of nodes has changed. Therefore, only the instance groups
 // and possibly the backend service need to be updated.
 func (g *Cloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, nodes []*v1.Node) error {
-	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) && !hasFinalizer(svc, ILBFinalizerV1) {
+	// Skip update of services which don't have v1 finalizer. If LegacyRegionalInternalLoadBalancerClass
+	// is set, v1 finalizer should already be present and this controller should process the update.
+	// LoadBalancerClass can't be updated so we know this controller should process the ILB.
+	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) && !hasFinalizer(svc, ILBFinalizerV1) && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
 		klog.V(2).Infof("Skipped updateInternalLoadBalancer for service %s/%s since it does not contain %q finalizer.", svc.Namespace, svc.Name, ILBFinalizerV1)
+		return cloudprovider.ImplementedElsewhere
+	}
+	// Ignore services handled by other controllers
+	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
+		klog.V(2).Infof("Skipped updateInternalLoadBalancer for service %s/%s as service contains %q loadBalancerClass.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return cloudprovider.ImplementedElsewhere
 	}
 	g.sharedResourceLock.Lock()
@@ -354,6 +368,19 @@ func (g *Cloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v
 }
 
 func (g *Cloud) ensureInternalLoadBalancerDeleted(clusterName, clusterID string, svc *v1.Service) error {
+	// Skip deletion of services which don't have v1 finalizer. If LegacyRegionalInternalLoadBalancerClass
+	// is set, v1 finalizer should already be present and this controller should process the update.
+	// LoadBalancerClass can't be updated so we know this controller should process the ILB.
+	if g.AlphaFeatureGate.Enabled(AlphaFeatureILBSubsets) && !hasFinalizer(svc, ILBFinalizerV1) && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
+		klog.V(2).Infof("Skipped ensureInternalLoadBalancerDeleted for service %s/%s since it does not contain %q finalizer.", svc.Namespace, svc.Name, ILBFinalizerV1)
+		return cloudprovider.ImplementedElsewhere
+	}
+	// Ignore services handled by other controllers
+	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
+		klog.V(2).Infof("Skipped ensureInternalLoadBalancerDeleted for service %s/%s as service contains %q loadBalancerClass.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
+		return cloudprovider.ImplementedElsewhere
+	}
+
 	loadBalancerName := g.GetLoadBalancerName(context.TODO(), clusterName, svc)
 	svcNamespacedName := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 	_, _, protocol := getPortsAndProtocol(svc.Spec.Ports)

--- a/providers/gce/gce_loadbalancer_internal_test.go
+++ b/providers/gce/gce_loadbalancer_internal_test.go
@@ -1332,12 +1332,32 @@ func TestEnsureInternalLoadBalancerSubsetting(t *testing.T) {
 		createForwardingRule bool
 		expectErrorMsg       string
 	}{
-		{desc: "New service creation fails with Implemented Elsewhere", expectErrorMsg: cloudprovider.ImplementedElsewhere.Error()},
-		{desc: "Service with existing ForwardingRule is processed", createForwardingRule: true},
-		{desc: "Service with v1 finalizer is processed", finalizers: []string{ILBFinalizerV1}},
-		{desc: "Service with v2 finalizer is skipped", finalizers: []string{ILBFinalizerV2}, expectErrorMsg: cloudprovider.ImplementedElsewhere.Error()},
-		{desc: "Service with v2 finalizer and existing ForwardingRule is processed", finalizers: []string{ILBFinalizerV2}, createForwardingRule: true},
-		{desc: "Service with v1 and v2 finalizers is processed", finalizers: []string{ILBFinalizerV1, ILBFinalizerV2}},
+		{
+			desc:           "New service creation fails with Implemented Elsewhere",
+			expectErrorMsg: cloudprovider.ImplementedElsewhere.Error(),
+		},
+		{
+			desc:                 "Service with existing ForwardingRule is processed",
+			createForwardingRule: true,
+		},
+		{
+			desc:       "Service with v1 finalizer is processed",
+			finalizers: []string{ILBFinalizerV1},
+		},
+		{
+			desc:           "Service with v2 finalizer is skipped",
+			finalizers:     []string{ILBFinalizerV2},
+			expectErrorMsg: cloudprovider.ImplementedElsewhere.Error(),
+		},
+		{
+			desc:                 "Service with v2 finalizer and existing ForwardingRule is processed",
+			finalizers:           []string{ILBFinalizerV2},
+			createForwardingRule: true,
+		},
+		{
+			desc:       "Service with v1 and v2 finalizers is processed",
+			finalizers: []string{ILBFinalizerV1, ILBFinalizerV2},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			vals := DefaultTestClusterValues()
@@ -1378,13 +1398,15 @@ func TestEnsureInternalLoadBalancerSubsetting(t *testing.T) {
 				assert.Empty(t, status)
 				assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
 			} else {
+				svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+				assert.NoError(t, err)
 				assert.NotEmpty(t, status.Ingress)
 				assertInternalLbResources(t, gce, svc, vals, nodeNames)
+				// Ensure that cleanup is successful, if applicable.
+				err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
+				assert.NoError(t, err)
+				assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
 			}
-			// Ensure that cleanup is successful, if applicable.
-			err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
-			assert.NoError(t, err)
-			assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
 		})
 	}
 }
@@ -1408,14 +1430,26 @@ func TestEnsureInternalLoadBalancerDeletedSubsetting(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, status.Ingress)
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	if !hasFinalizer(svc, ILBFinalizerV1) {
+		t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
+	}
 	// Enable FeatureGate
 	gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureILBSubsets})
 	// mock scenario where user updates the service to use a different IP, this should be processed here.
 	svc.Spec.LoadBalancerIP = "1.2.3.4"
-	status, err = gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, svc, nodes)
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{})
+	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, svc, nodes)
 	assert.NoError(t, err)
+	// ensure service is still managed by this controller
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	if !hasFinalizer(svc, ILBFinalizerV1) {
+		t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
+	}
 	// ensure that the status has the new IP
-	assert.Equal(t, status.Ingress[0].IP, "1.2.3.4")
+	assert.Equal(t, svc.Spec.LoadBalancerIP, "1.2.3.4")
 	// Invoked when service is deleted.
 	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, svc)
 	assert.NoError(t, err)
@@ -2284,4 +2318,124 @@ func TestSubnetNameFromURL(t *testing.T) {
 		})
 	}
 
+}
+
+func TestEnsureInternalLoadBalancerClass(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	for _, tc := range []struct {
+		desc                 string
+		loadBalancerClass    string
+		shouldProcess        bool
+		gkeSubsettingEnabled bool
+	}{
+		{
+			desc:                 "Custom loadBalancerClass should not process",
+			loadBalancerClass:    "customLBClass",
+			shouldProcess:        false,
+			gkeSubsettingEnabled: true,
+		},
+		{
+			desc:                 "Use legacy ILB loadBalancerClass",
+			loadBalancerClass:    LegacyRegionalInternalLoadBalancerClass,
+			shouldProcess:        true,
+			gkeSubsettingEnabled: true,
+		},
+		{
+			desc:                 "Use legacy NetLB loadBalancerClass",
+			loadBalancerClass:    LegacyRegionalExternalLoadBalancerClass,
+			shouldProcess:        false,
+			gkeSubsettingEnabled: true,
+		},
+		{
+			desc:                 "don't process Unset loadBalancerClass with Subsetting enabled",
+			loadBalancerClass:    "",
+			shouldProcess:        false,
+			gkeSubsettingEnabled: true,
+		},
+		{
+			desc:                 "Custom loadBalancerClass should never process",
+			loadBalancerClass:    "customLBClass",
+			shouldProcess:        false,
+			gkeSubsettingEnabled: false,
+		},
+		{
+			desc:                 "Use legacy ILB loadBalancerClass",
+			loadBalancerClass:    LegacyRegionalInternalLoadBalancerClass,
+			shouldProcess:        true,
+			gkeSubsettingEnabled: false,
+		},
+		{
+			desc:                 "Use legacy NetLB loadBalancerClass",
+			loadBalancerClass:    LegacyRegionalExternalLoadBalancerClass,
+			shouldProcess:        false,
+			gkeSubsettingEnabled: false,
+		},
+		{
+			desc:                 "Subsetting disabled, process unset loadBalancerClass",
+			loadBalancerClass:    "",
+			shouldProcess:        true,
+			gkeSubsettingEnabled: false,
+		},
+	} {
+		gce, err := fakeGCECloud(vals)
+		assert.NoError(t, err)
+		// Enable FeatureGate GKE Subsetting
+		if tc.gkeSubsettingEnabled {
+			gce.AlphaFeatureGate = NewAlphaFeatureGate([]string{AlphaFeatureILBSubsets})
+		}
+		recorder := record.NewFakeRecorder(1024)
+		gce.eventRecorder = recorder
+		nodeNames := []string{"test-node-1"}
+
+		svc := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
+		if tc.loadBalancerClass == "" {
+			svc = fakeLoadbalancerService(string(LBTypeInternal))
+		}
+		svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// Create ILB
+		status, err := createInternalLoadBalancer(gce, svc, nil, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			assert.NotEmpty(t, status.Ingress)
+			svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			if !hasFinalizer(svc, ILBFinalizerV1) {
+				t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
+			}
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+			assert.Empty(t, status)
+		}
+
+		nodeNames = []string{"test-node-1", "test-node-2"}
+		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+		assert.NoError(t, err)
+
+		// Update ILB
+		err = gce.updateInternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nodes)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+			assert.NoError(t, err)
+			if !hasFinalizer(svc, ILBFinalizerV1) {
+				t.Errorf("Expected finalizer '%s' not found in Finalizer list - %v", ILBFinalizerV1, svc.Finalizers)
+			}
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+			assert.Empty(t, status)
+		}
+
+		// Delete ILB
+		err = gce.ensureInternalLoadBalancerDeleted(vals.ClusterName, vals.ClusterID, svc)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+			assertInternalLbResourcesDeleted(t, gce, svc, vals, true)
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		}
+	}
 }

--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -450,52 +450,130 @@ func Test_hasLoadBalancerPortsError(t *testing.T) {
 	}
 }
 
-func TestEnsureLoadBalancerIgnoresServiceWithLoadBalancerClass(t *testing.T) {
+func TestEnsureLoadBalancerServiceWithLoadBalancerClass(t *testing.T) {
 	t.Parallel()
+	for _, tc := range []struct {
+		desc              string
+		loadBalancerClass string
+		shouldProcess     bool
+	}{
+		{
+			desc:              "Custom loadBalancerClass should not process",
+			loadBalancerClass: "customLBClass",
+			shouldProcess:     false,
+		},
+		{
+			desc:              "Use legacy ILB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalInternalLoadBalancerClass,
+			shouldProcess:     true,
+		},
+		{
+			desc:              "Use legacy NetLB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalExternalLoadBalancerClass,
+			shouldProcess:     true,
+		},
+		{
+			desc:              "Unset loadBalancerClass",
+			loadBalancerClass: "",
+			shouldProcess:     true,
+		},
+	} {
 
-	vals := DefaultTestClusterValues()
-	gce, err := fakeGCECloud(vals)
-	require.NoError(t, err)
+		vals := DefaultTestClusterValues()
+		gce, err := fakeGCECloud(vals)
+		require.NoError(t, err)
 
-	nodeNames := []string{"test-node-1"}
-	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
-	require.NoError(t, err)
+		nodeNames := []string{"test-node-1"}
+		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+		require.NoError(t, err)
 
-	apiService := fakeLoadbalancerService("")
-	testClass := "TestClass"
-	apiService.Spec.LoadBalancerClass = &testClass
-	status, err := gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
-	assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
-	assert.Empty(t, status)
+		apiService := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
+		if tc.loadBalancerClass == "" {
+			apiService = fakeLoadbalancerService("")
+		}
+
+		apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		expectedStatus, err := gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+
+		if tc.shouldProcess {
+			require.NoError(t, err)
+			status, found, err := gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+			assert.Equal(t, expectedStatus, status)
+			assert.True(t, found)
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+			assert.Empty(t, expectedStatus)
+		}
+	}
 }
 
 func TestUpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 	t.Parallel()
+	for _, tc := range []struct {
+		desc              string
+		loadBalancerClass string
+		shouldProcess     bool
+	}{
+		{
+			desc:              "Update with custom loadBalancerClass, should not process",
+			loadBalancerClass: "customLBClass",
+			shouldProcess:     false,
+		},
+		{
+			desc:              "Update with legacy ILB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalInternalLoadBalancerClass,
+			shouldProcess:     true,
+		},
+		{
+			desc:              "Update with legacy NetLB loadBalancerClass",
+			loadBalancerClass: LegacyRegionalExternalLoadBalancerClass,
+			shouldProcess:     true,
+		},
+		{
+			desc:              "Update with loadBalancerClass unset",
+			loadBalancerClass: "",
+			shouldProcess:     true,
+		},
+	} {
+		vals := DefaultTestClusterValues()
+		gce, err := fakeGCECloud(vals)
+		require.NoError(t, err)
 
-	vals := DefaultTestClusterValues()
-	gce, err := fakeGCECloud(vals)
-	require.NoError(t, err)
+		nodeNames := []string{"test-node-1"}
+		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+		require.NoError(t, err)
 
-	nodeNames := []string{"test-node-1"}
-	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
-	require.NoError(t, err)
+		apiService := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
+		if tc.loadBalancerClass == "" {
+			apiService = fakeLoadbalancerService("")
+		}
 
-	apiService := fakeLoadbalancerService("")
-	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
-		Protocol: v1.ProtocolUDP,
-		Port:     int32(8080),
-	})
-	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
-	require.NoError(t, err)
+		apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
+		assert.NoError(t, err)
+		gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
 
-	// create an external loadbalancer to simulate an upgrade scenario where the loadbalancer exists
-	// before the new controller is running and later the Service is updated
-	_, err = createExternalLoadBalancer(gce, apiService, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
-	assert.NoError(t, err)
+		apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
+			Protocol: v1.ProtocolTCP,
+			Port:     int32(80),
+		})
+		err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
 
-	testClass := "testClass"
-	apiService.Spec.LoadBalancerClass = &testClass
+		if tc.shouldProcess {
+			require.NoError(t, err)
+			_, found, err := gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+			assert.True(t, found)
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		}
 
-	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
-	assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, apiService)
+		if tc.shouldProcess {
+			assert.NoError(t, err)
+		} else {
+			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+		}
+	}
 }

--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -58,6 +58,20 @@ func fakeLoadBalancerServiceDeprecatedAnnotation(lbType string) *v1.Service {
 	return fakeLoadbalancerServiceHelper(lbType, deprecatedServiceAnnotationLoadBalancerType)
 }
 
+func fakeLoadbalancerServiceWithLoadBalancerClass(lbType, lbClass string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fakeSvcName,
+			Annotations: map[string]string{ServiceAnnotationLoadBalancerType: lbType},
+		},
+		Spec: v1.ServiceSpec{
+			LoadBalancerClass: &lbClass,
+			Type:              v1.ServiceTypeLoadBalancer,
+			Ports:             []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: int32(123)}},
+		},
+	}
+}
+
 func fakeLoadbalancerServiceHelper(lbType string, annotationKey string) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -48,6 +48,10 @@ import (
 )
 
 const (
+	// RegionalExternalLoadBalancerClass is the loadBalancerClass name used to select the
+	// RBS LB implementation.
+	RegionalExternalLoadBalancerClass = "networking.gke.io/l4-regional-external"
+
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
 
@@ -388,6 +392,15 @@ func hasFinalizer(service *v1.Service, key string) bool {
 	return false
 }
 
+func hasLoadBalancerClass(service *v1.Service, key string) bool {
+	if service.Spec.LoadBalancerClass != nil {
+		if *service.Spec.LoadBalancerClass == key {
+			return true
+		}
+	}
+	return false
+}
+
 // removeString returns a newly created []string that contains all items from slice that
 // are not equal to s.
 func removeString(slice []string, s string) []string {
@@ -404,6 +417,10 @@ func removeString(slice []string, s string) []string {
 // Such services implemented in other controllers and
 // should not be handled by Service Controller.
 func usesL4RBS(service *v1.Service, forwardingRule *compute.ForwardingRule) bool {
+	// Detect RBS by loadBalancerClass
+	if hasLoadBalancerClass(service, RegionalExternalLoadBalancerClass) {
+		return true
+	}
 	// Detect RBS by annotation
 	if val, ok := service.Annotations[RBSAnnotationKey]; ok && val == RBSEnabled {
 		return true


### PR DESCRIPTION
This PR implements support for the `spec.loadBalancerClass` field in Kubernetes Services for Layer 4 load balancers. This change enables users to explicitl specify the controller responsible for managing their LoadBalancer services, providing greater flexibility and control.