### PR TITLE
Add make commands for e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,3 +413,35 @@ kops-e2e-test: kops-tool ## Run E2E tests on kOps cluster.
 		--skip-regex="\[Serial\]" \
 		--focus-regex="\[Conformance\]"
 
+
+## --------------------------------------
+##@ E2E
+## --------------------------------------
+
+.PHONY: test-e2e-latest
+test-e2e-latest: ## Run the latest periodic E2E tests.
+	./dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+
+.PHONY: test-e2e-latest-with-gcepd
+test-e2e-latest-with-gcepd: ## Run the latest periodic E2E tests with GCE PD.
+	ENABLE_GCEPD=true ./dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+
+.PHONY: test-e2e-latest-with-kubernetes-master
+test-e2e-latest-with-kubernetes-master: ## Run the latest periodic E2E tests with Kubernetes master.
+	USE_KUBERNETES_MASTER=true ./dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+
+.PHONY: test-conformance-latest
+test-conformance-latest: ## Run the latest periodic conformance tests.
+	./dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
+
+.PHONY: test-conformance-latest-with-gcepd
+test-conformance-latest-with-gcepd: ## Run the latest periodic conformance tests with GCE PD.
+	ENABLE_GCEPD=true ./dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
+
+.PHONY: test-e2e-scenario-kops-simple
+test-e2e-scenario-kops-simple: ## Run the kops simple E2E periodic test.
+	./dev/ci/periodics/ci-cloud-provider-gcp-e2e-scenario-kops-simple.sh
+
+.PHONY: test-presubmit
+test-presubmit: ## Run the cloud-provider-gcp presubmit tests.
+	./dev/ci/presubmits/cloud-provider-gcp-tests

--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 
-# TODO: Use published release tars for cloud-provider-gcp if/once they exist
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
-
-REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
-cd
-export GO111MODULE=on
-
-go install sigs.k8s.io/kubetest2@latest
-go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
-  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
-  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
-else
-  export TEST_PACKAGE_VERSION="v1.25.0"
-  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
-fi
-kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size e2-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]' --test-args=--enabled-volume-drivers=gcepd
+# Wrapper script to run conformance tests with GCEPD enabled via Make
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+make test-conformance-latest-with-gcepd

--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
@@ -9,6 +9,8 @@ set -o xtrace
 REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
 cd
 export GO111MODULE=on
+# Optional Features
+ENABLE_GCEPD=${ENABLE_GCEPD:-"false"}
 
 go install sigs.k8s.io/kubetest2@latest
 go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
@@ -20,4 +22,9 @@ else
   export TEST_PACKAGE_VERSION="v1.25.0"
   echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
 fi
-kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size e2-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]'
+TEST_ARGS=""
+if [[ "${ENABLE_GCEPD}" == "true" ]]; then
+  TEST_ARGS="--enabled-volume-drivers=gcepd"
+fi
+
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --master-size e2-standard-2  -- --test-package-version="${TEST_PACKAGE_VERSION}" --focus-regex='\[Conformance\]' --test-args="${TEST_ARGS}"

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
@@ -1,23 +1,6 @@
 #!/bin/bash
 
-# TODO: Use published release tars for cloud-provider-gcp if/once they exist
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
-
-REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
-cd
-export GO111MODULE=on
-
-go install sigs.k8s.io/kubetest2@latest
-go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
-  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
-  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
-else
-  export TEST_PACKAGE_VERSION="v1.25.0"
-  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
-fi
-kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8 --enabled-volume-drivers=gcepd' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+# Wrapper script to run E2E tests with GCEPD enabled via Make
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+make test-e2e-latest-with-gcepd

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
@@ -1,25 +1,6 @@
 #!/bin/bash
 
-# TODO: Use published release tars for cloud-provider-gcp if/once they exist
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
-
-REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
-cd
-export GO111MODULE=on
-
-go install sigs.k8s.io/kubetest2@latest
-go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
-go install sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest
-if [[ -f "${REPO_ROOT}/ginko-test-package-version.env" ]]; then
-  export TEST_PACKAGE_VERSION=$(cat "${REPO_ROOT}/ginko-test-package-version.env")
-  echo "TEST_PACKAGE_VERSION set to ${TEST_PACKAGE_VERSION}"
-else
-  export TEST_PACKAGE_VERSION="v1.25.0"
-  echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
-fi
-cd $GOPATH/src/k8s.io/cloud-provider-gcp
-e2e/add-kubernetes-to-workspace.sh
-kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+# Wrapper script to run E2E tests using the kubernetes master branch via Make
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "${REPO_ROOT}"
+make test-e2e-latest-with-kubernetes-master

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
@@ -9,6 +9,9 @@ set -o xtrace
 REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp
 cd
 export GO111MODULE=on
+# Optional Features
+ENABLE_GCEPD=${ENABLE_GCEPD:-"false"}
+USE_KUBERNETES_MASTER=${USE_KUBERNETES_MASTER:-"false"}
 
 go install sigs.k8s.io/kubetest2@latest
 go install sigs.k8s.io/kubetest2/kubetest2-gce@latest
@@ -20,4 +23,14 @@ else
   export TEST_PACKAGE_VERSION="v1.25.0"
   echo "TEST_PACKAGE_VERSION - Falling back to v1.25.0"
 fi
-kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args='--minStartupPods=8' --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+TEST_ARGS="--minStartupPods=8"
+if [[ "${ENABLE_GCEPD}" == "true" ]]; then
+  TEST_ARGS="${TEST_ARGS} --enabled-volume-drivers=gcepd"
+fi
+
+if [[ "${USE_KUBERNETES_MASTER}" == "true" ]]; then
+  cd $GOPATH/src/k8s.io/cloud-provider-gcp
+  e2e/add-kubernetes-to-workspace.sh
+fi
+
+kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo --node-size e2-standard-4 --master-size e2-standard-8 -- --test-package-version="${TEST_PACKAGE_VERSION}" --parallel=30 --test-args="${TEST_ARGS}" --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'


### PR DESCRIPTION
After this is submitted we can update test-infra to use the make commands, then remove the .sh files which have been changed to wrappers for the commands.