### PR TITLE
feat: introduce gkops tool and use kops in e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ release/*
 _artifacts/
 _rundir/
 _tmp/
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+LOCAL_BIN := $(PROJECT_DIR)/bin
 
 GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||')
 GIT_COMMIT := $(shell git rev-parse HEAD)
@@ -316,7 +318,8 @@ bump-cluster: ## Bump cluster version.
 
 .PHONY: push-images
 push-images: ## Push images to IMAGE_REPO.
-	./tools/push-images
+	gcloud auth configure-docker
+	IMAGE_REPO=$(IMAGE_REPO) IMAGE_TAG=$(IMAGE_TAG) ./tools/push-images
 
 .PHONY: merge-licenses
 merge-licenses: ## Merge licenses from vendor directory.
@@ -329,3 +332,87 @@ run-e2e-test: ## Run e2e tests.
 .PHONY: verify-up-to-date
 verify-up-to-date: ## Verify that the repository is up to date.
 	./tools/verify-up-to-date.sh
+
+.PHONY: print-k8s-version
+print-k8s-version: ## Print the pinned Kubernetes version.
+	@if [ -f ginko-test-package-version.env ]; then cat ginko-test-package-version.env | tr -d '[:space:]'; else curl -sL https://dl.k8s.io/release/stable.txt; fi
+
+## --------------------------------------
+##@ kOps E2E
+## --------------------------------------
+
+KOPS_CLUSTER_NAME ?= kops-e2e.k8s.local
+GCP_LOCATION ?= us-central1
+GCP_ZONES ?= $(GCP_LOCATION)-b
+IMAGE_REPO ?= gcr.io/$(GCP_PROJECT)
+KOPS_STATE_STORE ?= gs://kops-state-$(GCP_PROJECT)
+IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
+
+.PHONY: kops-simple
+kops-simple: ## Run kOps simple E2E test scenario.
+	./e2e/scenarios/kops-simple
+
+.PHONY: install-kops-deps
+install-kops-deps: ## Install kubetest2 and other dependencies.
+	@echo "Installing kubetest2 and plugins..."
+	@mkdir -p $(LOCAL_BIN)
+	@GOBIN=$(LOCAL_BIN) go install sigs.k8s.io/kubetest2@latest
+	@GOBIN=$(LOCAL_BIN) go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
+	@TEMP_DIR=$$(mktemp -d); \
+	trap 'rm -rf "$$TEMP_DIR"' EXIT; \
+	git clone --depth 1 https://github.com/kubernetes/kops.git "$$TEMP_DIR"; \
+	cd "$$TEMP_DIR/tests/e2e" && GOBIN=$(LOCAL_BIN) go install ./kubetest2-kops ./kubetest2-tester-kops
+	@echo "Downloading latest green kOps binary..."
+	@KOPS_BASE_URL=$$(curl -s https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt); \
+	mkdir -p $(LOCAL_BIN); \
+	wget -qO $(LOCAL_BIN)/kops.tmp $${KOPS_BASE_URL}/linux/amd64/kops; \
+	chmod +x $(LOCAL_BIN)/kops.tmp; \
+	mv $(LOCAL_BIN)/kops.tmp $(LOCAL_BIN)/kops
+
+.PHONY: kops-tool
+kops-tool: $(LOCAL_BIN)/gkops ## Build the kOps lifecycle tool.
+
+$(LOCAL_BIN)/gkops: tools/kops/main.go tools/kops/pkg/kops/*.go
+	@echo "Building kOps lifecycle tool..."
+	mkdir -p $(LOCAL_BIN)
+	go build -o $(LOCAL_BIN)/gkops tools/kops/main.go
+
+.PHONY: kops-setup
+kops-setup: install-kops-deps kops-tool push-images ## Setup environment for kOps E2E.
+
+.PHONY: kops-up
+kops-up: kops-setup ## Provision kOps cluster.
+	PATH=$(LOCAL_BIN):$(PATH) KOPS_STATE_STORE=$(KOPS_STATE_STORE) $(LOCAL_BIN)/gkops up \
+		--cluster-name=$(KOPS_CLUSTER_NAME) \
+		--gcp-project=$(GCP_PROJECT) \
+		--gcp-location=$(GCP_LOCATION) \
+		--gcp-zones=$(GCP_ZONES) \
+		--state-store=$(KOPS_STATE_STORE) \
+		--image-repo=$(IMAGE_REPO) \
+		--image-tag=$(IMAGE_TAG)
+
+.PHONY: kops-down
+kops-down: kops-tool ## Tear down kOps cluster.
+	PATH=$(LOCAL_BIN):$(PATH) KOPS_STATE_STORE=$(KOPS_STATE_STORE) $(LOCAL_BIN)/gkops down \
+		--cluster-name=$(KOPS_CLUSTER_NAME) \
+		--gcp-project=$(GCP_PROJECT) \
+		--state-store=$(KOPS_STATE_STORE)
+
+.PHONY: kops-e2e-test
+kops-e2e-test: kops-tool ## Run E2E tests on kOps cluster.
+	@echo "Running E2E tests on cluster $(KOPS_CLUSTER_NAME)..."
+	PATH=$(LOCAL_BIN):$(PATH) KOPS_STATE_STORE=$(KOPS_STATE_STORE) KOPS_CLUSTER_NAME= CLUSTER_NAME= $(LOCAL_BIN)/kubetest2 kops \
+		-v=2 \
+		--cloud-provider=gce \
+		--cluster-name=$(KOPS_CLUSTER_NAME) \
+		--kops-binary-path=$(LOCAL_BIN)/kops \
+		--gcp-project=$(GCP_PROJECT) \
+		--admin-access=$(ADMIN_ACCESS) \
+		--test=kops \
+		--kubernetes-version=$(K8S_VERSION) \
+		-- \
+		--parallel=30 \
+		--test-package-version="${K8S_VERSION}" \
+		--skip-regex="\[Serial\]" \
+		--focus-regex="\[Conformance\]"
+

--- a/Makefile
+++ b/Makefile
@@ -123,11 +123,6 @@ clean-builder: ## Remove the docker buildx builder.
 	@echo "Removing docker buildx builder..."
 	docker buildx rm multiarch-multiplatform-builder || true
 	@echo "Docker buildx builder removed."
-
-.PHONY: gke-gcloud-auth-plugin-darwin-arm64 gke-gcloud-auth-plugin-darwin-amd64
-gke-gcloud-auth-plugin-darwin-arm64 gke-gcloud-auth-plugin-darwin-amd64: gke-gcloud-auth-plugin-darwin-%:
-	mkdir -p release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/$*
-	CGO_ENABLED=0 GOOS=darwin GOARCH=$* go build $(LDFLAGS) -o release/$(GIT_VERSION)/gke-gcloud-auth-plugin/darwin/$*/gke-gcloud-auth-plugin k8s.io/cloud-provider-gcp/cmd/gke-gcloud-auth-plugin
   
 .PHONY: copy-binaries-to-gcs
 copy-binaries-to-gcs: build-all ## Build and copy binaries to GCS.

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 LOCAL_BIN := $(PROJECT_DIR)/bin
+GCP_PROJECT := $(shell gcloud config get-value project)
 
 GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||')
 GIT_COMMIT := $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 LOCAL_BIN := $(PROJECT_DIR)/bin
-GCP_PROJECT := $(shell gcloud config get-value project)
+GCP_PROJECT ?= $(shell gcloud config get-value project)
 
 GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||')
 GIT_COMMIT := $(shell git rev-parse HEAD)

--- a/deploy/packages/default/manifest.yaml
+++ b/deploy/packages/default/manifest.yaml
@@ -145,6 +145,7 @@ rules:
   resources:
   - endpoints
   - serviceaccounts
