### PR TITLE
Add Resource Annotations to L4 LB Service 

### DIFF
--- a/providers/gce/BUILD
+++ b/providers/gce/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types",
         "//vendor/k8s.io/apimachinery/pkg/util/errors",
         "//vendor/k8s.io/apimachinery/pkg/util/sets",
+        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch",
         "//vendor/k8s.io/apimachinery/pkg/util/wait",
         "//vendor/k8s.io/apimachinery/pkg/watch",
         "//vendor/k8s.io/client-go/applyconfigurations/core/v1:core",

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -209,6 +209,9 @@ type Cloud struct {
 
 	// enableRBSDefaultForL4NetLB disable Service controller from picking up services by default
 	enableRBSDefaultForL4NetLB bool
+
+	// enableL4LBAnnotations enable annotations related to provisioned resources in GCE
+	enableL4LBAnnotations bool
 }
 
 // ConfigGlobal is the in memory representation of the gce.conf config data
@@ -868,6 +871,10 @@ func (g *Cloud) SetEnableDiscretePortForwarding(enabled bool) {
 
 func (g *Cloud) SetEnableRBSDefaultForL4NetLB(enabled bool) {
 	g.enableRBSDefaultForL4NetLB = enabled
+}
+
+func (g *Cloud) SetEnableL4LBAnnotations(enabled bool) {
+	g.enableL4LBAnnotations = enabled
 }
 
 // getProjectsBasePath returns the compute API endpoint with the `projects/` element.

--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -89,7 +89,27 @@ const (
 
 	// RBSEnabled is an annotation to indicate the Service is opt-in for RBS
 	RBSEnabled = "enabled"
+
+	// serviceStatusPrefix is the prefix used in annotations used to record
+	// debug information in the Service annotations. This is applicable to L4 LB services.
+	serviceStatusPrefix = "networking.gke.io"
+
+	backendServiceResource = "backend-service"
+	targetPoolResource     = "target-pool"
+
+	// backendServiceKey is the annotation key used by l4 controller to record
+	// GCP Backend service name.
+	backendServiceKey = serviceStatusPrefix + "/" + backendServiceResource
+
+	// targetPoolKey is the annotation key used by l4 controller to record
+	// GCP Target pool name.
+	targetPoolKey = serviceStatusPrefix + "/" + targetPoolResource
 )
+
+var l4ResourceAnnotationKeys = []string{
+	backendServiceKey,
+	targetPoolKey,
+}
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.
 func GetLoadBalancerAnnotationType(service *v1.Service) LoadBalancerType {
@@ -175,4 +195,17 @@ func GetLoadBalancerAnnotationSubnet(service *v1.Service) string {
 		return val
 	}
 	return ""
+}
+
+// mergeMap merges the update map into the dst map.
+// Keys in dst are overwritten by values from update.
+// If a value in the update map is an empty string, the key is removed from dst.
+func mergeMap(dst, update map[string]string) {
+	for k, v := range update {
+		if v == "" {
+			delete(dst, k)
+		} else {
+			dst[k] = v
+		}
+	}
 }

--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -55,7 +55,9 @@ const (
 // Due to an interesting series of design decisions, this handles both creating
 // new load balancers and updating existing load balancers, recognizing when
 // each is needed.
-func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string, apiService *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*lbSyncResult, error) {
+	syncResult := newLBSyncResult()
+
 	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-external-legacy" used for this controller.
 	// LoadBalancerClass can't be updated so we know this controller should process the NetLB.
 	// Skip service handling if it uses Regional Backend Services and handled by other controllers
@@ -282,6 +284,7 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	if err := g.ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation, apiService, loadBalancerName, clusterID, ipAddressToUse, hosts, hcToCreate, hcToDelete); err != nil {
 		return nil, err
 	}
+	syncResult.annotations[targetPoolKey] = loadBalancerName
 
 	if tpNeedsRecreation || fwdRuleNeedsUpdate {
 		klog.Infof("ensureExternalLoadBalancer(%s): Creating forwarding rule, IP %s (tier: %s).", lbRefStr, ipAddressToUse, netTier)
@@ -299,7 +302,8 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 	status := &v1.LoadBalancerStatus{}
 	status.Ingress = []v1.LoadBalancerIngress{{IP: ipAddressToUse}}
 
-	return status, nil
+	syncResult.status = status
+	return syncResult, nil
 }
 
 // updateExternalLoadBalancer is the external implementation of LoadBalancer.UpdateLoadBalancer.

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -477,7 +477,7 @@ func TestDeleteAddressWithWrongTier(t *testing.T) {
 	}
 }
 
