### PR TITLE
Add Makefile to support kubetest2 build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: release-tars
+
+release-tars:
+	# 1. Build the artifacts using Bazel
+	bazel build //release:release-tars
+
+	# 2. Prepare the output directory expected by kubetest2
+	mkdir -p _output/release-tars
+
+	# 3. Copy Linux artifacts (These should always exist on Linux builds)
+	cp bazel-bin/release/kubernetes-server-linux-amd64.tar.gz _output/release-tars/
+	cp bazel-bin/release/kubernetes-server-linux-amd64.tar.gz.sha512 _output/release-tars/
+	cp bazel-bin/release/kubernetes-manifests.tar.gz _output/release-tars/
+	cp bazel-bin/release/kubernetes-manifests.tar.gz.sha512 _output/release-tars/
+
+	# 4. Copy Windows artifacts ONLY if they were built
+	if [ -f bazel-bin/release/kubernetes-node-windows-amd64.tar.gz ]; then \
+		cp bazel-bin/release/kubernetes-node-windows-amd64.tar.gz _output/release-tars/; \
+		cp bazel-bin/release/kubernetes-node-windows-amd64.tar.gz.sha512 _output/release-tars/; \
+	fi


### PR DESCRIPTION
This PR adds a Makefile to the repository root to support standard Kubernetes CI tooling (kubetest2).

Currently, running kubetest2 ... --build fails with:

make: *** No rule to make target 'release-tars'. Stop.
This PR introduces the release-tars target which acts as a bridge between Make and Bazel. It:

Invokes the existing bazel build //release:release-tars target.

Copies the generated artifacts from bazel-bin/ to _output/release-tars/ so kubetest2 can locate them for the cluster provisioning phase.