+  - services
   verbs:
   - create
   - get
@@ -167,6 +168,7 @@ rules:
   - ""
   resources:
   - nodes/status
+  - services/status
   verbs:
   - patch
   - update

--- a/dev/ci/presubmits/cloud-provider-gcp-tests
+++ b/dev/ci/presubmits/cloud-provider-gcp-tests
@@ -10,8 +10,8 @@ def find_go_modules():
     """Finds all go.mod files in the repository."""
     go_mod_files = []
     for file in glob.glob("**/go.mod", recursive=True):
-        # Ignore matches under vendor
-        if file.startswith("vendor/"):
+        # Ignore matches under vendor and _tmp
+        if file.startswith("vendor/") or file.startswith("_tmp/"):
             continue
         go_mod_files.append(file)
     if os.path.exists("go.mod"):

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -65,18 +65,8 @@ Update the `/cluster` directory if needed. A script under `/cluster` is used to 
 
 ### Testing
 1. Run `make verify`.
-1. Build `cloud-provider-gcp` with command `make clean && make release-tars`.
-1. Bring the cluster up with `kubetest2 gce -v 2 --repo-root $REPO\_ROOT --build --up`
-1. Run conformance tests locally with `kubetest2 gce -v 2 --repo-root $REPO\_ROOT --build --up --down --test=ginkgo -- --test-package-version=[your version] --focus-regex='\[Conformance\]'`
-
-**_Note_**: if kubetest2 not working as expected, try with:
-
-```bash
-go get sigs.k8s.io/kubetest2@latest
-go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
-go get sigs.k8s.io/kubetest2/kubetest2-tester-exec@latest;
-go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-```
+1. Bring the cluster up with `make kops-up`
+1. Run conformance tests locally with `make kops-e2e-test`
 
 ## Create Release Branch
 This is only necessary for CCM releases corresponding to a Kubernetes minor version release. Create a branch from the latest commit on master with the dependency updates mentioned above.

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,203 +14,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-cd ${REPO_ROOT}
-cd ..
-WORKSPACE=$(pwd)
+cd "${REPO_ROOT}"
 
-# Create bindir
-BINDIR=${WORKSPACE}/bin
-export PATH=${BINDIR}:${PATH}
-mkdir -p "${BINDIR}"
+# 1. Project Lifecycle Management (Boskos)
+if [[ -z "${GCP_PROJECT:-}" ]]; then
+    echo "GCP_PROJECT not set, acquiring project from boskos"
+    source test/boskos.sh
+    acquire_project
+    export GCP_PROJECT="${PROJECT}"
+    trap cleanup_boskos EXIT
+else
+    export GCP_PROJECT
+fi
 
-# Setup our cleanup function; as we allocate resources we set a variable to indicate they should be cleaned up
+# 2. Cluster Lifecycle Management
+export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-kops-simple.k8s.local}"
+make kops-up
+
+# 3. Define cleanup function
 function cleanup {
-  if [[ "${CLEANUP_BOSKOS:-}" == "true" ]]; then
-    cleanup_boskos
+  local exit_status=$?
+  if [[ "${DELETE_CLUSTER:-true}" == "true" ]]; then
+    make kops-down
   fi
-  # shellcheck disable=SC2153
-  if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
-      kubetest2 kops ${KUBETEST2_ARGS} --down || echo "kubetest2 down failed"
+  if [[ -n "${BOSKOS_HEARTBEAT_PID:-}" ]]; then
+    source test/boskos.sh
+    cleanup_boskos || echo "Warning: cleanup_boskos failed"
   fi
+  exit "${exit_status}"
 }
 trap cleanup EXIT
 
-# Default cluster name
-SCRIPT_NAME=$(basename $0 .sh)
-if [[ -z "${CLUSTER_NAME:-}" ]]; then
-  CLUSTER_NAME="${SCRIPT_NAME}.k8s.local"
-fi
-echo "CLUSTER_NAME=${CLUSTER_NAME}"
+# 4. Test Execution
+export K8S_VERSION=$(make print-k8s-version)
+make kops-e2e-test KOPS_CLUSTER_NAME="${KOPS_CLUSTER_NAME}"
 
