### PR TITLE
fix bazel build with python dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ http_archive(
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
-    name = "python_3_11",
+    name = "python_3_9",
     # Available versions are listed in @rules_python//python:versions.bzl.
     ignore_root_user_error = True,
     python_version = "3.9",


### PR DESCRIPTION
Fix `bazel build //release:release-tars` build error. It looks bazel is confused about the python version.
This problem is probably linux environment only(not exist in the CI machine or mac).

This is error log from my glinux machine:
```
$  bazel clean && bazel build //release:release-tars
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
INFO: Analyzed target //release:release-tars (1358 packages loaded, 23560 targets configured).
INFO: Found 1 target...
ERROR: /usr/local/google/home/zivy/cloud-provider-gcp/deploy/BUILD:5:8: PackageTar deploy/manifest.tar failed: (Exit 1): build_tar failed: error executing command
  (cd /usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp && \
  exec env - \
    PATH=/usr/local/google/home/zivy/bin:/usr/local/sbin/protoc-gen-grpc:/usr/local/google/home/zivy/jdk-11.0.2/bin:/usr/lib/google-golang/bin:/usr/local/buildtools/java/jdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar --flagfile bazel-out/k8-fastbuild/bin/deploy/manifest.args)
# Configuration: 9b10e5be35fc4899806d8665ae6c56a3240c98b076914940f994efbcd04406d7
# Execution platform: @local_config_platform//:host

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Traceback (most recent call last):
  File "/usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/tools/build_defs/pkg/build_tar.py", line 21, in <module>
    from absl import app
  File "/usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/third_party/py/abseil/absl/app.py", line 38, in <module>
    from absl import flags
  File "/usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/third_party/py/abseil/absl/flags/__init__.py", line 40, in <module>
    from absl.flags import _argument_parser
  File "/usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/third_party/py/abseil/absl/flags/_argument_parser.py", line 29, in <module>
    from absl.flags import _helpers
  File "/usr/local/google/home/zivy/.cache/bazel/_bazel_zivy/5c54abc67a5cbd579d396d87a25726a1/sandbox/linux-sandbox/14902/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/build_defs/pkg/build_tar.runfiles/bazel_tools/third_party/py/abseil/absl/flags/_helpers.py", line 38, in <module>
    from six.moves import range  # pylint: disable=redefined-builtin
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'six.moves'
Target //release:release-tars failed to build
INFO: Elapsed time: 3.406s, Critical Path: 1.34s
INFO: 53 processes: 53 internal.
FAILED: Build did NOT complete successfully
```