### PR TITLE
Cherry pick flaky test fixes to release-1.35

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -241,14 +241,8 @@ func TestNodeTopologyCR_AddOrUpdateNode(t *testing.T) {
 	fakeInformerFactory.Start(stopCh)
 	go cloudAllocator.Run(stopCh)
 
-	// Wait for allocator to sync
-	if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-		return cloudAllocator.nodesSynced(), nil
-	}); err != nil {
-		t.Fatalf("failed to wait for informer sync: %v", err)
-	}
-
-	fakeClient.CoreV1().Nodes().Create(context.TODO(), mscnode, metav1.CreateOptions{})
+	time.Sleep(time.Millisecond * 500)
+	fakeClient.Tracker().Add(mscnode)
 	expectedSubnets := []string{"subnet-def", "subnet1"}
 	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
 		ok, _ := verifySubnetsInCR(t, expectedSubnets, nodeTopologyClient)
@@ -269,7 +263,7 @@ func TestNodeTopologyCR_AddOrUpdateNode(t *testing.T) {
 		},
 	}
 	fakeGCE.Compute().Instances().Insert(context.TODO(), meta.ZonalKey("testNode2", testClusterValues.ZoneName), &compute.Instance{Name: "testNode2"})
-	fakeClient.CoreV1().Nodes().Create(context.TODO(), mscnode2, metav1.CreateOptions{})
+	fakeClient.Tracker().Add(mscnode2)
 	expectedSubnets = []string{"subnet-def", "subnet1", "subnet2"}
 	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
 		ok, _ := verifySubnetsInCR(t, expectedSubnets, nodeTopologyClient)
@@ -340,14 +334,6 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 	defer close(stopCh)
 	fakeInformerFactory.Start(stopCh)
 	go cloudAllocator.Run(stopCh)
-
-	// Wait for allocator to sync
-	if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-		return cloudAllocator.nodesSynced(), nil
-	}); err != nil {
-		t.Fatalf("failed to wait for informer sync: %v", err)
-	}
-
 	mscnode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testNode",
@@ -359,7 +345,7 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 			ProviderID: "gce://test-project/us-central1-b/testNode",
 		},
 	}
-	fakeClient.CoreV1().Nodes().Create(context.TODO(), mscnode, metav1.CreateOptions{})
+	fakeClient.Tracker().Add(mscnode)
 
 	expectedSubnets := []string{"subnet-def", "subnet1"}
 	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
@@ -369,7 +355,8 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 		t.Fatalf("Add node topology CR not working as expected: %v", err)
 	}
 
-	fakeClient.CoreV1().Nodes().Delete(context.TODO(), mscnode.GetName(), metav1.DeleteOptions{})
+	gvr := v1.SchemeGroupVersion.WithResource("nodes")
+	fakeClient.Tracker().Delete(gvr, mscnode.GetNamespace(), mscnode.GetName(), metav1.DeleteOptions{})
 
 	expectedSubnets = []string{"subnet-def"}
 	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {

--- a/pkg/controller/nodeipam/ipam/node_topology_syncer.go
+++ b/pkg/controller/nodeipam/ipam/node_topology_syncer.go
@@ -149,6 +149,20 @@ func (syncer *NodeTopologySyncer) updateNodeTopology(node *v1.Node) error {
 			Name:       defaultSubnet,
 			SubnetPath: subnetPrefix + defaultSubnet,
 		})
+
+		// If the node we are processing has a subnet that isn't the default, add it immediately.
+		// This is necessary because the informer's LIST/WATCH mechanism does not guarantee
+		// strict chronological ordering of external events. A node heavily delayed in
+		// registration, or a restart of this controller, could result in a node with a
+		// custom subnet being processed before the default subnet.
+		if hasSubnetLabel && nodeSubnet != defaultSubnet {
+			klog.V(2).Infof("Adding the node's subnet %s to the cr along with default subnetwork", nodeSubnet)
+			updatedCR.Status.Subnets = append(updatedCR.Status.Subnets, nodetopologyv1.SubnetConfig{
+				Name:       nodeSubnet,
+				SubnetPath: subnetPrefix + nodeSubnet,
+			})
+		}
+
 		// We always expect zones field in the status.
 		if updatedCR.Status.Zones == nil {
 			updatedCR.Status.Zones = []string{}

--- a/pkg/controller/nodeipam/ipam/node_topology_syncer_test.go
+++ b/pkg/controller/nodeipam/ipam/node_topology_syncer_test.go
@@ -244,6 +244,26 @@ func TestNodeTopologySync(t *testing.T) {
 			wantSubnets:     []string{"subnet-def"},
 		},
 		{
+			name: "node has a non-default subnet and cr's subnets is empty",
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-node-2",
+				},
+			},
+			nodeListInCache: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "a-node-2",
+						Labels: map[string]string{
+							testNodePoolSubnetLabelPrefix: "subnet-def-1",
+						},
+					},
+				},
+			},
+			existingSubnets: []string{},
+			wantSubnets:     []string{"subnet-def", "subnet-def-1"},
+		},
+		{
 			name: "node has no subnet label and ensure we add the default subnet to cr",
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
To reduce unit test flakiness on release-1.35, cherrypicking #980 and #988 to improve the unit test runs

/assign @hdp617 