### PR TITLE
Update TestGetLoadBalancer with finalizer check

### DIFF
--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -59,6 +59,26 @@ func TestGetLoadBalancer(t *testing.T) {
 	assert.Equal(t, expectedStatus, status)
 	assert.True(t, found)
 	assert.NoError(t, err)
+
+	err = gce.EnsureLoadBalancerDeleted(context.Background(), vals.ClusterName, apiService)
+	require.NoError(t, err)
+
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Nil(t, status)
+	assert.False(t, found)
+	assert.NoError(t, err)
+
+	apiService.Finalizers = []string{NetLBFinalizerV1}
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Equal(t, &v1.LoadBalancerStatus{}, status)
+	assert.True(t, found)
+	assert.NoError(t, err)
+
+	apiService.Finalizers = []string{NetLBFinalizerV1}
+	status, found, err = gce.GetLoadBalancer(context.Background(), vals.ClusterName, apiService)
+	assert.Equal(t, &v1.LoadBalancerStatus{}, status)
+	assert.True(t, found)
+	assert.NoError(t, err)
 }
 
 func TestEnsureLoadBalancerCreatesExternalLb(t *testing.T) {


### PR DESCRIPTION
The `GetLoadBalancer` function returns `found=true` with an empty status if the underlying forwarding rule is deleted but the Service object still contains a finalizer (`ILBFinalizerV1` or `NetLBFinalizerV1`). This indicates to the controller that resource cleanup is still in progress.

This commit updates `TestGetLoadBalancer` to verify this behavior. After the load balancer is deleted, the test now adds a finalizer to the service and asserts that `GetLoadBalancer` correctly returns `found=true`.


this is a rebased version of #888