-# Default workdir
-if [[ -z "${WORKDIR:-}" ]]; then
-  WORKDIR="${WORKSPACE}/clusters/${CLUSTER_NAME}"
-fi
-mkdir -p "${WORKDIR}"
-
-# Ensure we have a project; get one from boskos if one not provided in GCP_PROJECT
-source "${REPO_ROOT}"/test/boskos.sh
-if [[ -z "${GCP_PROJECT:-}" ]]; then
-  echo "GCP_PROJECT not set, acquiring project from boskos"
-  acquire_project
-  GCP_PROJECT="${PROJECT}"
-  CLEANUP_BOSKOS="true"
-fi
-echo "GCP_PROJECT=${GCP_PROJECT}"
-
-# Ensure we have an SSH key; needed to dump the node information to artifacts/
-if [[ -z "${SSH_PRIVATE_KEY:-}" ]]; then
-  echo "SSH_PRIVATE_KEY not set, creating one"
-
-  SSH_PRIVATE_KEY="${WORKDIR}/google_compute_engine"
-  gcloud compute --project="${GCP_PROJECT}" config-ssh --ssh-key-file="${SSH_PRIVATE_KEY}"
-  export KUBE_SSH_USER="${USER}"
-fi
-echo "SSH_PRIVATE_KEY=${SSH_PRIVATE_KEY}"
-
-# Build kubetest-2 kOps support
-pushd ${WORKSPACE}/kops
-GOBIN=${BINDIR} make test-e2e-install
-popd
-
-if [[ -z "${K8S_VERSION:-}" ]]; then
-  K8S_VERSION="$(curl -sL https://dl.k8s.io/release/stable.txt)"
-fi
-
-# Download latest prebuilt kOps
-if [[ -z "${KOPS_BASE_URL:-}" ]]; then
-  KOPS_BRANCH="master"
-  KOPS_BASE_URL="$(curl -s https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/${KOPS_BRANCH}/latest-ci-updown-green.txt)"
-fi
-export KOPS_BASE_URL
-
-KOPS_BIN=${BINDIR}/kops
-wget -qO "${KOPS_BIN}" "$KOPS_BASE_URL/$(go env GOOS)/$(go env GOARCH)/kops"
-chmod +x "${KOPS_BIN}"
-
-# Set cloud provider to gce
-CLOUD_PROVIDER="gce"
-echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
-
-#Set cloud provider location
-GCP_LOCATION="${GCP_LOCATION:-us-central1}"
-
-# KOPS_STATE_STORE holds metadata about the clusters we create
-if [[ -z "${KOPS_STATE_STORE:-}" ]]; then
-  KOPS_STATE_STORE="gs://kops-state-${GCP_PROJECT}"
-  # Ensure the bucket exists
-  gsutil ls -p "${GCP_PROJECT}" "${KOPS_STATE_STORE}" || gsutil mb -p "${GCP_PROJECT}" -l "${GCP_LOCATION}" "${KOPS_STATE_STORE}"
-
-  # Setting ubla off so that kOps can automatically set ACLs for the default serviceACcount
-  gsutil ubla set off "${KOPS_STATE_STORE}"
-
-  # Grant storage.admin on the bucket to our ServiceAccount
-  SA=$(gcloud config list --format 'value(core.account)')
-  gsutil iam ch serviceAccount:${SA}:admin "${KOPS_STATE_STORE}"
-fi
-echo "KOPS_STATE_STORE=${KOPS_STATE_STORE}"
-export KOPS_STATE_STORE
-
-# IMAGE_REPO is used to upload images
-if [[ -z "${IMAGE_REPO:-}" ]]; then
-  IMAGE_REPO="gcr.io/${GCP_PROJECT}"
-fi
-echo "IMAGE_REPO=${IMAGE_REPO}"
-
-cd ${REPO_ROOT}
-if [[ -z "${IMAGE_TAG:-}" ]]; then
-  IMAGE_TAG=$(git rev-parse --short HEAD)-$(date +%Y%m%dT%H%M%S)
-fi
-echo "IMAGE_TAG=${IMAGE_TAG}"
-
-# Build and push cloud-controller-manager
-cd ${REPO_ROOT}
-
-export KUBE_ROOT=${REPO_ROOT}
-source "${REPO_ROOT}/tools/version.sh"
-get_version_vars
-unset KUBE_ROOT
-
-echo "git status:"
-git status
-
-echo "Configuring docker auth with gcloud"
-gcloud auth configure-docker
-
-echo "Building and pushing images"
-IMAGE_REPO=${IMAGE_REPO} IMAGE_TAG=${IMAGE_TAG} tools/push-images
-
-if [[ -z "${ADMIN_ACCESS:-}" ]]; then
-  ADMIN_ACCESS="0.0.0.0/0" # Or use your IPv4 with /32
-fi
-echo "ADMIN_ACCESS=${ADMIN_ACCESS}"
-
-# cilium does not yet pass conformance tests (shared hostport test)
-#create_args="--networking cilium"
-create_args="--networking gce"
-if [[ -n "${ZONES:-}" ]]; then
-    create_args="${create_args} --zones=${ZONES}"
-fi
-
-# Workaround for test-infra#24747
-create_args="${create_args} --gce-service-account=default"
-
-# Add our manifest
-cp "${REPO_ROOT}/deploy/packages/default/manifest.yaml" "${WORKDIR}/cloud-provider-gcp.yaml"
-sed -i -e "s@k8scloudprovidergcp/cloud-controller-manager:latest@${IMAGE_REPO}/cloud-controller-manager:${IMAGE_TAG}@g" "${WORKDIR}/cloud-provider-gcp.yaml"
-create_args="${create_args} --add=${WORKDIR}/cloud-provider-gcp.yaml"
-
-# Enable cluster addons, this enables us to replace the built-in manifest
-KOPS_FEATURE_FLAGS="ClusterAddons,${KOPS_FEATURE_FLAGS:-}"
-echo "KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
-
-# Note that these arguments for kubetest2 and kOps, not (for example) the arguments passed to the cloud-provider-gcp
-KUBETEST2_ARGS=""
-KUBETEST2_ARGS="${KUBETEST2_ARGS} -v=2 --cloud-provider=${CLOUD_PROVIDER}"
-KUBETEST2_ARGS="${KUBETEST2_ARGS} --cluster-name=${CLUSTER_NAME:-}"
-KUBETEST2_ARGS="${KUBETEST2_ARGS} --kops-binary-path=${KOPS_BIN}"
-KUBETEST2_ARGS="${KUBETEST2_ARGS} --admin-access=${ADMIN_ACCESS:-}"
-KUBETEST2_ARGS="${KUBETEST2_ARGS} --env=KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS}"
-
-if [[ -n "${GCP_PROJECT:-}" ]]; then
-  KUBETEST2_ARGS="${KUBETEST2_ARGS} --gcp-project=${GCP_PROJECT}"
-fi
-
-if [[ -n "${SSH_PRIVATE_KEY:-}" ]]; then
-  KUBETEST2_ARGS="${KUBETEST2_ARGS} --ssh-private-key=${SSH_PRIVATE_KEY}"
-fi
-
-# Pass through GOOGLE_APPLICATION_CREDENTIALS (we should probably do this automatically in kubetest2-kops)
-if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-  KUBETEST2_ARGS="${KUBETEST2_ARGS} --env=GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
-fi
-
-# The caller can set DELETE_CLUSTER=false to stop us deleting the cluster
-if [[ -z "${DELETE_CLUSTER:-}" ]]; then
-  DELETE_CLUSTER="true"
-fi
-
-kubetest2 kops ${KUBETEST2_ARGS} \
-  --up \
-  --kubernetes-version="${K8S_VERSION}" \
-  --create-args="${create_args}" \
-  --control-plane-size="${KOPS_CONTROL_PLANE_SIZE:-1}" \
-  --template-path="${KOPS_TEMPLATE:-}"
-
-kubetest2 kops ${KUBETEST2_ARGS} \
-  --test=kops \
-  --kubernetes-version="${K8S_VERSION}" \
-  -- \
-  --test-package-version="${K8S_VERSION}" \
-  --parallel=30 \
-  --skip-regex="\[Serial\]" \
-  --focus-regex="\[Conformance\]"
-
-if [[ "${DELETE_CLUSTER:-}" == "true" ]]; then
-  kubetest2 kops ${KUBETEST2_ARGS} --down
-  DELETE_CLUSTER=false # Don't delete again in trap
+# 5. Teardown
+if [[ "${DELETE_CLUSTER:-true}" == "true" ]]; then
+  make kops-down
+  DELETE_CLUSTER=false # Prevent redundant deletion in trap
 fi

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -54,7 +54,7 @@ function cleanup {
 trap cleanup EXIT
 
 # 4. Test Execution
-export K8S_VERSION=$(make print-k8s-version)
+export K8S_VERSION=$(make --silent print-k8s-version)
 make kops-e2e-test KOPS_CLUSTER_NAME="${KOPS_CLUSTER_NAME}"
 
 # 5. Teardown

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -32,6 +32,7 @@ if [[ -z "${GCP_PROJECT:-}" ]]; then
 else
     export GCP_PROJECT
 fi
+export IMAGE_REPO="gcr.io/${GCP_PROJECT}"
 
 # 2. Cluster Lifecycle Management
 export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-kops-simple.k8s.local}"

--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -33,6 +33,7 @@ else
     export GCP_PROJECT
 fi
 export IMAGE_REPO="gcr.io/${GCP_PROJECT}"
+export KOPS_STATE_STORE="gs://kops-state-${GCP_PROJECT}"
 
 # 2. Cluster Lifecycle Management
 export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-kops-simple.k8s.local}"

