### PR TITLE
fix: Dockerfile should set entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ RUN CGO_ENABLED=0 go build -o /go/bin/cloud-controller-manager ./cmd/cloud-contr
 FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.0-bookworm.0
 COPY --from=builder --chown=root:root /go/bin/cloud-controller-manager /cloud-controller-manager
 CMD ["/cloud-controller-manager"]
+ENTRYPOINT ["/cloud-controller-manager"]


### PR DESCRIPTION
The introduction of the Dockerfile had changed the entrypoint to
ko-runner, breaking manifests that did not override the entrypoint.

Restore the old behaviour where specifying the entrypoint was optional.
