### PR TITLE
Populate lastTransitionTime for LoadBalancerPortsError

### DIFF
--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -159,6 +159,7 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 				WithType(v1.LoadBalancerPortsError).
 				WithStatus(metav1.ConditionTrue).
 				WithReason(v1.LoadBalancerPortsErrorReason).
+				WithLastTransitionTime(metav1.Now()).
 				WithMessage("LoadBalancer with multiple protocols are not supported"))
 		svcApply := corev1apply.Service(svc.Name, svc.Namespace).WithStatus(svcApplyStatus)
 		if _, errApply := g.client.CoreV1().Services(svc.Namespace).ApplyStatus(ctx, svcApply, metav1.ApplyOptions{FieldManager: "gce-cloud-controller", Force: true}); errApply != nil {
@@ -239,6 +240,7 @@ func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc 
 				WithType(v1.LoadBalancerPortsError).
 				WithStatus(metav1.ConditionTrue).
 				WithReason(v1.LoadBalancerPortsErrorReason).
+				WithLastTransitionTime(metav1.Now()).
 				WithMessage("LoadBalancer with multiple protocols are not supported"))
 		svcApply := corev1apply.Service(svc.Name, svc.Namespace).WithStatus(svcApplyStatus)
 		if _, errApply := g.client.CoreV1().Services(svc.Namespace).ApplyStatus(ctx, svcApply, metav1.ApplyOptions{FieldManager: "gce-cloud-controller", Force: true}); errApply != nil {


### PR DESCRIPTION
This change addresses an issue where the `lastTransitionTime` field in the `LoadBalancerPortsError` condition was null. This would happen when a service was created with mixed protocols (e.g., TCP and UDP), which is not supported by the L4 regional external and internal load balancers.

According to the Kubernetes API specification, `lastTransitionTime` is a required field.