### PR TITLE
TestGetLoadBalancer improvement: finalizer check logic in GetLoadBalancer

### DIFF
--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -59,6 +59,26 @@ func TestGetLoadBalancer(t *testing.T) {
 	assert.Equal(t, expectedStatus, status)
 	assert.True(t, found)
 	assert.NoError(t, err)
+
+	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, apiService)
+	require.NoError(t, err)
+
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Nil(t, status)
+	assert.False(t, found)
+	assert.NoError(t, err)
+
+	apiService.Finalizers = []string{NetLBFinalizerV1}
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Equal(t, &v1.LoadBalancerStatus{}, status)
+	assert.True(t, found)
+	assert.NoError(t, err)
+
+	apiService.Finalizers = []string{NetLBFinalizerV1}
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Equal(t, &v1.LoadBalancerStatus{}, status)
+	assert.True(t, found)
+	assert.NoError(t, err)
 }
 
 func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {


### PR DESCRIPTION
This PR enhances the TestGetLoadBalancer function by adding a test case to verify its behavior when a Service has a finalizer, but the underlying cloud resource has already been deleted.

Motivation:
The GetLoadBalancer function has specific logic to handle the cleanup phase of a LoadBalancer. When a service is being deleted, it might still have a finalizer (e.g., NetLBFinalizerV1) even after the actual GCE forwarding rule is gone.

In this state, GetLoadBalancer should correctly report that the resource still exists (found=true) to ensure the controller completes the cleanup process gracefully. The existing tests did not explicitly cover this important lifecycle state.

Changes:
After the load balancer is deleted in the test, a finalizer is manually added back to the service object.

New assertions are added to confirm that GetLoadBalancer returns found=true with an empty status, which is the expected behavior in this scenario.