### PR TITLE
e2e: ensure kops e2e uses push-images script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@ ARG GOOS=linux
 ENV CGO_ENABLED=0
 
 WORKDIR /go/src/app
-COPY go.mod go.mod
-COPY go.sum go.sum
-COPY providers/go.mod providers/go.mod
-COPY providers/go.sum providers/go.sum
+COPY go.mod go.sum .
+COPY providers/go.mod providers/go.sum providers/
 COPY vendor/ vendor/
+
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY providers/ providers/
+
 RUN CGO_ENABLED=0 go build -o /go/bin/cloud-controller-manager ./cmd/cloud-controller-manager
 
 FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.0-bookworm.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY providers/go.mod providers/go.mod
 COPY providers/go.sum providers/go.sum
-RUN go mod download
+COPY vendor/ vendor/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 COPY providers/ providers/

--- a/e2e/add-kubernetes-to-workspace.sh
+++ b/e2e/add-kubernetes-to-workspace.sh
@@ -22,20 +22,26 @@ cd ${REPO_ROOT}
 cd ..
 WORKSPACE=$(pwd)
 
-# Set up go workspace to build with this version
 cd "${REPO_ROOT}"
 
-go work init
+# We used to build with a go workspace in our tests, but that means we were testing something different from what we were shipping.
+# We keep the workspace support around (for now), but guard it behind an env var (USE_GO_WORKSPACE) which we don't set.
 
-go work use .
-go work use providers
+# Set up go workspace to build with this version
+if [[ -n "${USE_GO_WORKSPACE:-}" ]]; then
+  echo "Setting up go workspace including kubernetes"
+  go work init
 
-# Add kubernetes to workspace
-go work use ${WORKSPACE}/kubernetes
-for d in ${WORKSPACE}/kubernetes/staging/src/k8s.io/*; do
-  go work use $d
-done
+  go work use .
+  go work use providers
 
-# Workaround for go.mod replacements
-sed -i 's/^\s*k8s.io.*//g' go.mod
-go work sync
+  # Add kubernetes to workspace
+  go work use ${WORKSPACE}/kubernetes
+  for d in ${WORKSPACE}/kubernetes/staging/src/k8s.io/*; do
+    go work use $d
+  done
+
+  # Workaround for go.mod replacements
+  sed -i 's/^\s*k8s.io.*//g' go.mod
+  go work sync
+fi

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -127,43 +127,17 @@ if [[ -z "${IMAGE_TAG:-}" ]]; then
 fi
 echo "IMAGE_TAG=${IMAGE_TAG}"
 
-
 # Build and push cloud-controller-manager
 cd ${REPO_ROOT}
-export KO_DOCKER_REPO="${IMAGE_REPO}"
 
 export KUBE_ROOT=${REPO_ROOT}
 source "${REPO_ROOT}/tools/version.sh"
 get_version_vars
 unset KUBE_ROOT
 
-BUILD_DATE=$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')
-
-cat > ${WORKDIR}/.ko.yaml <<EOF
-builds:
-- id: cloud-controller-manager
-  dir: .
-  main: cmd/cloud-controller-manager
-  ldflags:
-  - -X k8s.io/component-base/version/verflag.programName=cloud-controller-manager
-
-  - -X k8s.io/component-base/version.buildDate=${BUILD_DATE}
-  - -X k8s.io/component-base/version.gitCommit=${KUBE_GIT_COMMIT}
-  - -X k8s.io/component-base/version.gitMajor=${KUBE_GIT_MAJOR}
-  - -X k8s.io/component-base/version.gitMinor=${KUBE_GIT_MINOR}
-  - -X k8s.io/component-base/version.gitTreeState=${KUBE_GIT_TREE_STATE}
-  - -X k8s.io/component-base/version.gitVersion=${KUBE_GIT_VERSION}
-
-  - -X k8s.io/client-go/pkg/version.buildDate=${BUILD_DATE}
-  - -X k8s.io/client-go/pkg/version.gitCommit=${KUBE_GIT_COMMIT}
-  - -X k8s.io/client-go/pkg/version.gitMajor=${KUBE_GIT_MAJOR}
-  - -X k8s.io/client-go/pkg/version.gitMinor=${KUBE_GIT_MINOR}
-  - -X k8s.io/client-go/pkg/version.gitTreeState=${KUBE_GIT_TREE_STATE}
-  - -X k8s.io/client-go/pkg/version.gitVersion=${KUBE_GIT_VERSION}
-EOF
-
-# KO_CONFIG_PATH is the directory, not the path, until https://github.com/ko-build/ko/pull/731 lands in a tag (it's not in 0.12)
-KO_CONFIG_PATH=${WORKDIR}/ go run github.com/google/ko@v0.12.0 build --tags ${IMAGE_TAG} --base-import-paths --push=true ./cmd/cloud-controller-manager/
+echo "git status:"
+git status
+IMAGE_REPO=${IMAGE_REPO} IMAGE_TAG=${IMAGE_TAG} tools/push-images
 
 if [[ -z "${ADMIN_ACCESS:-}" ]]; then
   ADMIN_ACCESS="0.0.0.0/0" # Or use your IPv4 with /32
@@ -185,11 +159,9 @@ cp "${REPO_ROOT}/deploy/packages/default/manifest.yaml" "${WORKDIR}/cloud-provid
 sed -i -e "s@k8scloudprovidergcp/cloud-controller-manager:latest@${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}@g" "${WORKDIR}/cloud-provider-gcp.yaml"
 create_args="${create_args} --add=${WORKDIR}/cloud-provider-gcp.yaml"
 
-
 # Enable cluster addons, this enables us to replace the built-in manifest
 KOPS_FEATURE_FLAGS="ClusterAddons,${KOPS_FEATURE_FLAGS:-}"
 echo "KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
-
 
 # Note that these arguments for kubetest2 and kOps, not (for example) the arguments passed to the cloud-provider-gcp
 KUBETEST2_ARGS=""

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -137,6 +137,11 @@ unset KUBE_ROOT
 
 echo "git status:"
 git status
+
+echo "Configuring docker auth with gcloud"
+gcloud auth configure-docker
+
+echo "Building and pushing images"
 IMAGE_REPO=${IMAGE_REPO} IMAGE_TAG=${IMAGE_TAG} tools/push-images
 
 if [[ -z "${ADMIN_ACCESS:-}" ]]; then


### PR DESCRIPTION
We want to test with the same build that we are now using
to publish images.
