### PR TITLE
Fix MultiNetwork CRD Cache Sync for Network Informer Factory

### DIFF
--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -70,10 +70,7 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 	nwInformer := nwInfFactory.Networking().V1().Networks()
 	gnpInformer := nwInfFactory.Networking().V1().GKENetworkParamSets()
 
-	// TODO: Add a flag to control to start this informer specific to required GKE functionality
-	go nwInfFactory.Start(ctx.Stop)
-
-	return nodeipamcontroller.StartNodeIpamController(
+	ctrl, started, err := nodeipamcontroller.StartNodeIpamController(
 		wait.ContextForChannel(ctx.Stop),
 		ccmConfig.SharedInformers.Core().V1().Nodes(),
 		ccmConfig.ClientBuilder.ClientOrDie("node-controller"),
@@ -89,4 +86,13 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 		ipam.CIDRAllocatorType(ccmConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType),
 		ctx.ControllerManagerMetrics,
 	)
+
+	if err != nil {
+		return nil, false, err
+	}
+
+	// TODO: Add a flag to control to start this informer specific to required GKE functionality
+	go nwInfFactory.Start(ctx.Stop)
+
+	return ctrl, started, nil
 }

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -95,7 +95,9 @@ type cloudCIDRAllocator struct {
 	// NewCloudCIDRAllocator.
 	nodeLister corelisters.NodeLister
 	// nodesSynced returns true if the node shared informer has been synced at least once.
-	nodesSynced cache.InformerSynced
+	nodesSynced    cache.InformerSynced
+	networksSynced cache.InformerSynced
+	gnpsSynced     cache.InformerSynced
 
 	recorder          record.EventRecorder
 	queue             workqueue.RateLimitingInterface
@@ -147,6 +149,8 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 		gnpLister:             gnpInformer.Lister(),
 		nodeLister:            nodeInformer.Lister(),
 		nodesSynced:           nodeInformer.Informer().HasSynced,
+		networksSynced:        nwInformer.Informer().HasSynced,
+		gnpsSynced:            gnpInformer.Informer().HasSynced,
 		recorder:              recorder,
 		queue:                 workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: workqueueName}),
 		stackType:             stackType,
@@ -289,7 +293,12 @@ func (ca *cloudCIDRAllocator) Run(stopCh <-chan struct{}) {
 	klog.Infof("Starting cloud CIDR allocator")
 	defer klog.Infof("Shutting down cloud CIDR allocator")
 
-	if !cache.WaitForNamedCacheSync("cidrallocator", stopCh, ca.nodesSynced) {
+	syncFuncs := []cache.InformerSynced{ca.nodesSynced}
+	if ca.enableMultiNetworking {
+		syncFuncs = append(syncFuncs, ca.networksSynced, ca.gnpsSynced)
+	}
+
+	if !cache.WaitForNamedCacheSync("cidrallocator", stopCh, syncFuncs...) {
 		return
 	}
 


### PR DESCRIPTION
The recent startup refactor in the NodeIPAM controller (commit 6efe35aa66) introduced a regression where it began incorrectly patching nodes with empty multi-network annotations: `{"networking.gke.io/networks":"[]","networking.gke.io/north-interfaces":"[]"}`

This is due to a race condition. The previous code structure relied on side-effects of initialization timing to let the Network and GKENetworkParamSet (GNP) informers populate before processing node queue items. With the refactor starting informers concurrently via `go nwInfFactory.Start(ctx.Stop)`, `cloudCIDRAllocator.go` begins processing as soon as its node informer syncs, disregarding whether network and GNP caches have properly synchronized.

When `performMultiNetworkCIDRAllocation` asks for all Networks, it receives an empty list, computes zero matches with VM interfaces, and proceeds to strip whatever multi-network properties the node might currently have to reflect this (incorrect) empty state.

Also move `go nwInfFactory.Start(ctx.Stop) ` to execute after `StartNodeIpamController` returns. This guarantees that `StartNodeIpamController` (and` ipam.New `inside it) fully instantiates the informers, ensuring they are present in the factory's list before `Start()` iterates over them.