### PR TITLE
Remove the minimum gcloud version check.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2146,18 +2146,14 @@ function update-or-verify-gcloud() {
     version=$(gcloud version --format=json)
     python3 -c"
 import json,sys
-from distutils import version
 
-minVersion = version.LooseVersion('1.3.0')
 required = [ 'alpha', 'beta', 'core' ]
 data = json.loads(sys.argv[1])
 rel = data.get('Google Cloud SDK')
 if 'CL @' in rel:
   print('Using dev version of gcloud: %s' %rel)
   exit(0)
-if rel != 'HEAD' and version.LooseVersion(rel) < minVersion:
-  print('gcloud version out of date ( < %s )' % minVersion)
-  exit(1)
+
 missing = []
 for c in required:
   if not data.get(c):


### PR DESCRIPTION
The original check was supposed to gate against a legacy version that would be almost 10 years old as of today. This change removes dependency on `distutils`, which is deprecated and is causing issues in newer versions of python.

This PR mimic the change that was already merged here https://github.com/kubernetes/kubernetes/pull/136393