### PR TITLE
build the binaries correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 cluster/bin
 MERGED_LICENSES
+release/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+GIT_VERSION ?= $(shell git describe --tags --always --dirty | sed 's|.*/||')
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+BUCKET_NAME ?= k8s-staging-cloud-provider-gcp
+
+LDFLAGS := -ldflags="\
+-X 'k8s.io/component-base/version.gitVersion=$(GIT_VERSION)' \
+-X 'k8s.io/component-base/version.gitCommit=$(GIT_COMMIT)' \
+-X 'k8s.io/component-base/version.buildDate=$(BUILD_DATE)' \
+-s -w"
+
+all: clean build-all
+
+build-all: clean auth-provider-gcp-linux-amd64 auth-provider-gcp-linux-arm64 auth-provider-gcp-windows-amd64 \
+	cloud-controller-manager-linux-amd64 cloud-controller-manager-linux-arm64 \
+	gke-gcloud-auth-plugin-linux-amd64 gke-gcloud-auth-plugin-linux-arm64 gke-gcloud-auth-plugin-windows-amd64 gke-gcloud-auth-plugin-windows-arm64	gke-gcloud-auth-plugin-darwin-arm64
+
+cloud-controller-manager-linux-amd64 cloud-controller-manager-linux-arm64: cloud-controller-manager-linux-%:
+	mkdir -p release/$(GIT_VERSION)/cloud-controller-manager/linux/$*
+	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/cloud-controller-manager/linux/$*/cloud-controller-manager k8s.io/cloud-provider-gcp/cmd/cloud-controller-manager
+
+auth-provider-gcp-linux-amd64 auth-provider-gcp-linux-arm64: auth-provider-gcp-linux-%:
+	mkdir -p release/$(GIT_VERSION)/auth-provider-gcp/linux/$*
+	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/auth-provider-gcp/linux/$*/auth-provider-gcp k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp
+
+auth-provider-gcp-windows-amd64:
+	mkdir -p release/$(GIT_VERSION)/auth-provider-gcp/windows/amd64
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o release/$(GIT_VERSION)/auth-provider-gcp/windows/amd64/auth-provider-gcp.exe k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp
+
+gke-gcloud-auth-plugin-linux-amd64 gke-gcloud-auth-plugin-linux-arm64: gke-gcloud-auth-plugin-linux-%:
+	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/linux/$*
+	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/linux/$*/gke-gcloud-auth-plugin k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
+
+gke-gcloud-auth-plugin-windows-amd64 gke-gcloud-auth-plugin-windows-arm64: gke-gcloud-auth-plugin-windows-%:
+	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/windows/$*
+	CGO_ENABLED=0 GOOS=windows GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/windows/$*/gke-gcloud-auth-plugin.exe k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
+
+gke-gcloud-auth-plugin-darwin-arm64:
+	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/arm64
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/arm64/gke-gcloud-auth-plugin k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
+
+
+.PHONY: all clean build-all copy-binaries-to-gcs
+
+clean:
+	@echo "Cleaning up..."
+	@find release/ -type d -mindepth 1 -print0 | xargs -0 rm -rf
+
+release-tars:
+	bazel build release:release-tars
+
+copy-binaries-to-gcs: build-all
+	gcloud storage cp --recursive release/$(GIT_VERSION) gs://$(BUCKET_NAME)/$(GIT_VERSION)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,83 +12,10 @@ steps:
       - CI=1
       - BUILDX_NO_DEFAULT_ATTESTATIONS=1
     entrypoint: tools/push-images
-  # build gke-gcloud-auth-plugin binary
-  - name: "gcr.io/cloud-builders/bazel"
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:latest
+    entrypoint: make
     args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-linux-amd64
-      - build
-      - //cmd/gke-gcloud-auth-plugin
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-linux-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin
-      - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/linux-amd64/${_GIT_TAG}
-  # build auth-provider-gcp binary
-  - name: "gcr.io/cloud-builders/bazel"
-    args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-linux-amd64
-      - build
-      - //cmd/auth-provider-gcp
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-linux-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp
-      - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/linux-amd64/${_GIT_TAG}
-  # build gke-gcloud-auth-plugin binary
-  - name: "gcr.io/cloud-builders/bazel"
-    args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-linux-arm64
-      - build
-      - --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
-      - //cmd/gke-gcloud-auth-plugin
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-linux-arm64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin
-      - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/linux-arm64/${_GIT_TAG}
-  # build auth-provider-gcp binary
-  - name: "gcr.io/cloud-builders/bazel"
-    args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-linux-arm64
-      - build
-      - --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
-      - //cmd/auth-provider-gcp
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-linux-arm64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp
-      - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/linux-arm64/${_GIT_TAG}
-  # build gke-gcloud-auth-plugin binary
-  - name: "gcr.io/cloud-builders/bazel"
-    args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-windows-amd64
-      - build
-      - --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64
-      - //cmd/gke-gcloud-auth-plugin
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-windows-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/gke-gcloud-auth-plugin/gke-gcloud-auth-plugin_/gke-gcloud-auth-plugin.exe
-      - gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/windows-amd64/${_GIT_TAG}
-  # build auth-provider-gcp binary
-  - name: "gcr.io/cloud-builders/bazel"
-    args:
-      - --output_user_root=/workspace/bazel-root
-      - --output_base=/workspace/bazel-base-windows-amd64
-      - build
-      - --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64
-      - //cmd/auth-provider-gcp
-  - name: "gcr.io/cloud-builders/gsutil"
-    args:
-      - cp
-      - /workspace/bazel-base-windows-amd64/execroot/io_k8s_cloud_provider_gcp/bazel-out/k8-fastbuild/bin/cmd/auth-provider-gcp/auth-provider-gcp_/auth-provider-gcp.exe
-      - gs://k8s-staging-cloud-provider-gcp/auth-provider-gcp/windows-amd64/${_GIT_TAG}
-# TODO: figure out how to do this better, most probably getting rid of bazel
+      - copy-binaries-to-gcs
 substitutions:
   _PULL_BASE_REF: "master"
   _GIT_TAG: "12345"


### PR DESCRIPTION
Part of #929

This PR changes how the binaries are published to GCS.

It will change from `gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/linux-amd64/v20251203-ccmv34.1.0-6-gbe9a8bb4` to `gs://k8s-staging-cloud-provider-gcp/gke-gcloud-auth-plugin/ccmv34.1.0-6-gbe9a8bb4/linux/amd64/gke-gcloud-auth-plugin` similar to how the kubernetes binaries are structured.




