### PR TITLE
feat(provider/gcp): Add NetLBFinalizerV1 to legacy L4 LB services

### DIFF
--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -210,6 +210,11 @@ func assertExternalLbResourcesDeleted(t *testing.T, gce *Cloud, apiService *v1.S
 	require.Error(t, err)
 	assert.Nil(t, healthcheck)
 
+	// Check finalizer is removed
+	svc, err := gce.client.CoreV1().Services(apiService.Namespace).Get(context.TODO(), apiService.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	hasFinalizer := hasFinalizer(svc, NetLBFinalizerV1)
+	assert.False(t, hasFinalizer)
 }
 
 func assertInternalLbResources(t *testing.T, gce *Cloud, apiService *v1.Service, vals TestClusterValues, nodeNames []string) {


### PR DESCRIPTION
This change introduces the `NetLBFinalizerV1` ("gke.networking.io/l4-netlb-v1") to Kubernetes Service objects of type LoadBalancer managed by the legacy cloud-controller-manager logic for external L4 Network Load Balancers (NetLB).

 **Controller Distinction:** It clearly marks the Service as being managed
    by this specific controller logic (`ensureExternalLoadBalancer`),
    distinguishing it from services managed by newer controllers using
    Regional Backend Services (RBS), which use `NetLBFinalizerV2` or
    `NetLBFinalizerV3`. The `usesL4RBS` function now explicitly checks
    for the absence of V1 finalizer as one condition to determine if a
    service *might* be managed elsewhere.

Implementation details:
- The `NetLBFinalizerV1` is added to the Service metadata within the `ensureExternalLoadBalancer` function when the load balancer is created or updated.
- The finalizer is removed from the Service metadata within the `ensureExternalLoadBalancerDeleted` function *after* all associated GCP resources have been successfully deleted or confirmed non-existent.

Tested the create, update, and delete lifecycle for external L4 LoadBalancer services to ensure the finalizer is added and removed correctly and that resource cleanup proceeds as expected.