### PR TITLE
Use native build platform to speed up build times for multiarch builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.24.10 AS builder
 # golang envs
 ARG TARGETARCH
 ARG GOOS=linux


### PR DESCRIPTION
By default, when building an image, docker executes instructions on `$TARGETPLATFORM`. That means if we build on `amd64` machine for `arm64` it is going to emulate `arm64`. Emulating different platforms and compiling code tends to be slow and leads to timeouts. By specifying `--platform=${BUILDPLATFORM}` we can force using `amd64` for golang code compilation (which is native and therefore fast). Final executable will still be `arm64` as indicated by `GOARCH` env var.