### PR TITLE
Adding SyncMutex as unit tests is failing when detecting race

### DIFF
--- a/pkg/controller/nodeipam/ipam/task_queue_test.go
+++ b/pkg/controller/nodeipam/ipam/task_queue_test.go
@@ -32,10 +32,13 @@ func simpleKeyFun(obj interface{}) (string, error) {
 func TestTaskQueue(t *testing.T) {
 	t.Parallel()
 	synced := map[string]bool{}
+	var syncedMutex sync.Mutex
 	doneCh := make(chan struct{}, 1)
 
 	sync := func(key string) error {
+		syncedMutex.Lock()
 		synced[key] = true
+		syncedMutex.Unlock()
 		switch key {
 		case "err":
 			return errors.New("injected error")


### PR DESCRIPTION
example - go test -count=1 -race -v $(go list ./...)

Complete log [data](https://www.diffchecker.com/NUVo0Bj3/) , left ( failed without fix) right (Passed with fix)
