### PR TITLE
Add `make test` to replace `bazel test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,45 +24,91 @@ LDFLAGS := -ldflags="\
 -X 'k8s.io/component-base/version.buildDate=$(BUILD_DATE)' \
 -s -w"
 
-all: clean build-all
+AUTH_PROVIDER_GCP := \
+  auth-provider-gcp-linux-amd64 \
+  auth-provider-gcp-linux-arm64 \
+  auth-provider-gcp-windows-amd64
 
-build-all: clean auth-provider-gcp-linux-amd64 auth-provider-gcp-linux-arm64 auth-provider-gcp-windows-amd64 \
-	cloud-controller-manager-linux-amd64 cloud-controller-manager-linux-arm64 \
-	gke-gcloud-auth-plugin-linux-amd64 gke-gcloud-auth-plugin-linux-arm64 gke-gcloud-auth-plugin-windows-amd64 gke-gcloud-auth-plugin-windows-arm64	gke-gcloud-auth-plugin-darwin-arm64
+CLOUD_CONTROLLER_MANAGER := \
+  cloud-controller-manager-linux-amd64 \
+  cloud-controller-manager-linux-arm64
 
+GKE_GCLOUD_AUTH_PLUGIN := \
+  $(foreach platform, \
+  linux-amd64 linux-arm64 windows-amd64 windows-arm64 darwin-arm64, \
+  $(addsuffix $(platform), gke-gcloud-auth-plugin-))
+
+##@ General
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[.a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+## --------------------------------------
+##@ Build
+## --------------------------------------
+
+.PHONY: all
+all: clean build-all ## Clean and build all binaries.
+
+.PHONY: clean
+clean: ## Clean up release directory.
+	@echo "Cleaning up..."
+	@find release/ -type d -mindepth 1 -print0 | xargs -0 rm -rf
+
+.PHONY: build-all
+build-all: $(AUTH_PROVIDER_GCP) $(CLOUD_CONTROLLER_MANAGER) $(GKE_GCLOUD_AUTH_PLUGIN) ## Build all binaries.
+
+.PHONY: cloud-controller-manager-linux-amd64 cloud-controller-manager-linux-arm64
 cloud-controller-manager-linux-amd64 cloud-controller-manager-linux-arm64: cloud-controller-manager-linux-%:
 	mkdir -p release/$(GIT_VERSION)/cloud-controller-manager/linux/$*
 	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/cloud-controller-manager/linux/$*/cloud-controller-manager k8s.io/cloud-provider-gcp/cmd/cloud-controller-manager
 
+.PHONY: auth-provider-gcp-linux-amd64 auth-provider-gcp-linux-arm64
 auth-provider-gcp-linux-amd64 auth-provider-gcp-linux-arm64: auth-provider-gcp-linux-%:
 	mkdir -p release/$(GIT_VERSION)/auth-provider-gcp/linux/$*
 	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/auth-provider-gcp/linux/$*/auth-provider-gcp k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp
 
+.PHONY: auth-provider-gcp-windows-amd64
 auth-provider-gcp-windows-amd64:
 	mkdir -p release/$(GIT_VERSION)/auth-provider-gcp/windows/amd64
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o release/$(GIT_VERSION)/auth-provider-gcp/windows/amd64/auth-provider-gcp.exe k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp
 
+.PHONY: gke-gcloud-auth-plugin-linux-amd64 gke-gcloud-auth-plugin-linux-arm64
 gke-gcloud-auth-plugin-linux-amd64 gke-gcloud-auth-plugin-linux-arm64: gke-gcloud-auth-plugin-linux-%:
 	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/linux/$*
 	CGO_ENABLED=0 GOOS=linux GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/linux/$*/gke-gcloud-auth-plugin k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
 
+.PHONY: gke-gcloud-auth-plugin-windows-amd64 gke-gcloud-auth-plugin-windows-arm64
 gke-gcloud-auth-plugin-windows-amd64 gke-gcloud-auth-plugin-windows-arm64: gke-gcloud-auth-plugin-windows-%:
 	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/windows/$*
 	CGO_ENABLED=0 GOOS=windows GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/windows/$*/gke-gcloud-auth-plugin.exe k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
 
+.PHONY: gke-gcloud-auth-plugin-darwin-arm64
 gke-gcloud-auth-plugin-darwin-arm64:
 	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/arm64
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/arm64/gke-gcloud-auth-plugin k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
+ 
+.PHONY: copy-binaries-to-gcs
+copy-binaries-to-gcs: build-all ## Build and copy binaries to GCS.
+	gcloud storage cp --recursive release/$(GIT_VERSION) gs://$(BUCKET_NAME)/$(GIT_VERSION)
 
-
-.PHONY: all clean build-all copy-binaries-to-gcs
-
-clean:
-	@echo "Cleaning up..."
-	@find release/ -type d -mindepth 1 -print0 | xargs -0 rm -rf
-
-release-tars:
+.PHONY: release-tars
+release-tars: ## Build release tarballs using bazel.
 	bazel build release:release-tars
 
-copy-binaries-to-gcs: build-all
-	gcloud storage cp --recursive release/$(GIT_VERSION) gs://$(BUCKET_NAME)/$(GIT_VERSION)
+## --------------------------------------
+##@ Test
+## --------------------------------------
+
+.PHONY: test
+test: ## Run unit tests.
+	go test -race ./...
+	go test -race ./providers/...
+
+.PHONY: test-sh
+test-sh: ## Run shell script syntax checks.
+	bash -n cluster/common.sh
+	bash -n cluster/clientbin.sh
+	bash -n cluster/kube-util.sh

--- a/cmd/auth-provider-gcp/BUILD
+++ b/cmd/auth-provider-gcp/BUILD
@@ -18,7 +18,6 @@ go_library(
     importpath = "k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp",
     deps = [
         "//cmd/auth-provider-gcp/app",
-        "//providers/gce/gcpcredential",
         "//vendor/github.com/spf13/cobra",
         "//vendor/github.com/spf13/pflag",
         "//vendor/k8s.io/klog/v2:klog",

--- a/cmd/auth-provider-gcp/main.go
+++ b/cmd/auth-provider-gcp/main.go
@@ -18,17 +18,12 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/cloud-provider-gcp/cmd/auth-provider-gcp/app"
 	klog "k8s.io/klog/v2"
-	"os"
-
-	// bazel test on "k8s.io/cloud-provider-gcp/providers/gce/gcpcredential" run into issues
-	// because it has dependencies on "k8s.io/cloud-provider/credentialconfig" which is not required by "k8s.io/cloud-provider-gcp" hence
-	// it will fail to get the dependency from //vendor directory.
-	// TODO: remove the import after https://github.com/kubernetes/cloud-provider-gcp/issues/211 solved.
-	_ "k8s.io/cloud-provider-gcp/providers/gce/gcpcredential"
 )
 
 func main() {


### PR DESCRIPTION
Replace the functionality of `bazel test` for upcoming removal of Bazel. Runs go test for all modules except test/e2e, and bash test from cluster/BUILD (only non-go test in BUILDs).