--- a/tools/kops/main.go
+++ b/tools/kops/main.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cloud-provider-gcp/tools/kops/pkg/kops"
+)
+
+var (
+	config *kops.Config
+)
+
+func main() {
+	var err error
+	config, err = kops.NewConfigFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
+		os.Exit(1)
+	}
+
+	rootCmd := &cobra.Command{
+		Use:   "kops",
+		Short: "kOps cluster lifecycle management tool",
+	}
+
+	// Define flags for all config fields
+	rootCmd.PersistentFlags().StringVar(&config.ClusterName, "cluster-name", config.ClusterName, "The name of the cluster")
+	rootCmd.PersistentFlags().StringVar(&config.GCPProject, "gcp-project", config.GCPProject, "The GCP project")
+	rootCmd.PersistentFlags().StringVar(&config.GCPLocation, "gcp-location", config.GCPLocation, "The GCP location (region)")
+	rootCmd.PersistentFlags().StringVar(&config.GCPZones, "gcp-zones", config.GCPZones, "The GCP zones (comma separated)")
+	rootCmd.PersistentFlags().StringVar(&config.StateStore, "state-store", config.StateStore, "The kOps state store (GCS bucket)")
+	rootCmd.PersistentFlags().StringVar(&config.KopsBin, "kops-binary-path", config.KopsBin, "Path to kops binary")
+	rootCmd.PersistentFlags().StringVar(&config.KopsBaseURL, "kops-base-url", config.KopsBaseURL, "The kOps base URL for CI artifacts")
+	rootCmd.PersistentFlags().StringVar(&config.K8sVersion, "kubernetes-version", config.K8sVersion, "Kubernetes version")
+	rootCmd.PersistentFlags().StringVar(&config.TemplateSrc, "template-src", config.TemplateSrc, "Path to kOps cluster template source")
+	rootCmd.PersistentFlags().StringVar(&config.TemplatePath, "template-path", config.TemplatePath, "Path where hydrated template will be saved")
+	rootCmd.PersistentFlags().StringVar(&config.AdminAccess, "admin-access", config.AdminAccess, "Admin access CIDR")
+	rootCmd.PersistentFlags().StringVar(&config.ControlPlaneMachineType, "control-plane-machine-type", config.ControlPlaneMachineType, "Control plane machine type")
+	rootCmd.PersistentFlags().StringVar(&config.NodeMachineType, "node-machine-type", config.NodeMachineType, "Node machine type")
+	rootCmd.PersistentFlags().IntVar(&config.NodeCount, "node-count", config.NodeCount, "Number of nodes")
+	rootCmd.PersistentFlags().StringVar(&config.SSHPrivateKey, "ssh-private-key", config.SSHPrivateKey, "Path to SSH private key")
+	rootCmd.PersistentFlags().StringVar(&config.NewCCMSpec, "new-ccm-spec", config.NewCCMSpec, "New CCM spec for template hydration")
+	rootCmd.PersistentFlags().StringVar(&config.ImageRepo, "image-repo", config.ImageRepo, "Image repository for local CCM injection")
+	rootCmd.PersistentFlags().StringVar(&config.ImageTag, "image-tag", config.ImageTag, "Image tag for local CCM injection")
+	rootCmd.PersistentFlags().DurationVar(&config.ValidationWait, "validation-wait", config.ValidationWait, "Time to wait for cluster validation")
+
+	// Root command logic
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return cmd.Help()
+	}
+
+	upCmd := &cobra.Command{
+		Use:   "up",
+		Short: "Provision the kOps cluster",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return kops.UpdateConfigFromFlags(config)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := kops.HydrateTemplate(config); err != nil {
+				return err
+			}
+			return kops.Up(config)
+		},
+	}
+
+	downCmd := &cobra.Command{
+		Use:   "down",
+		Short: "Tear down the kOps cluster",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return kops.UpdateConfigFromFlags(config)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return kops.Down(config)
+		},
+	}
+
+	prepareCmd := &cobra.Command{
+		Use:   "prepare",
+		Short: "Prepare the kOps cluster (hydrate template and ensure state store)",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return kops.UpdateConfigFromFlags(config)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := kops.HydrateTemplate(config); err != nil {
+				return err
+			}
+			return kops.EnsureStateStore(config)
+		},
+	}
+
+	rootCmd.AddCommand(upCmd, downCmd, prepareCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tools/kops/pkg/kops/config.go
+++ b/tools/kops/pkg/kops/config.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config holds all parameters for kOps cluster lifecycle.
+type Config struct {
+	ClusterName             string
+	GCPProject              string
+	GCPLocation             string
+	GCPZones                string
+	K8sVersion              string
+	KopsBin                 string
+	KopsBaseURL             string
+	StateStore              string
+	TemplateSrc             string
+	TemplatePath            string
+	AdminAccess             string
+	ControlPlaneMachineType string
+	NodeMachineType         string
+	NodeCount               int
+	SSHPrivateKey           string
+	SSHPublicKey            string // Derived internally
+	KopsFeatureFlags        string
+	GoogleAppCredentials    string
+	NewCCMSpec              string
+	ImageRepo               string
+	ImageTag                string
+	ValidationWait          time.Duration
+}
+
+// NewConfigFromEnv initializes Config with values from environment variables.
+func NewConfigFromEnv() (*Config, error) {
+	c := &Config{
+		ClusterName:             os.Getenv("CLUSTER_NAME"),
+		GCPProject:              os.Getenv("GCP_PROJECT"),
+		GCPLocation:             os.Getenv("GCP_LOCATION"),
+		GCPZones:                os.Getenv("GCP_ZONES"),
+		K8sVersion:              os.Getenv("K8S_VERSION"),
+		KopsBin:                 os.Getenv("KOPS_BIN"),
+		KopsBaseURL:             os.Getenv("KOPS_BASE_URL"),
+		StateStore:              os.Getenv("KOPS_STATE_STORE"),
+		TemplateSrc:             os.Getenv("KOPS_TEMPLATE_SRC"),
+		TemplatePath:            os.Getenv("KOPS_TEMPLATE"),
+		AdminAccess:             os.Getenv("ADMIN_ACCESS"),
+		ControlPlaneMachineType: os.Getenv("CONTROL_PLANE_MACHINE_TYPE"),
+		NodeMachineType:         os.Getenv("NODE_MACHINE_TYPE"),
+		SSHPrivateKey:           os.Getenv("SSH_PRIVATE_KEY"),
+		KopsFeatureFlags:        os.Getenv("KOPS_FEATURE_FLAGS"),
+		GoogleAppCredentials:    os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"),
+		NewCCMSpec:              os.Getenv("NEW_CCM_SPEC"),
+		ImageRepo:               os.Getenv("IMAGE_REPO"),
+		ImageTag:                os.Getenv("IMAGE_TAG"),
+	}
+
+	if nodeCountStr := os.Getenv("NODE_COUNT"); nodeCountStr != "" {
+		c.NodeCount, _ = strconv.Atoi(nodeCountStr)
+	}
+
+	if valWaitStr := os.Getenv("VALIDATION_WAIT"); valWaitStr != "" {
+		c.ValidationWait, _ = time.ParseDuration(valWaitStr)
+	}
+
+	if err := c.Finalize(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Finalize ensures all config fields have valid defaults and derived paths.
+func (c *Config) Finalize() error {
+	repoRoot, err := repoRoot()
+	if err != nil {
+		return err
+	}
+	workspace := repoRoot
+
+	if c.ClusterName == "" {
+		c.ClusterName = "kops.k8s.local"
+	}
+
+	workDir := filepath.Join(workspace, "clusters", c.ClusterName)
+
+	if c.GCPLocation == "" {
+		c.GCPLocation = "us-central1"
+	}
+	if c.GCPZones == "" {
+		c.GCPZones = fmt.Sprintf("%s-b", c.GCPLocation)
+	}
+
+	if c.NodeCount <= 0 {
+		c.NodeCount = 2
+	}
+
+	if c.K8sVersion == "" {
+		if v, err := versionFromFile(repoRoot); err == nil {
+			c.K8sVersion = v
+		} else if v, err := latestK8sVersion(); err == nil {
+			c.K8sVersion = v
+		}
+	}
+
+	if c.KopsBin == "" {
+		c.KopsBin = filepath.Join(workspace, "bin", "kops")
+	}
+
+	if c.KopsBaseURL == "" {
+		if v, err := latestKopsVersion(); err == nil {
+			c.KopsBaseURL = v
+		}
+	}
+
+	if c.TemplateSrc == "" {
+		c.TemplateSrc = filepath.Join(repoRoot, "test", "kops-cluster.yaml.template")
+	}
+
+	if c.TemplatePath == "" {
+		c.TemplatePath = filepath.Join(workDir, "kops-cluster.yaml")
+	}
+
+	if c.AdminAccess == "" {
+		c.AdminAccess = "0.0.0.0/0"
+	}
+
+	if c.ControlPlaneMachineType == "" {
+		c.ControlPlaneMachineType = "e2-standard-2"
+	}
+
+	if c.NodeMachineType == "" {
+		c.NodeMachineType = "e2-standard-2"
+	}
+
+	if c.SSHPrivateKey == "" {
+		c.SSHPrivateKey = filepath.Join(workDir, "google_compute_engine")
+	}
+	c.SSHPublicKey = c.SSHPrivateKey + ".pub"
+
+	if c.ValidationWait <= 0 {
+		c.ValidationWait = 20 * time.Minute
+	}
+
+	return nil
+}
+
+// UpdateConfigFromFlags is now a thin wrapper around Finalize.
+func UpdateConfigFromFlags(c *Config) error {
+	return c.Finalize()
+}
+
+func repoRoot() (string, error) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(pwd, ".git")); err == nil {
+			return pwd, nil
+		}
+		parent := filepath.Dir(pwd)
+		if parent == pwd {
+			return "", fmt.Errorf("could not find repo root")
+		}
+		pwd = parent
+	}
+}
+
+func versionFromFile(repoRoot string) (string, error) {
+	path := filepath.Join(repoRoot, "ginko-test-package-version.env")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func latestK8sVersion() (string, error) {
+	return versionFromURL("https://dl.k8s.io/release/stable.txt")
+}
+
+func latestKopsVersion() (string, error) {
+	return versionFromURL("https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt")
+}
+
+func versionFromURL(url string) (string, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(body)), nil
+}

