### PR TITLE
Dockerfile: Use debian-base as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY pkg/ pkg/
 COPY providers/ providers/
 RUN CGO_ENABLED=0 go build -o /go/bin/cloud-controller-manager ./cmd/cloud-controller-manager
 
-FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.0-bookworm.0
+FROM registry.k8s.io/build-image/debian-base:bookworm-v1.0.4
 COPY --from=builder --chown=root:root /go/bin/cloud-controller-manager /cloud-controller-manager
 CMD ["/cloud-controller-manager"]
 ENTRYPOINT ["/cloud-controller-manager"]


### PR DESCRIPTION
I don't think go-runner should be needed for running CCM. `debian-base` should be good enough.
Ref: https://github.com/kubernetes/release/tree/master/images/build/debian-base

/cc @justinsb
/assign @justinsb 