### PR TITLE
Automated cherry pick of #925: make the docker image multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-ARG GOARCH="amd64"
-
-FROM golang:1.24.5 AS builder
+FROM golang:1.24.10 AS builder
 # golang envs
-ARG GOARCH="amd64"
+ARG TARGETARCH
 ARG GOOS=linux
 ENV CGO_ENABLED=0
+ENV GOARCH=${TARGETARCH}
 
 WORKDIR /go/src/app
 COPY go.mod go.sum ./
@@ -17,7 +16,7 @@ COPY providers/ providers/
 
 RUN CGO_ENABLED=0 go build -o /go/bin/cloud-controller-manager ./cmd/cloud-controller-manager
 
-FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.0-bookworm.0
+FROM registry.k8s.io/build-image/go-runner:v2.4.0-go1.24.10-bookworm.0
 COPY --from=builder --chown=root:root /go/bin/cloud-controller-manager /cloud-controller-manager
 CMD ["/cloud-controller-manager"]
 ENTRYPOINT ["/cloud-controller-manager"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,93 +3,96 @@
 timeout: 3600s
 options:
   substitution_option: ALLOW_LOOSE
+  machineType: E2_HIGHCPU_32
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
+  - name: "gcr.io/cloud-builders/docker"
     env:
       - IMAGE_REPO=${_IMAGE_REPO}
       - IMAGE_TAG=${_PULL_BASE_REF}
+      - CI=1
+      - BUILDX_NO_DEFAULT_ATTESTATIONS=1
     entrypoint: tools/push-images
   # build gke-gcloud-auth-plugin binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-linux-amd64
       - build
       - //cmd/gke-gcloud-auth-plugin
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-linux-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin
       - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/linux-amd64/${_GIT_TAG}
   # build auth-provider-gcp binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-linux-amd64
       - build
       - //cmd/auth-provider-gcp
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-linux-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp
       - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/linux-amd64/${_GIT_TAG}
   # build gke-gcloud-auth-plugin binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-linux-arm64
       - build
       - --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
       - //cmd/gke-gcloud-auth-plugin
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-linux-arm64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin
       - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/linux-arm64/${_GIT_TAG}
   # build auth-provider-gcp binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-linux-arm64
       - build
       - --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
       - //cmd/auth-provider-gcp
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-linux-arm64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp
       - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/linux-arm64/${_GIT_TAG}
   # build gke-gcloud-auth-plugin binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-windows-amd64
       - build
       - --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64
       - //cmd/gke-gcloud-auth-plugin
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-windows-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin.exe
       - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/windows-amd64/${_GIT_TAG}
   # build auth-provider-gcp binary
-  - name: 'gcr.io/cloud-builders/bazel'
+  - name: "gcr.io/cloud-builders/bazel"
     args:
       - --output_user_root=/workspace/bazel-root
       - --output_base=/workspace/bazel-base-windows-amd64
       - build
       - --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64
       - //cmd/auth-provider-gcp
-  - name: 'gcr.io/cloud-builders/gsutil'
+  - name: "gcr.io/cloud-builders/gsutil"
     args:
       - cp
       - /workspace/bazel-base-windows-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp.exe
       - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/windows-amd64/${_GIT_TAG}
 # TODO: figure out how to do this better, most probably getting rid of bazel
 substitutions:
-  _PULL_BASE_REF: 'master'
-  _GIT_TAG: '12345'
-  _IMAGE_REPO: 'gcr.io/k8s-staging-cloud-provider-gcp'
+  _PULL_BASE_REF: "master"
+  _GIT_TAG: "12345"
+  _IMAGE_REPO: "gcr.io/k8s-staging-cloud-provider-gcp"
 tags:
-  - 'cloud-provider-gcp'
+  - "cloud-provider-gcp"
   - ${_GIT_TAG}

--- a/tools/push-images
+++ b/tools/push-images
@@ -44,9 +44,16 @@ else
   echo "IMAGE_TAG=${IMAGE_TAG}"
 fi
 
+if [ -n "${CI:-}" ]; then
+  docker run --privileged --rm tonistiigi/binfmt --install all
+  docker buildx create \
+    --name multiarch-multiplatform-builder \
+    --driver docker-container \
+    --bootstrap --use
+fi
+
 if [[ "${COMPONENT:-ccm}" == "ccm" ]]; then
-  docker build -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} .
-  docker push ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}
+  docker buildx build --platform linux/arm64,linux/amd64 -t ${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG} . --push
 else
   echo "Skipping CCM build, because component is ${COMPONENT}"
 fi


### PR DESCRIPTION
Cherry pick of #925 on release-1.34.

#925: make the docker image multi-arch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```