--- a/tools/kops/pkg/kops/default_template.go
+++ b/tools/kops/pkg/kops/default_template.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+const defaultTemplate = `apiVersion: kops.k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: {{ .clusterName }}
+spec:
+  api:
+    loadBalancer:
+      type: Public
+  authorization:
+    rbac: {}
+  channel: stable
+  cloudConfig:
+    gceServiceAccount: default
+  cloudLabels:
+    group: sig-cluster-lifecycle
+    subproject: kops
+  cloudProvider: gce
+  configBase: {{ .stateStore }}/{{ .clusterName }}
+  containerd:
+    configAdditions:
+      plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler.runtime_type: io.containerd.runc.v2
+  etcdClusters:
+  - cpuRequest: 200m
+    etcdMembers:
+{{- range $i, $zone := (splitList "," "${GCP_ZONES}") }}
+    - instanceGroup: control-plane-{{ $zone }}
+      name: {{ index (splitList "-" $zone) 2 }}
+{{- end }}
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
+    name: main
+  - cpuRequest: 100m
+    etcdMembers:
+{{- range $i, $zone := (splitList "," "${GCP_ZONES}") }}
+    - instanceGroup: control-plane-{{ $zone }}
+      name: {{ index (splitList "-" $zone) 2 }}
+{{- end }}
+    manager:
+      backupRetentionDays: 90
+    memoryRequest: 100Mi
+    name: events
+  iam:
+    allowContainerRegistry: true
+    legacy: false
+  kubelet:
+    anonymousAuth: false
+  kubernetesApiAccess:
+  - 0.0.0.0/0
+  kubernetesVersion: ${K8S_VERSION}
+  networking:
+    gce: {}
+  nodePortAccess:
+  - 0.0.0.0/0
+  nonMasqueradeCIDR: 10.0.0.0/8
+  podCIDR: 10.4.0.0/14
+  project: ${GCP_PROJECT}
+  serviceClusterIPRange: 10.1.0.0/16
+  sshAccess:
+  - 0.0.0.0/0
+  subnets:
+  - cidr: 10.0.32.0/19
+    name: ${GCP_LOCATION}
+    region: ${GCP_LOCATION}
+    type: Public
+  topology:
+    dns:
+      type: None
+  externalCloudControllerManager:
+    useServiceAccountCredentials: false
+---
+apiVersion: kops.k8s.io/v1alpha2
+kind: SSHCredential
+metadata:
+  name: admin
+  labels:
+    kops.k8s.io/cluster: {{ .clusterName }}
+spec:
+  publicKey: {{ .sshPublicKey }}
+{{- range $i, $zone := (splitList "," "${GCP_ZONES}") }}
+---
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: {{ $.clusterName }}
+  name: control-plane-{{ $zone }}
+spec:
+  machineType: ${CONTROL_PLANE_MACHINE_TYPE}
+  role: Master
+  subnets:
+  - ${GCP_LOCATION}
+  zones:
+  - {{ $zone }}
+{{- end }}
+---
+apiVersion: kops.k8s.io/v1alpha2
+kind: InstanceGroup
+metadata:
+  labels:
+    kops.k8s.io/cluster: {{ .clusterName }}
+  name: nodes-{{ (index (splitList "," "${GCP_ZONES}") 0) }}
+spec:
+  machineType: ${NODE_MACHINE_TYPE}
+  minSize: ${NODE_COUNT}
+  maxSize: ${NODE_COUNT}
+  role: Node
+  subnets:
+  - ${GCP_LOCATION}
+  zones:
+{{- range $i, $zone := (splitList "," "${GCP_ZONES}") }}
+  - {{ $zone }}
+{{- end }}
+`

--- a/tools/kops/pkg/kops/gcp.go
+++ b/tools/kops/pkg/kops/gcp.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// EnsureStateStore ensures the GCS bucket for kOps state exists and has correct settings.
+func EnsureStateStore(c *Config) error {
+	if c.StateStore == "" {
+		if c.GCPProject == "" {
+			return fmt.Errorf("GCP_PROJECT must be set if KOPS_STATE_STORE is not provided")
+		}
+		c.StateStore = fmt.Sprintf("gs://kops-state-%s", c.GCPProject)
+	}
+
+	fmt.Printf("Ensuring KOPS_STATE_STORE exists: %s\n", c.StateStore)
+
+	// Check if bucket exists
+	lsCmd := exec.Command("gsutil", "ls", "-p", c.GCPProject, c.StateStore)
+	if err := lsCmd.Run(); err != nil {
+		// Assume it doesn't exist, try to create it
+		fmt.Printf("Bucket %s does not exist, creating...\n", c.StateStore)
+		mbCmd := exec.Command("gsutil", "mb", "-p", c.GCPProject, "-l", c.GCPLocation, c.StateStore)
+		mbCmd.Stdout = os.Stdout
+		mbCmd.Stderr = os.Stderr
+		if err := mbCmd.Run(); err != nil {
+			return fmt.Errorf("failed to create bucket: %v", err)
+		}
+	}
+
+	// Disable uniform bucket-level access
+	ublaCmd := exec.Command("gsutil", "ubla", "set", "off", c.StateStore)
+	ublaCmd.Stdout = os.Stdout
+	ublaCmd.Stderr = os.Stderr
+	if err := ublaCmd.Run(); err != nil {
+		return fmt.Errorf("failed to disable UBLA: %v", err)
+	}
+
+	// Grant storage.admin to the current account
+	// SA=$(gcloud config list --format 'value(core.account)')
+	saCmd := exec.Command("gcloud", "config", "list", "--format", "value(core.account)")
+	saBytes, err := saCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get current account: %v", err)
+	}
+	sa := strings.TrimSpace(string(saBytes))
+
+	iamCmd := exec.Command("gsutil", "iam", "ch", fmt.Sprintf("serviceAccount:%s:admin", sa), c.StateStore)
+	iamCmd.Stdout = os.Stdout
+	iamCmd.Stderr = os.Stderr
+	if err := iamCmd.Run(); err != nil {
+		// This might fail if the account is not a service account (e.g. user account)
+		// The bash script assumes serviceAccount:
+		fmt.Printf("Warning: failed to grant storage.admin to %s: %v. Retrying with user account...\n", sa, err)
+		iamUserCmd := exec.Command("gsutil", "iam", "ch", fmt.Sprintf("user:%s:admin", sa), c.StateStore)
+		iamUserCmd.Stdout = os.Stdout
+		iamUserCmd.Stderr = os.Stderr
+		if err := iamUserCmd.Run(); err != nil {
+			fmt.Printf("Warning: failed to grant storage.admin to user %s: %v\n", sa, err)
+		}
+	}
+
+	return nil
+}
+
+// EnsureSSHKey ensures that an SSH key exists for kOps.
+func EnsureSSHKey(c *Config) error {
+	if c.SSHPrivateKey == "" {
+		return fmt.Errorf("SSHPrivateKey must be set in config")
+	}
+
+	if _, err := os.Stat(c.SSHPrivateKey); err == nil {
+		fmt.Printf("SSH key already exists at %s\n", c.SSHPrivateKey)
+		return nil
+	}
+
+	fmt.Printf("SSH key %s not found, creating one...\n", c.SSHPrivateKey)
+	// gcloud compute --project="${GCP_PROJECT}" config-ssh --ssh-key-file="${SSH_PRIVATE_KEY}"
+	cmd := exec.Command("gcloud", "compute", "--project="+c.GCPProject, "config-ssh", "--ssh-key-file="+c.SSHPrivateKey)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create SSH key: %v", err)
+	}
+
+	return nil
+}

