### PR TITLE
Copy periodic test-infra tests into scripts

### DIFF
--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# TODO: Use published release tars for cloud-provider-gcp if/once they exist
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
+cd
+export GO111MODULE=on
+if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
+  export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion")
+  echo "BAZEL_VERSION set to ${BAZEL_VERSION}"
+else
+  export BAZEL_VERSION="5.3.0"
+  echo "BAZEL_VERSION - Falling back to 5.3.0"
+fi
+/workspace/test-infra/images/kubekins-e2e/install-bazel.sh
+go install sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
+  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
+else
+  export TEST_PACKAGE_VERSION="v1.25.0"
+  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
+fi
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size e2-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]' --test-args=--enabled-volume-drivers=gcepd

--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# TODO: Use published release tars for cloud-provider-gcp if/once they exist
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
+cd
+export GO111MODULE=on
+if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
+  export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion")
+  echo "BAZEL_VERSION set to ${BAZEL_VERSION}"
+else
+  export BAZEL_VERSION="5.3.0"
+  echo "BAZEL_VERSION - Falling back to 5.3.0"
+fi
+/workspace/test-infra/images/kubekins-e2e/install-bazel.sh
+go install sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
+  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
+else
+  export TEST_PACKAGE_VERSION="v1.25.0"
+  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
+fi
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size e2-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# TODO: Use published release tars for cloud-provider-gcp if/once they exist
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
+cd
+export GO111MODULE=on
+if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
+  export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion")
+  echo "BAZEL_VERSION set to ${BAZEL_VERSION}"
+else
+  export BAZEL_VERSION="5.3.0"
+  echo "BAZEL_VERSION - Falling back to 5.3.0"
+fi
+/workspace/test-infra/images/kubekins-e2e/install-bazel.sh
+go install sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
+  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
+else
+  export TEST_PACKAGE_VERSION="v1.25.0"
+  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
+fi
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --enabled-volume-drivers=gcepd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# TODO: Use published release tars for cloud-provider-gcp if/once they exist
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
+cd
+export GO111MODULE=on
+if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
+  export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion")
+  echo "BAZEL_VERSION set to ${BAZEL_VERSION}"
+else
+  export BAZEL_VERSION="5.3.0"
+  echo "BAZEL_VERSION - Falling back to 5.3.0"
+fi
+/workspace/test-infra/images/kubekins-e2e/install-bazel.sh
+go install sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
+  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
+else
+  export TEST_PACKAGE_VERSION="v1.25.0"
+  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
+fi
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# TODO: Use published release tars for cloud-provider-gcp if/once they exist
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
+cd
+export GO111MODULE=on
+if [[ -f "${REPO_ROOT}/.bazelversion" ]]; then
+  export BAZEL_VERSION=$(cat "${REPO_ROOT}/.bazelversion")
+  echo "BAZEL_VERSION set to ${BAZEL_VERSION}"
+else
+  export BAZEL_VERSION="5.3.0"
+  echo "BAZEL_VERSION - Falling back to 5.3.0"
+fi
+/workspace/test-infra/images/kubekins-e2e/install-bazel.sh
+go install sigs.k8s.io/kubetest2@latest
+go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
+go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
+  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
+  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
+else
+  export TEST_PACKAGE_VERSION="v1.25.0"
+  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
+fi
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-scenario-kops-simple.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-scenario-kops-simple.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+cd $GOPATH/src/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+e2e/scenarios/kops-simple


### PR DESCRIPTION
Analogous to https://github.com/kubernetes/cloud-provider-gcp/pull/917/changes
Test scripts from https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
The config will remain in test-infra and will call these scripts. They will be updated soon to replace bazel with kops.