### PR TITLE
bazel build: use go 1.24 in go_sdk (1.33 backport)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ go_rules_dependencies()
 
 go_download_sdk(
     name = "go_sdk",
-    version = "1.23.3",
+    version = "1.24.1",
 )
 
 go_register_toolchains()


### PR DESCRIPTION
cherry pick of https://github.com/kubernetes/cloud-provider-gcp/pull/858

The post submit job has been fixed after #858
https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/post-cloud-provider-gcp-push-images


/label tide/merge-method-squash


/cc @XuanWang-Amos
/assign @mmamczur 