--- a/tools/kops/pkg/kops/kops_test.go
+++ b/tools/kops/pkg/kops/kops_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kops
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHydrateTemplate(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "kops-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	templateSrc := filepath.Join(tmpDir, "template.yaml")
+	templateContent := `
+project: ${GCP_PROJECT}
+location: ${GCP_LOCATION}
+zones: ${GCP_ZONES}
+nodes: ${NODE_COUNT}
+kops: {{ .clusterName }}
+`
+	if err := os.WriteFile(templateSrc, []byte(templateContent), 0644); err != nil {
+		t.Fatalf("failed to write template source: %v", err)
+	}
+
+	config := &Config{
+		GCPProject:   "test-project",
+		GCPLocation:  "test-location",
+		GCPZones:     "test-zone-1,test-zone-2",
+		NodeCount:    3,
+		TemplateSrc:  templateSrc,
+		TemplatePath: filepath.Join(tmpDir, "hydrated.yaml"),
+	}
+
+	if err := HydrateTemplate(config); err != nil {
+		t.Fatalf("HydrateTemplate failed: %v", err)
+	}
+
+	hydratedContent, err := os.ReadFile(config.TemplatePath)
+	if err != nil {
+		t.Fatalf("failed to read hydrated template: %v", err)
+	}
+
+	expected := `
+project: test-project
+location: test-location
+zones: test-zone-1,test-zone-2
+nodes: 3
+kops: {{ .clusterName }}
+`
+	if string(hydratedContent) != expected {
+		t.Errorf("Hydrated content mismatch.\nExpected: %s\nGot: %s", expected, string(hydratedContent))
+	}
+}
+
+func TestConfigFinalize(t *testing.T) {
+	// We assume we are running from the repo
+	repo, err := repoRoot()
+	if err != nil {
+		t.Fatalf("failed to find repo root: %v", err)
+	}
+	workspace := repo
+
+	c := &Config{
+		ClusterName: "custom.k8s.local",
+	}
+
+	if err := c.Finalize(); err != nil {
+		t.Fatalf("Finalize failed: %v", err)
+	}
+
+	// Verify defaults
+	if c.GCPLocation != "us-central1" {
+		t.Errorf("expected GCPLocation us-central1, got %s", c.GCPLocation)
+	}
+	if c.NodeCount != 2 {
+		t.Errorf("expected NodeCount 2, got %d", c.NodeCount)
+	}
+
+	// Verify derived paths
+	expectedWorkDir := filepath.Join(workspace, "clusters", "custom.k8s.local")
+	if !strings.Contains(c.TemplatePath, expectedWorkDir) {
+		t.Errorf("expected TemplatePath to contain %s, got %s", expectedWorkDir, c.TemplatePath)
+	}
+	if !strings.Contains(c.SSHPrivateKey, expectedWorkDir) {
+		t.Errorf("expected SSHPrivateKey to contain %s, got %s", expectedWorkDir, c.SSHPrivateKey)
+	}
+	if c.SSHPublicKey != c.SSHPrivateKey+".pub" {
+		t.Errorf("expected SSHPublicKey to be SSHPrivateKey + .pub, got %s", c.SSHPublicKey)
+	}
+}

--- a/tools/kops/pkg/kops/lifecycle.go
+++ b/tools/kops/pkg/kops/lifecycle.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Up provisions the cluster.
+func Up(c *Config) error {
+	if err := EnsureStateStore(c); err != nil {
+		return err
+	}
+	if err := EnsureSSHKey(c); err != nil {
+		return err
+	}
+
+	args := commonArgs(c)
+
+	// Inject local CCM image if requested
+	featureFlags := c.KopsFeatureFlags
+	if c.ImageRepo != "" && c.ImageTag != "" {
+		manifestPath, err := prepareLocalCCMManifest(c)
+		if err != nil {
+			return err
+		}
+
+		args = append(args, "--create-args=--add="+manifestPath)
+
+		// Enable ClusterAddons feature flag
+		if featureFlags == "" {
+			featureFlags = "ClusterAddons"
+		} else if !strings.Contains(featureFlags, "ClusterAddons") {
+			featureFlags += ",ClusterAddons"
+		}
+	}
+
+	args = append(args, "--env=KOPS_FEATURE_FLAGS="+featureFlags)
+	args = append(args, "--up")
+	args = append(args, "--template-path="+c.TemplatePath)
+	if c.K8sVersion != "" {
+		args = append(args, "--kubernetes-version="+c.K8sVersion)
+	}
+
+	return runKubetest2(c, args)
+}
+
+// Down tears down the cluster.
+func Down(c *Config) error {
+	args := commonArgs(c)
+	args = append(args, "--down")
+	return runKubetest2(c, args)
+}
+
+func commonArgs(c *Config) []string {
+	args := []string{
+		"kops",
+		"-v=2",
+		"--cloud-provider=gce",
+		"--cluster-name=" + c.ClusterName,
+		"--kops-binary-path=" + c.KopsBin,
+		"--admin-access=" + c.AdminAccess,
+		"--validation-wait=" + c.ValidationWait.String(),
+	}
+
+	if c.GCPProject != "" {
+		args = append(args, "--gcp-project="+c.GCPProject)
+	}
+
+	if c.SSHPrivateKey != "" {
+		args = append(args, "--ssh-private-key="+c.SSHPrivateKey)
+		args = append(args, "--ssh-public-key="+c.SSHPublicKey)
+		sshUser := os.Getenv("KUBE_SSH_USER")
+		if sshUser == "" {
+			sshUser = os.Getenv("USER")
+		}
+		if sshUser != "" {
+			args = append(args, "--ssh-user="+sshUser)
+		}
+	}
+
+	if c.GoogleAppCredentials != "" {
+		args = append(args, "--env=GOOGLE_APPLICATION_CREDENTIALS="+c.GoogleAppCredentials)
+	}
+
+	return args
+}
+
+func runKubetest2(c *Config, args []string) error {
+	fmt.Printf("Running kubetest2 %s\n", strings.Join(args, " "))
+	cmd := exec.Command("kubetest2", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Create a clean environment based on current process
+	env := os.Environ()
+	newEnv := []string{}
+	for _, e := range env {
+		// Filter out KOPS_CLUSTER_NAME and CLUSTER_NAME to prevent ambiguity
+		if !strings.HasPrefix(e, "KOPS_CLUSTER_NAME=") && !strings.HasPrefix(e, "CLUSTER_NAME=") && !strings.HasPrefix(e, "PATH=") {
+			newEnv = append(newEnv, e)
+		}
+	}
+
+	// Add local bin to PATH so kubetest2 can find its plugins
+	repoRoot, _ := repoRoot()
+	localBin := filepath.Join(repoRoot, "bin")
+	path := os.Getenv("PATH")
+	newEnv = append(newEnv, fmt.Sprintf("PATH=%s:%s", localBin, path))
+
+	cmd.Env = newEnv
+
+	// Ensure critical variables are in the environment for the subprocess
+	setEnvIfNotEmpty(cmd, "KOPS_STATE_STORE", c.StateStore)
+	setEnvIfNotEmpty(cmd, "GCP_PROJECT", c.GCPProject)
+	setEnvIfNotEmpty(cmd, "K8S_VERSION", c.K8sVersion)
+	setEnvIfNotEmpty(cmd, "KOPS_BASE_URL", c.KopsBaseURL)
+
+	return cmd.Run()
+}
+
+func prepareLocalCCMManifest(c *Config) (string, error) {
+	repoRoot, err := repoRoot()
+	if err != nil {
+		return "", err
+	}
+	manifestSrc := filepath.Join(repoRoot, "deploy/packages/default/manifest.yaml")
+	data, err := os.ReadFile(manifestSrc)
+	if err != nil {
+		return "", fmt.Errorf("failed to read CCM manifest: %v", err)
+	}
+
+	localImage := fmt.Sprintf("%s/cloud-controller-manager:%s", c.ImageRepo, c.ImageTag)
+	replaced := strings.ReplaceAll(string(data), "k8scloudprovidergcp/cloud-controller-manager:latest", localImage)
+
+	// Save temporary manifest in the cluster workdir
+	manifestPath := filepath.Join(filepath.Dir(c.TemplatePath), "cloud-provider-gcp.yaml")
+	if err := os.WriteFile(manifestPath, []byte(replaced), 0644); err != nil {
+		return "", fmt.Errorf("failed to write local CCM manifest: %v", err)
+	}
+
+	return manifestPath, nil
+}
+
+func setEnvIfNotEmpty(cmd *exec.Cmd, key, value string) {
+	if value != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
+	}
+}

