### PR TITLE
bazel build: use go 1.24 in go_sdk

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.23.3",
+    version = "1.24.1",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
Fix https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images/1915536523495739392

/label tide/merge-method-squash