### PR TITLE
Revert "[Cherry-pick #834 to release-1.32] Implement loadBalancerClass support for L4 Service selection"

### DIFF
--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -22,10 +22,10 @@ package gce
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"k8s.io/api/core/v1"
 )
 
 // LoadBalancerType defines a specific type for holding load balancer types (eg. Internal)
@@ -45,14 +45,6 @@ const (
 
 	// Deprecating the lowercase spelling of Internal.
 	deprecatedTypeInternalLowerCase LoadBalancerType = "internal"
-
-	// LegacyRegionalInternalLoadBalancerClass is the loadBalancerClass name used to select the
-	// GKE CCM ILB implementation.
-	LegacyRegionalInternalLoadBalancerClass = "networking.gke.io/l4-regional-internal-legacy"
-
-	// LegacyRegionalExternalLoadBalancerClass is the loadBalancerClass name used to select the
-	// GKE CCM NetLB implementation.
-	LegacyRegionalExternalLoadBalancerClass = "networking.gke.io/l4-regional-external-legacy"
 
 	// ServiceAnnotationILBBackendShare is annotated on a service with "true" when users
 	// want to share GCP Backend Services for a set of internal load balancers.
@@ -94,12 +86,6 @@ const (
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.
 func GetLoadBalancerAnnotationType(service *v1.Service) LoadBalancerType {
 	var lbType LoadBalancerType
-	// Check LoadBalancerClass before load balancer type annotation since it has precedence.
-	if hasLoadBalancerClass(service, LegacyRegionalInternalLoadBalancerClass) {
-		return LBTypeInternal
-	} else if hasLoadBalancerClass(service, LegacyRegionalExternalLoadBalancerClass) {
-		return lbType
-	}
 	for _, ann := range []string{
 		ServiceAnnotationLoadBalancerType,
 		deprecatedServiceAnnotationLoadBalancerType,

--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -130,11 +130,10 @@ func (g *Cloud) GetLoadBalancerName(ctx context.Context, clusterName string, svc
 
 // EnsureLoadBalancer is an implementation of LoadBalancer.EnsureLoadBalancer.
 func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	// Ignore services with LoadBalancerClass different than "networking.gke.io/l4-regional-external-legacy" or
-	// "networking.gke.io/l4-regional-internal-legacy" used for these controllers.
-	// LoadBalancerClass can't be updated (see the field API doc) so we don't need to clean any resources.
-	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) && !hasLoadBalancerClass(svc, LegacyRegionalExternalLoadBalancerClass) {
-		klog.Infof("Ignoring service %s/%s using load balancer class %q, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
+	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
+	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
+	if svc.Spec.LoadBalancerClass != nil {
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
 		return nil, cloudprovider.ImplementedElsewhere
 	}
 
@@ -213,11 +212,10 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 
 // UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
 func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc *v1.Service, nodes []*v1.Node) error {
-	// Ignore services with LoadBalancerClass different than "networking.gke.io/l4-regional-external-legacy" or
-	// "networking.gke.io/l4-regional-internal-legacy" used for these controllers.
-	// LoadBalancerClass can't be updated (see the field API doc) so we don't need to clean any resources.
-	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) && !hasLoadBalancerClass(svc, LegacyRegionalExternalLoadBalancerClass) {
-		klog.Infof("Ignoring service %s/%s using load balancer class %q, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
+	// GCE load balancers do not support services with LoadBalancerClass set. LoadBalancerClass can't be updated for an existing load balancer, so here we don't need to clean any resources.
+	// Check API documentation for .Spec.LoadBalancerClass for details on when this field is allowed to be changed.
+	if svc.Spec.LoadBalancerClass != nil {
+		klog.Infof("Ignoring service %s/%s using load balancer class %s, it is not supported by this controller.", svc.Namespace, svc.Name, svc.Spec.LoadBalancerClass)
 		return cloudprovider.ImplementedElsewhere
 	}
 
@@ -261,14 +259,6 @@ func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc 
 
 // EnsureLoadBalancerDeleted is an implementation of LoadBalancer.EnsureLoadBalancerDeleted.
 func (g *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, svc *v1.Service) error {
-	// Ignore services with LoadBalancerClass different than "networking.gke.io/l4-regional-external-legacy" or
-	// "networking.gke.io/l4-regional-internal-legacy" used for these controllers.
-	// LoadBalancerClass can't be updated (see the field API doc) so we don't need to clean any resources.
-	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) && !hasLoadBalancerClass(svc, LegacyRegionalExternalLoadBalancerClass) {
-		klog.Infof("Ignoring service %s/%s using load balancer class %q, it is not supported by this controller.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
-		return cloudprovider.ImplementedElsewhere
-	}
-
 	loadBalancerName := g.GetLoadBalancerName(ctx, clusterName, svc)
 	scheme := getSvcScheme(svc)
 	clusterID, err := g.ClusterID.GetID()

--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -450,130 +450,52 @@ func Test_hasLoadBalancerPortsError(t *testing.T) {
 	}
 }
 
-func TestEnsureLoadBalancerServiceWithLoadBalancerClass(t *testing.T) {
+func TestEnsureLoadBalancerIgnoresServiceWithLoadBalancerClass(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
-		desc              string
-		loadBalancerClass string
-		shouldProcess     bool
-	}{
-		{
-			desc:              "Custom loadBalancerClass should not process",
-			loadBalancerClass: "customLBClass",
-			shouldProcess:     false,
-		},
-		{
-			desc:              "Use legacy ILB loadBalancerClass",
-			loadBalancerClass: LegacyRegionalInternalLoadBalancerClass,
-			shouldProcess:     true,
-		},
-		{
-			desc:              "Use legacy NetLB loadBalancerClass",
-			loadBalancerClass: LegacyRegionalExternalLoadBalancerClass,
-			shouldProcess:     true,
-		},
-		{
-			desc:              "Unset loadBalancerClass",
-			loadBalancerClass: "",
-			shouldProcess:     true,
-		},
-	} {
 
-		vals := DefaultTestClusterValues()
-		gce, err := fakeGCECloud(vals)
-		require.NoError(t, err)
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
 
-		nodeNames := []string{"test-node-1"}
-		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
-		require.NoError(t, err)
+	nodeNames := []string{"test-node-1"}
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
 
-		apiService := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
-		if tc.loadBalancerClass == "" {
-			apiService = fakeLoadbalancerService("")
-		}
-
-		apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
-		assert.NoError(t, err)
-		expectedStatus, err := gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
-
-		if tc.shouldProcess {
-			require.NoError(t, err)
-			status, found, err := gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
-			assert.Equal(t, expectedStatus, status)
-			assert.True(t, found)
-			assert.NoError(t, err)
-		} else {
-			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
-			assert.Empty(t, expectedStatus)
-		}
-	}
+	apiService := fakeLoadbalancerService("")
+	testClass := "TestClass"
+	apiService.Spec.LoadBalancerClass = &testClass
+	status, err := gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
+	assert.Empty(t, status)
 }
 
 func TestUpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
-		desc              string
-		loadBalancerClass string
-		shouldProcess     bool
-	}{
-		{
-			desc:              "Update with custom loadBalancerClass, should not process",
-			loadBalancerClass: "customLBClass",
-			shouldProcess:     false,
-		},
-		{
-			desc:              "Update with legacy ILB loadBalancerClass",
-			loadBalancerClass: LegacyRegionalInternalLoadBalancerClass,
-			shouldProcess:     true,
-		},
-		{
-			desc:              "Update with legacy NetLB loadBalancerClass",
-			loadBalancerClass: LegacyRegionalExternalLoadBalancerClass,
-			shouldProcess:     true,
-		},
-		{
-			desc:              "Update with loadBalancerClass unset",
-			loadBalancerClass: "",
-			shouldProcess:     true,
-		},
-	} {
-		vals := DefaultTestClusterValues()
-		gce, err := fakeGCECloud(vals)
-		require.NoError(t, err)
 
-		nodeNames := []string{"test-node-1"}
-		nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
-		require.NoError(t, err)
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
 
-		apiService := fakeLoadbalancerServiceWithLoadBalancerClass("", tc.loadBalancerClass)
-		if tc.loadBalancerClass == "" {
-			apiService = fakeLoadbalancerService("")
-		}
+	nodeNames := []string{"test-node-1"}
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
 
-		apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
-		assert.NoError(t, err)
-		gce.EnsureLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	apiService := fakeLoadbalancerService("")
+	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
+		Protocol: v1.ProtocolUDP,
+		Port:     int32(8080),
+	})
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
+	require.NoError(t, err)
 
-		apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
-			Protocol: v1.ProtocolTCP,
-			Port:     int32(80),
-		})
-		err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	// create an external loadbalancer to simulate an upgrade scenario where the loadbalancer exists
+	// before the new controller is running and later the Service is updated
+	_, err = createExternalLoadBalancer(gce, apiService, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	assert.NoError(t, err)
 
-		if tc.shouldProcess {
-			require.NoError(t, err)
-			_, found, err := gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
-			assert.True(t, found)
-			assert.NoError(t, err)
-		} else {
-			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
-		}
+	testClass := "testClass"
+	apiService.Spec.LoadBalancerClass = &testClass
 
-		err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, apiService)
-		if tc.shouldProcess {
-			assert.NoError(t, err)
-		} else {
-			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
-		}
-	}
+	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
+	assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
 }

--- a/providers/gce/gce_loadbalancer_utils_test.go
+++ b/providers/gce/gce_loadbalancer_utils_test.go
@@ -58,20 +58,6 @@ func fakeLoadBalancerServiceDeprecatedAnnotation(lbType string) *v1.Service {
 	return fakeLoadbalancerServiceHelper(lbType, deprecatedServiceAnnotationLoadBalancerType)
 }
 
-func fakeLoadbalancerServiceWithLoadBalancerClass(lbType, lbClass string) *v1.Service {
-	return &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        fakeSvcName,
-			Annotations: map[string]string{ServiceAnnotationLoadBalancerType: lbType},
-		},
-		Spec: v1.ServiceSpec{
-			LoadBalancerClass: &lbClass,
-			Type:              v1.ServiceTypeLoadBalancer,
-			Ports:             []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: int32(123)}},
-		},
-	}
-}
-
 func fakeLoadbalancerServiceHelper(lbType string, annotationKey string) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -48,10 +48,6 @@ import (
 )
 
 const (
-	// RegionalExternalLoadBalancerClass is the loadBalancerClass name used to select the
-	// RBS LB implementation.
-	RegionalExternalLoadBalancerClass = "networking.gke.io/l4-regional-external"
-
 	// NetLBFinalizerV2 is the finalizer used by newer controllers that manage L4 External LoadBalancer services.
 	NetLBFinalizerV2 = "gke.networking.io/l4-netlb-v2"
 
@@ -392,15 +388,6 @@ func hasFinalizer(service *v1.Service, key string) bool {
 	return false
 }
 
-func hasLoadBalancerClass(service *v1.Service, key string) bool {
-	if service.Spec.LoadBalancerClass != nil {
-		if *service.Spec.LoadBalancerClass == key {
-			return true
-		}
-	}
-	return false
-}
-
 // removeString returns a newly created []string that contains all items from slice that
 // are not equal to s.
 func removeString(slice []string, s string) []string {
@@ -417,10 +404,6 @@ func removeString(slice []string, s string) []string {
 // Such services implemented in other controllers and
 // should not be handled by Service Controller.
 func usesL4RBS(service *v1.Service, forwardingRule *compute.ForwardingRule) bool {
-	// Detect RBS by loadBalancerClass
-	if hasLoadBalancerClass(service, RegionalExternalLoadBalancerClass) {
-		return true
-	}
 	// Detect RBS by annotation
 	if val, ok := service.Annotations[RBSAnnotationKey]; ok && val == RBSEnabled {
 		return true


### PR DESCRIPTION
Reverts kubernetes/cloud-provider-gcp#840

Changes cherry-picked to release 1.32 are no longer needed and were never released. This behavior is not expected to be supported in 1.32 for now. Removing them from this release to keep it clean and prevent releasing this changes which are not needed if a necessary backport is needed.