### PR TITLE
Add enableMultiNetworking flag and clarify the multi-networking judgement logic

### DIFF
--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -150,6 +150,7 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 		gnpInformer,
 		nodeTopologyClient,
 		nodeIPAMConfig.EnableMultiSubnetCluster,
+		nodeIPAMConfig.EnableMultiNetworking,
 		clusterCIDRs,
 		serviceCIDR,
 		secondaryServiceCIDR,

--- a/cmd/cloud-controller-manager/options/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/options/nodeipamcontroller.go
@@ -40,6 +40,7 @@ func (o *NodeIPAMControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv4, "node-cidr-mask-size-ipv4", o.NodeCIDRMaskSizeIPv4, "Mask size for IPv4 node cidr in dual-stack cluster. Default is 24.")
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv6, "node-cidr-mask-size-ipv6", o.NodeCIDRMaskSizeIPv6, "Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.")
 	fs.BoolVar(&o.EnableMultiSubnetCluster, "enable-multi-subnet-cluster", o.EnableMultiSubnetCluster, "Enabled multi-subnet cluster feature. This enables generating updated nodeTopology custom resource. ")
+	fs.BoolVar(&o.EnableMultiNetworking, "enable-multi-networking", o.EnableMultiNetworking, "Enabled multi-networking related logics such as multi-networking IPAM.")
 }
 
 // ApplyTo fills up NodeIpamController config with options.
@@ -61,6 +62,7 @@ func (o *NodeIPAMControllerOptions) ApplyTo(cfg *nodeipamconfig.NodeIPAMControll
 	cfg.NodeCIDRMaskSizeIPv4 = o.NodeCIDRMaskSizeIPv4
 	cfg.NodeCIDRMaskSizeIPv6 = o.NodeCIDRMaskSizeIPv6
 	cfg.EnableMultiSubnetCluster = o.EnableMultiSubnetCluster
+	cfg.EnableMultiNetworking = o.EnableMultiNetworking
 
 	return nil
 }

--- a/pkg/controller/nodeipam/config/types.go
+++ b/pkg/controller/nodeipam/config/types.go
@@ -36,4 +36,8 @@ type NodeIPAMControllerConfiguration struct {
 	// which is represented by a node label. Enabling this feature also assumes that a
 	// nodeTopology CR named 'default' is already installed.
 	EnableMultiSubnetCluster bool
+	// enableMultiNetworking is bound to a command-line flag. It should be set to true
+	// when the cluster-level "enable-multi-networking" flag is true to enable
+	// the multi-networking related logics such as multi-networking IPAM.
+	EnableMultiNetworking bool
 }

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -115,7 +115,7 @@ type CIDRAllocatorParams struct {
 }
 
 // New creates a new CIDR range allocator.
-func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, enableMultiSubnetCluster bool, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
+func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, enableMultiSubnetCluster bool, enableMultiNetworking bool, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
 	nodeList, err := listNodes(kubeClient)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInfo
 	case RangeAllocatorType:
 		return NewCIDRRangeAllocator(kubeClient, nodeInformer, allocatorParams, nodeList)
 	case CloudAllocatorType:
-		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, nodeInformer, allocatorParams)
+		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, enableMultiNetworking, nodeInformer, allocatorParams)
 	default:
 		return nil, fmt.Errorf("invalid CIDR allocator type: %v", allocatorType)
 	}

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -80,6 +80,7 @@ func NewNodeIpamController(
 	gnpInformer networkinformer.GKENetworkParamSetInformer,
 	nodeTopologyClient nodetopologyclientset.Interface,
 	enableMultiSubnetCluster bool,
+	enableMultiNetworking bool,
 	clusterCIDRs []*net.IPNet,
 	serviceCIDR *net.IPNet,
 	secondaryServiceCIDR *net.IPNet,
@@ -136,7 +137,7 @@ func NewNodeIpamController(
 			NodeCIDRMaskSizes:    nodeCIDRMaskSizes,
 		}
 
-		ic.cidrAllocator, err = ipam.New(kubeClient, cloud, nodeInformer, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, ic.allocatorType, allocatorParams)
+		ic.cidrAllocator, err = ipam.New(kubeClient, cloud, nodeInformer, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, enableMultiNetworking, ic.allocatorType, allocatorParams)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -63,7 +63,7 @@ func newTestNodeIpamController(clusterCIDR []*net.IPNet, serviceCIDR *net.IPNet,
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	return NewNodeIpamController(
 		fakeNodeInformer, fakeGCE, clientSet, fakeNwInformer, fakeGNPInformer, nodeTopologyFakeClient,
-		true, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType,
+		true, false, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType,
 	)
 }
 


### PR DESCRIPTION
The current way in cloud-controller-manager to determine multi-networking-enabled clusters is based on the number of NICs. However, as an ongoing effort to decouple multi-NIC nodes with the enableMultiNetworking flag, nodes with multi-NICs but don't have the multi-networking features enabled are incorrectly processed by multi-networking code paths. 

For logic that differs between non-multi-networking and multi-networking clusters (such as determining node's podCIDR), the direct discriminator should be the --enable-multi-networking flag. 

Introducing this enableMultiNetworking flag to CCM ensures more accurate feature logic and unblocks the creation of new multi-NIC nodes.