### PR TITLE
Fix: Target Pool are leaked when Forwarding Rule fails deletion

### DIFF
--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -116,7 +116,7 @@ func (g *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, svc *v1
 	}
 	// Checking for finalizer is more accurate because controller restart could happen in the middle of resource
 	// deletion. So even though forwarding rule was deleted, cleanup might not have been complete.
-	if hasFinalizer(svc, ILBFinalizerV1) {
+	if hasFinalizer(svc, ILBFinalizerV1) || hasFinalizer(svc, NetLBFinalizerV1) {
 		return &v1.LoadBalancerStatus{}, true, nil
 	}
 	return nil, false, ignoreNotFound(err)


### PR DESCRIPTION
Adding finalizer-netlb-v1 check when checking if NetLB exists. 

If FR was deleted but deletion call fails, the controller will think the LB does not exist anymore and it will skip cleaning up the Target Pool.

Since Finalizer V1 is removed only when all the resources are successfully cleaned up we can use it to know if something is left to clean up.