-func createExternalLoadBalancer(gce *Cloud, svc *v1.Service, nodeNames []string, clusterName, clusterID, zoneName string) (*v1.LoadBalancerStatus, error) {
+func createExternalLoadBalancer(gce *Cloud, svc *v1.Service, nodeNames []string, clusterName, clusterID, zoneName string) (*lbSyncResult, error) {
 	nodes, err := createAndInsertNodes(gce, nodeNames, zoneName)
 	if err != nil {
 		return nil, err
@@ -490,6 +490,12 @@ func createExternalLoadBalancer(gce *Cloud, svc *v1.Service, nodeNames []string,
 		nil,
 		nodes,
 	)
+}
+
+// Helper function to assert lbSyncResult annotations
+func assertSyncResultAnnotations(t *testing.T, gce *Cloud, svc *v1.Service, clusterID string, syncResult *lbSyncResult) {
+	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
+	assert.Equal(t, lbName, syncResult.annotations[targetPoolKey], "TargetPoolKey annotation mismatch")
 }
 
 func TestShouldNotRecreateLBWhenNetworkTiersMismatch(t *testing.T) {
@@ -554,14 +560,16 @@ func TestShouldNotRecreateLBWhenNetworkTiersMismatch(t *testing.T) {
 		},
 	} {
 		tc.mutateSvc(svc)
-		status, err := gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+		syncResult, err := gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
 		if tc.expectError {
 			if err == nil {
 				t.Errorf("for test case %q, expect errror != nil, but got %v", tc.desc, err)
 			}
 		} else {
 			assert.NoError(t, err)
-			assert.NotEmpty(t, status.Ingress)
+			assert.NotEmpty(t, syncResult)
+			assert.NotEmpty(t, syncResult.status.Ingress)
+			assertSyncResultAnnotations(t, gce, svc, vals.ClusterID, syncResult)
 		}
 
 		lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
@@ -586,9 +594,11 @@ func TestEnsureExternalLoadBalancer(t *testing.T) {
 	svc := fakeLoadbalancerService("")
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 	require.NoError(t, err)
-	status, err := createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	syncResult, err := createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, status.Ingress)
+	assert.NotEmpty(t, syncResult)
+	assert.NotEmpty(t, syncResult.status.Ingress)
+	assertSyncResultAnnotations(t, gce, svc, vals.ClusterID, syncResult)
 
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 	require.NoError(t, err)
@@ -1133,12 +1143,13 @@ func TestForwardingRuleNeedsUpdate(t *testing.T) {
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	status, err := createExternalLoadBalancer(gce, svc, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
-	require.NotNil(t, status)
+	syncResult, err := createExternalLoadBalancer(gce, svc, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	require.NotNil(t, syncResult)
+	require.NotNil(t, syncResult.status)
 	require.NoError(t, err)
 
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
-	ipAddr := status.Ingress[0].IP
+	ipAddr := syncResult.status.Ingress[0].IP
 
 	lbIP := svc.Spec.LoadBalancerIP
 	wrongPorts := []v1.ServicePort{svc.Spec.Ports[0]}
@@ -1662,12 +1673,13 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 		{Name: "port7", Protocol: v1.ProtocolTCP, Port: int32(88), TargetPort: intstr.FromInt(87)},
 	}
 
-	status, err := createExternalLoadBalancer(gce, svc, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
-	require.NotNil(t, status)
+	syncResult, err := createExternalLoadBalancer(gce, svc, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	require.NotNil(t, syncResult)
+	require.NotNil(t, syncResult.status)
 	require.NoError(t, err)
 	svcName := "/" + svc.ObjectMeta.Name
 
-	ipAddr := status.Ingress[0].IP
+	ipAddr := syncResult.status.Ingress[0].IP
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
 	ipnet, err := utilnet.ParseIPNets("0.0.0.0/0")
@@ -1676,7 +1688,8 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 	wrongIpnet, err := utilnet.ParseIPNets("1.0.0.0/10")
 	require.NoError(t, err)
 
-	fw, err := gce.GetFirewall(MakeFirewallName(lbName))
+	fwName := MakeFirewallName(lbName)
+	fw, err := gce.GetFirewall(fwName)
 	require.NoError(t, err)
 
 	for desc, tc := range map[string]struct {
@@ -1870,7 +1883,7 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 			fw.SourceRanges[0] = tc.sourceRange
 			fw, err = gce.GetFirewall(MakeFirewallName(lbName))
 			require.Equal(t, fw.SourceRanges[0], tc.sourceRange)
-			require.Equal(t, fw.DestinationRanges[0], status.Ingress[0].IP)
+			require.Equal(t, fw.DestinationRanges[0], syncResult.status.Ingress[0].IP)
 
 			c := gce.c.(*cloud.MockGCE)
 			c.MockFirewalls.GetHook = tc.getHook
@@ -1880,7 +1893,8 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 				svcName,
 				tc.ipAddr,
 				tc.ports,
-				tc.ipnet)
+				tc.ipnet,
+			)
 			assert.Equal(t, tc.exists, exists, "'exists' didn't return as expected "+desc)
 			assert.Equal(t, tc.needsUpdate, needsUpdate, "'needsUpdate' didn't return as expected "+desc)
 			if tc.hasErr {
@@ -1925,14 +1939,15 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	status, err := gce.ensureExternalLoadBalancer(
+	syncResult, err := gce.ensureExternalLoadBalancer(
 		vals.ClusterName,
 		vals.ClusterID,
 		svc,
 		nil,
 		nodes,
 	)
-	require.NotNil(t, status)
+	require.NotNil(t, syncResult)
+	require.NotNil(t, syncResult.status)
 	require.NoError(t, err)
 
 	hostNames := nodeNames(nodes)
@@ -1940,7 +1955,7 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	require.NoError(t, err)
 	clusterID := vals.ClusterID
 
-	ipAddr := status.Ingress[0].IP
+	ipAddr := syncResult.status.Ingress[0].IP
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 	region := vals.Region
 
@@ -1975,13 +1990,13 @@ func TestEnsureTargetPoolAndHealthCheck(t *testing.T) {
 	require.NoError(t, err)
 	err = gce.ensureTargetPoolAndHealthCheck(true, true, svc, lbName, clusterID, ipAddr, manyHosts, hcToCreate, hcToDelete)
 	assert.NoError(t, err)
-
 	pool, err = gce.GetTargetPool(lbName, region)
 	require.NoError(t, err)
 	assert.Equal(t, maxTargetPoolCreateInstances+1, len(pool.Instances))
 
 	err = gce.ensureTargetPoolAndHealthCheck(true, false, svc, lbName, clusterID, ipAddr, hosts, hcToCreate, hcToDelete)
 	assert.NoError(t, err)
+
 	pool, err = gce.GetTargetPool(lbName, region)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(pool.Instances))
@@ -2178,7 +2193,7 @@ func TestEnsureExternalLoadBalancerErrors(t *testing.T) {
 			if tc.injectMock != nil {
 				tc.injectMock(gce.c.(*cloud.MockGCE))
 			}
-			status, err := gce.ensureExternalLoadBalancer(
+			syncResult, err := gce.ensureExternalLoadBalancer(
 				params.clusterName,
 				params.clusterID,
 				params.service,
@@ -2186,7 +2201,7 @@ func TestEnsureExternalLoadBalancerErrors(t *testing.T) {
 				params.nodes,
 			)
 			assert.Error(t, err, "Should return an error when "+desc)
-			assert.Nil(t, status, "Should not return a status when "+desc)
+			assert.Nil(t, syncResult, "Should not return a status when "+desc)
 		})
 	}
 }
@@ -2560,10 +2575,14 @@ func TestEnsureExternalLoadBalancerClass(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Create NetLB
-		status, err := createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+		syncResult, err := createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 		if tc.shouldProcess {
 			assert.NoError(t, err)
-			require.NotNil(t, status)
+			require.NotNil(t, syncResult)
+			require.NotNil(t, syncResult.status)
+
+			assertSyncResultAnnotations(t, gce, svc, vals.ClusterID, syncResult)
+
 			svc, err = gce.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 			assert.NoError(t, err)
 			if hasFinalizer(svc, NetLBFinalizerV2) || hasFinalizer(svc, NetLBFinalizerV3) {
@@ -2571,7 +2590,7 @@ func TestEnsureExternalLoadBalancerClass(t *testing.T) {
 			}
 		} else {
 			assert.ErrorIs(t, err, cloudprovider.ImplementedElsewhere)
-			assert.Empty(t, status)
+			assert.Nil(t, syncResult)
 		}
 
 		nodeNames = []string{"test-node-1", "test-node-2"}

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -54,7 +54,10 @@ const (
 	labelGKESubnetworkName = "cloud.google.com/gke-node-pool-subnet"
 )
 
-func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+// ensureInternalLoadBalancer is the internal implementation of LoadBalancer.EnsureLoadBalancer.
+func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v1.Service, existingFwdRule *compute.ForwardingRule, nodes []*v1.Node) (*lbSyncResult, error) {
+	syncResult := newLBSyncResult()
+
 	// Process services with LoadBalancerClass "networking.gke.io/l4-regional-internal-legacy" used for this controller.
 	// LoadBalancerClass can't be updated so we know this controller should process the ILB.
 	if existingFwdRule == nil && !hasFinalizer(svc, ILBFinalizerV1) && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
@@ -220,6 +223,7 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 	if err != nil {
 		return nil, err
 	}
+	syncResult.annotations[backendServiceKey] = backendServiceName
 
 	if fwdRuleDeleted || existingFwdRule == nil {
 		// existing rule has been deleted, pass in nil
@@ -259,7 +263,8 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 
 	status := &v1.LoadBalancerStatus{}
 	status.Ingress = []v1.LoadBalancerIngress{{IP: updatedFwdRule.IPAddress}}
-	return status, nil
+	syncResult.status = status
+	return syncResult, nil
 }
 
 func removeNodesInNonDefaultNetworks(nodes []*v1.Node, defaultSubnetName string) []*v1.Node {
@@ -581,6 +586,7 @@ func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID s
 	if err != nil {
 		return err
 	}
+
 	err = g.ensureInternalFirewall(svc, MakeFirewallName(loadBalancerName), fwDesc, ipAddress, sourceRanges.StringSlice(), portRanges, protocol, nodes, loadBalancerName)
 	if err != nil {
 		return err


### PR DESCRIPTION
- change ensure LB return type to include both Status and Annotations
- added tests to check annotations are correctly set on both Internal and External L4 LBs
- added Merge Annotation helper function and tests for it