### PR TITLE
add sig leads to the owners files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- sig-cloud-provider-leads
 - aojea
 - bowei
 - cheftako
@@ -14,5 +15,6 @@ emeritus_approvers:
 - dnardo
 - nicksardo
 reviewers:
+- sig-cloud-provider-leads
 - justinsb
 - seans3

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+aliases:
+  sig-cloud-provider-leads:
+    - bridgetkromhout
+    - cheftako
+    - elmiko
+    - joelspeed


### PR DESCRIPTION
as discussed in the SIG Cloud Provider office hours on 16 July 2025, the leads are being added to all repositories that the sig owns. This is being done to help provide an extra layer of redundancy for merging changes.