### PR TITLE
fix docker file COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GOOS=linux
 ENV CGO_ENABLED=0
 
 WORKDIR /go/src/app
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 COPY providers/go.mod providers/go.sum providers/
 COPY vendor/ vendor/
 


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images/1915465901432377344:

```
Step #0: Step 7/17 : COPY go.mod go.sum .
Step #0: When using COPY with more than one source file, the destination must be a directory and end with a /
```


Related to https://github.com/kubernetes/cloud-provider-gcp/pull/838

Tested locally 
```
IMAGE_REPO=<something> IMAGE_TAG=<something> ./tools/push-images
```