--- a/tools/kops/pkg/kops/template.go
+++ b/tools/kops/pkg/kops/template.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kops
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// HydrateTemplate reads the template file and performs variable substitution.
+func HydrateTemplate(c *Config) error {
+	var content []byte
+	var err error
+
+	if c.TemplateSrc != "" {
+		content, err = os.ReadFile(c.TemplateSrc)
+		if err != nil {
+			fmt.Printf("Warning: failed to read template source %s: %v. Using default template.\n", c.TemplateSrc, err)
+			content = []byte(defaultTemplate)
+		}
+	} else {
+		content = []byte(defaultTemplate)
+	}
+
+	// ONLY variables that were hydrated by envsubst in the original bash script.
+	// This ensures that kOps-internal placeholders (like {{ .clusterName }}) are preserved.
+	vars := map[string]string{
+		"K8S_VERSION":                c.K8sVersion,
+		"GCP_PROJECT":                c.GCPProject,
+		"GCP_LOCATION":               c.GCPLocation,
+		"GCP_ZONES":                  c.GCPZones,
+		"CONTROL_PLANE_MACHINE_TYPE": c.ControlPlaneMachineType,
+		"NODE_MACHINE_TYPE":          c.NodeMachineType,
+		"NODE_COUNT":                 strconv.Itoa(c.NodeCount),
+		"NEW_CCM_SPEC":               c.NewCCMSpec,
+	}
+
+	hydrated := os.Expand(string(content), func(name string) string {
+		if val, ok := vars[name]; ok {
+			return val
+		}
+		// If not in our specific list, return the original string (e.g. $GOPATH)
+		return "$" + name
+	})
+
+	// Ensure workdir exists
+	if err := os.MkdirAll(filepath.Dir(c.TemplatePath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for hydrated template: %v", err)
+	}
+
+	if err := os.WriteFile(c.TemplatePath, []byte(hydrated), 0644); err != nil {
+		return fmt.Errorf("failed to write hydrated template: %v", err)
+	}
+
+	fmt.Printf("Hydrated template written to %s\n", c.TemplatePath)
+	return nil
+}

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2024 The Kubernetes Authors.
+# Copyright 2026 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,119 +15,79 @@
 # limitations under the License.
 
 # Runs the e2e tests.
-#  Can be run in two modes: 1) command-line, and 2) prow CI.
-#  - Builds the e2e test binary (i.e. "test/e2e/e2e.test").
-#  - Packages e2e test binary with "ginkgo" and "kubectl" binaries.
-#  - Starts a cluster with kubetest2, using the "gce" deployer.
-#    - Cluster started in either passed cluster (GCP_CLUSTER env var),
-#      or "boskos" cluster in prow CI.
-#    - Cluster version is latest stable version.
+#  - Starts a cluster with the "kops" tool via Makefile.
 #  - Runs the e2e test binary against the cluster using the "ginkgo" tester.
-
-# Parameter:
-#   GCP_PROJECT - if running from command line, this env var needs
-#     to be set to a project the user has credentials for.
-#   GCP_ZONE - an optional env var (e.g. us-central1-c) for zone.
-#   Requires both regular and application default credentials if
-#     running from the command line.
-#     - gcloud auth login
-#     - glcoud auth application-default login
-#
 
 set -o errexit
 set -o pipefail
+set -o xtrace
 
 # Find the top-level directory.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "${REPO_ROOT}"
 
-# Import the boskos code.
-source ${REPO_ROOT}/test/boskos.sh
+# 1. Project Lifecycle Management (Boskos)
+if [[ -z "${GCP_PROJECT:-}" ]]; then
+    echo "GCP_PROJECT not set, acquiring project from boskos"
+    source test/boskos.sh
+    acquire_project
+    export GCP_PROJECT="${PROJECT}"
+    CLEANUP_BOSKOS="true"
+fi
 
-# Parameters
-#
-# The cluster will run the latest stable released k8s binaries.
-VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-VERBOSITY=2
-DEFAULT_GCP_ZONE="us-central1-b"
+# 2. Cluster Lifecycle Management
+export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-run-e2e-test.k8s.local}"
+make kops-up
+
+# Define cleanup function
+function cleanup {
+  local exit_status=$?
+  if [[ "${DELETE_CLUSTER:-true}" == "true" ]]; then
+    make kops-down || echo "Warning: kops-down failed"
+  fi
+  if [[ "${CLEANUP_BOSKOS:-}" == "true" ]]; then
+    source test/boskos.sh
+    cleanup_boskos || echo "Warning: cleanup_boskos failed"
+  fi
+  exit "${exit_status}"
+}
+trap cleanup EXIT
+
+# 3. Test Setup
+export K8S_VERSION=$(make print-k8s-version)
+export KOPS_BIN="${REPO_ROOT}/bin/kops"
+export SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-$(pwd)/../clusters/${KOPS_CLUSTER_NAME}/google_compute_engine}"
+export KUBE_SSH_USER="${KUBE_SSH_USER:-${USER}}"
+export GCP_LOCATION="${GCP_LOCATION:-us-central1}"
+export GCP_ZONES="${GCP_ZONES:-${GCP_LOCATION}-b}"
+
 # run-id is set to milliseconds since the unix epoch.
 RUN_ID="$(date +%s%N | cut -b1-13)"
 RUN_DIR="${REPO_ROOT}/_rundir/${RUN_ID}"
-# Ensure GOPATH/GOBIN are set.
-if [[ ! -v GOPATH ]]; then
-    GOPATH="${HOME}/go"
-fi
-if [[ ! -v GOBIN ]]; then
-    GOBIN="${GOPATH}/bin"
-fi
+LOCAL_BIN="${REPO_ROOT}/bin"
 
