### PR TITLE
fix: Replacing cos-109-lts (deprecated) with cos-121-lts 

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -88,7 +88,7 @@ fi
 # By default, the latest image from the image family will be used unless an
 # explicit image will be set.
 GCI_VERSION=${KUBE_GCI_VERSION:-}
-IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-109-lts}
+IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-121-lts}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_FAMILY=${KUBE_GCE_MASTER_IMAGE_FAMILY:-${IMAGE_FAMILY}}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -101,7 +101,7 @@ ALLOWED_NOTREADY_NODES=${ALLOWED_NOTREADY_NODES:-$(($(get-num-nodes) / 100))}
 # By default, the latest image from the image family will be used unless an
 # explicit image will be set.
 GCI_VERSION=${KUBE_GCI_VERSION:-}
-IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-109-lts}
+IMAGE_FAMILY=${KUBE_IMAGE_FAMILY:-cos-121-lts}
 export MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 export MASTER_IMAGE_FAMILY=${KUBE_GCE_MASTER_IMAGE_FAMILY:-${IMAGE_FAMILY}}
 export MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -68,6 +68,12 @@ if [[ "${MASTER_OS_DISTRIBUTION}" == "gci" ]]; then
       kube_master_image=$(gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" --no-standard-images --filter="family:${MASTER_IMAGE_FAMILY}" --format 'value(name)')
     fi
 
+    # If master image is still empty, then we have an error.
+    if [[ -z "${kube_master_image}" ]]; then
+      echo "ERROR: Could not resolve image for family ${MASTER_IMAGE_FAMILY} in project ${MASTER_IMAGE_PROJECT}" >&2
+      exit 1
+    fi
+
     echo "Using image: ${kube_master_image} from project: ${MASTER_IMAGE_PROJECT} as master image" >&2
     export MASTER_IMAGE="${kube_master_image}"
 fi


### PR DESCRIPTION
Replacing default tests image familiy cos-109-lts (deprecated) with cos-121-lts for gce e2e tests ([doc](https://docs.cloud.google.com/container-optimized-os/docs/release-notes#Archived))

Also adding better error handling for unresolved master image