### PR TITLE
Make cloud controller manager image multi arch in bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,3 +121,41 @@ fetch_kube_release(
     },
     version = "v1.34.1",
 )
+
+http_archive(
+    name = "rules_oci",
+    sha256 = "5994ec0e8df92c319ef5da5e1f9b514628ceb8fc5824b4234f2fe635abb8cc2e",
+    strip_prefix = "rules_oci-2.2.6",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v2.2.6/rules_oci-v2.2.6.tar.gz",
+)
+
+http_archive(
+    name = "rules_pkg",
+    sha256 = "8c20f74bca25d2d442b327ba2d5471633c5a749432a66e638c563723d5d906f9",
+    urls = [
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+    ],
+)
+
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "oci_register_toolchains")
+oci_register_toolchains(
+    name = "oci",
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
+load("@rules_oci//oci:pull.bzl", "oci_pull")
+
+oci_pull(
+    name = "distroless_base",
+    image = "gcr.io/distroless/static",
+    digest = "sha256:1a891823eb0023df32d431c26b47c0b852955f10b7f6df54117b8979b9a67e85",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64",
+    ],
+)

--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -5,14 +5,18 @@ load(
     "go_binary",
     "go_library",
     "go_test",
+    "go_cross_binary",
 )
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("//defs:version.bzl", "version_x_defs")
 
 go_binary(
-    name = "cloud-controller-manager",
+    name = "cloud-controller-manager_bin",
     embed = [":cloud-controller-manager_lib"],
     pure = "on",
     x_defs = version_x_defs(),
+    visibility = ["//visibility:private"],
 )
 
 go_library(
@@ -55,10 +59,6 @@ go_library(
     ],
 )
 
-load("//defs:container.bzl", "image")
-
-image(binary = ":cloud-controller-manager")
-
 go_test(
     name = "cloud-controller-manager_test",
     srcs = [
@@ -76,3 +76,75 @@ go_test(
         "//vendor/k8s.io/controller-manager/app",
     ],
 )
+
+go_cross_binary(
+    name = "bin_amd64",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_amd64",
+    target = ":cloud-controller-manager_bin",
+)
+
+go_cross_binary(
+    name = "bin_arm64",
+    platform = "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    target = ":cloud-controller-manager_bin",
+)
+
+pkg_tar(
+    name = "layer_amd64",
+    srcs = [":bin_amd64"],
+    package_dir = "/usr/local/bin",
+)
+
+pkg_tar(
+    name = "layer_arm64",
+    srcs = [":bin_arm64"],
+    package_dir = "/usr/local/bin",
+)
+
+oci_image(
+    name = "image_amd64",
+    entrypoint = ["/usr/local/bin/bin_amd64"],
+    tars = [":layer_amd64"],
+    os = "linux",
+    architecture = "amd64",
+)
+
+oci_image(
+    name = "image_arm64",
+    entrypoint = ["/usr/local/bin/bin_arm64"],
+    tars = [":layer_arm64"],
+    os = "linux",
+    architecture = "arm64",
+)
+
+oci_load(
+    name = "load_amd64",
+    image = ":image_amd64",
+    repo_tags = ["my-repo/cloud-controller-manager:local"],
+)
+
+oci_load(
+    name = "load_arm64",
+    image = ":image_arm64",
+    repo_tags = ["my-repo/cloud-controller-manager:local"],
+)
+
+oci_image_index(
+    name = "cloud-controller-manager_index",
+    images = [
+        ":image_amd64",
+        ":image_arm64",
+    ],
+)
+
+oci_push(
+    name = "push_multiplatform_to_gcr",
+    image = ":cloud-controller-manager_index",
+    repository = "{repository_placeholder}",
+)
+
+# Legacy single platform image
+# Left to keep compatibility with existing Google pipeline 
+# To be removed once updated the pipeline to use multi platform image
+load("//defs:container.bzl", "image")
+image(binary = ":cloud-controller-manager_bin")


### PR DESCRIPTION
PR #925 added support for multi architecture images of GCP CCM.

Google internal tools use bazel configuration in `cmd/cloud-controller-manager/BUILD` which is only able to build single platform images. 

This PR updates BUILD file to be able to build multiplatform images as well while keeping compatibility with current pipelines.