-# Trap interrupt, error, and exit to cleanup.
-cleanup() {
-    # The PROJECT env var is set when acquiring a boskos project.
-    if [[ -v PROJECT ]]; then
-	echo "Cleaning up boskos..."
-	cleanup_boskos
-    fi
+# Ensure local bin is in PATH
+export PATH="${LOCAL_BIN}:${PATH}"
 
-    echo "Cleaning up run dir: ${RUN_DIR}"
-    rm -rf ${RUN_DIR}
-}
-trap cleanup INT TERM EXIT
-
-# Set up (for cli runs) or acquire a (in case of prow CI) GCP project
-# for bringing up the cluster.
-if [[ ! -v  GCP_PROJECT ]]; then
-    # GCP_PROJECT not defined, so attempt to acquire a boskos project
-    echo "No GCP Project specified...attempting to acquire boskos project"
-    acquire_project
-    GCP_PROJECT=${PROJECT}
-    echo "Boskos Project: ${GCP_PROJECT}"
-    if [[ ! -v GCP_ZONE ]]; then
-	GCP_ZONE=${DEFAULT_GCP_ZONE}
-    fi
-    echo "GCP ZONE: ${GCP_ZONE}"
-else
-    echo "GCP Project specified: ${GCP_PROJECT}"
-    if [[ ! -v GCP_ZONE ]]; then
-	GCP_ZONE=${DEFAULT_GCP_ZONE}
-    fi
-    echo "GCP ZONE: ${GCP_ZONE}"
-fi
-gcp_project_args="--gcp-project ${GCP_PROJECT} --gcp-zone ${GCP_ZONE} "
-test_args="--provider=gce --gce-project=${GCP_PROJECT} --gce-zone=${GCP_ZONE} --minStartupPods=8"
-
-# This script is currently using the "use-built-binaries" option, which
-# requires the built "e2e.test" binary as well as the "kubectl" and "ginkgo"
-# binaries to exist in the "_rundir/${RUN_ID}" directory.
+test_args="--provider=gce --gce-project=${GCP_PROJECT} --gce-region=${GCP_LOCATION} --gce-zones=${GCP_ZONES} --minStartupPods=8"
 
 # Create the run directory if it does not exist.
-#
 if [ ! -d "${RUN_DIR}" ]; then
     echo "Creating run dir: ${RUN_DIR}"
     mkdir -p "${RUN_DIR}"
 fi
 
-echo "Downloading/installing kubetest2"
-go install sigs.k8s.io/kubetest2@latest
+echo "Installing ginkgo binary"
+GOBIN="${LOCAL_BIN}" go install github.com/onsi/ginkgo/v2/ginkgo@latest
+cp "${LOCAL_BIN}/ginkgo" "${RUN_DIR}/ginkgo"
 
-echo "Downloading/installing kubetest2 gce deployer"
-go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
-
-echo "Downloading/installing kubetest2 ginkgo tester"
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-
-echo "Downloading/installing ginkgo binary"
-go install github.com/onsi/ginkgo/v2/ginkgo@latest
-cp "${GOBIN}/ginkgo" "${RUN_DIR}/ginkgo"
-
-echo "Downloading installing kubectl (${VERSION})"
-curl -LO -s "https://dl.k8s.io/release/${VERSION}/bin/linux/amd64/kubectl"
+echo "Downloading installing kubectl (${K8S_VERSION})"
+curl -LO -s "https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl"
 chmod u+x ./kubectl
 mv -f ./kubectl "${RUN_DIR}/kubectl"
 echo
 
 # Build the e2e.test binary and position it correctly.
-#
 echo "Build the e2e.test binary"
 pushd "${REPO_ROOT}/test/e2e"
 go test -c
@@ -135,23 +95,37 @@ popd
 echo "Move e2e.test binary to: ${RUN_DIR}"
 mv -f "${REPO_ROOT}/test/e2e/e2e.test" "${RUN_DIR}/e2e.test"
 
-# Run the e2e test using the "gce" provider and the "ginkgo" tester.
-echo "Running e2e test with k8s version: ${VERSION}"
-kubetest2 gce \
-	  -v ${VERBOSITY} \
-	  --kubernetes-version ${VERSION} \
-	  --repo-root ${REPO_ROOT} \
-	  --run-id ${RUN_ID} ${gcp_project_args} \
-	  --build \
-	  --up \
-	  --down \
-	  --test ginkgo \
-	  --overwrite-logs-dir \
-	  -- \
-	  --use-built-binaries true \
-	  --parallel 30 \
-	  --test-args="${test_args}" \
-	  --focus-regex='\[cloud-provider-gcp-e2e\]'
+# Workaround kubetest2-kops/kops ambiguity by unsetting cluster name env vars
+_CLUSTER_NAME="${KOPS_CLUSTER_NAME}"
+unset KOPS_CLUSTER_NAME
+unset CLUSTER_NAME
+
+# Run the e2e test using the "kops" provider and the "ginkgo" tester.
+echo "Running e2e test with k8s version: ${K8S_VERSION}"
+kubetest2 kops \
+  -v=2 \
+  --cloud-provider=gce \
+  --cluster-name="${_CLUSTER_NAME}" \
+  --kops-binary-path="${KOPS_BIN}" \
+  --ssh-private-key="${SSH_PRIVATE_KEY}" \
+  --ssh-user="${KUBE_SSH_USER}" \
+  --gcp-project="${GCP_PROJECT}" \
+  --admin-access="${ADMIN_ACCESS:-0.0.0.0/0}" \
+  --env="KOPS_FEATURE_FLAGS=${KOPS_FEATURE_FLAGS:-}" \
+  --test=ginkgo \
+  --kubernetes-version="${K8S_VERSION}" \
+  --run-id=${RUN_ID} \
+  -- \
+  --use-built-binaries=true \
+  --test-args="${test_args}" \
+  --parallel=30 \
+  --focus-regex='\[cloud-provider-gcp-e2e\]'
+
+# 4. Teardown
+if [[ "${DELETE_CLUSTER:-true}" == "true" ]]; then
+  make kops-down
+  DELETE_CLUSTER=false # Don't delete again in trap
+fi
 
 echo
 echo "FINISHED Running cloud-provider-gcp e2e tests"

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -34,6 +34,7 @@ if [[ -z "${GCP_PROJECT:-}" ]]; then
     export GCP_PROJECT="${PROJECT}"
     CLEANUP_BOSKOS="true"
 fi
+export IMAGE_REPO="gcr.io/${GCP_PROJECT}"
 
 # 2. Cluster Lifecycle Management
 export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-run-e2e-test.k8s.local}"

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -56,7 +56,7 @@ function cleanup {
 trap cleanup EXIT
 
 # 3. Test Setup
-export K8S_VERSION=$(make print-k8s-version)
+export K8S_VERSION=$(make --silent print-k8s-version)
 export KOPS_BIN="${REPO_ROOT}/bin/kops"
 export SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-$(pwd)/../clusters/${KOPS_CLUSTER_NAME}/google_compute_engine}"
 export KUBE_SSH_USER="${KUBE_SSH_USER:-${USER}}"

--- a/tools/run-e2e-test.sh
+++ b/tools/run-e2e-test.sh
@@ -35,6 +35,7 @@ if [[ -z "${GCP_PROJECT:-}" ]]; then
     CLEANUP_BOSKOS="true"
 fi
 export IMAGE_REPO="gcr.io/${GCP_PROJECT}"
+export KOPS_STATE_STORE="gs://kops-state-${GCP_PROJECT}"
 
 # 2. Cluster Lifecycle Management
 export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-run-e2e-test.k8s.local}"


### PR DESCRIPTION
Refactor kops cluster creation logic from `kops-simple` into a small go wrapper in `tools/kops`.

* Standardize cluster provisioning in both e2e tests `e2e/scenarios/kops-simple` and `tools/run-e2e-test.sh` on kops.
* Remove the kubetest2-gce dependency to facilitate the removal of the `/cluster` directory.

/label tide/merge-method-squash