### PR TITLE
Isolate k8s deps update with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: /cluster/gce/gci/mounter
-  schedule:
-    interval: weekly
-  labels:
-  - 'area/dependency'
-  - 'release-note-none'
-  - 'ok-to-test'
-- package-ecosystem: docker
-  directory: /cluster/addons/addon-manager
-  schedule:
-    interval: weekly
-  labels:
-  - 'area/dependency'
-  - 'release-note-none'
-  - 'ok-to-test'
 - package-ecosystem: gomod
-  directory: /providers
+  directories:
+  - "/"
+  - "/providers"
+  - "/metis"
+  - "/test/e2e"
   schedule:
     interval: weekly
   labels:
@@ -25,42 +13,15 @@ updates:
   - 'release-note-none'
   - 'ok-to-test'
   groups:
-    gomod-dependencies:
+    k8s-dependencies:
       patterns:
-      - '*'
-- package-ecosystem: gomod
-  directory: /
-  schedule:
-    interval: weekly
-  labels:
-  - 'area/dependency'
-  - 'release-note-none'
-  - 'ok-to-test'
-  groups:
-    gomod-dependencies:
+      - "k8s.io/*"
+      - "sigs.k8s.io/*"
+    workspace-deps:
       patterns:
-      - '*'
-- package-ecosystem: gomod
-  directory: /crd
-  schedule:
-    interval: weekly
-  labels:
-  - 'area/dependency'
-  - 'release-note-none'
-  - 'ok-to-test'
-  groups:
-    gomod-dependencies:
-      patterns:
-      - '*'
-- package-ecosystem: gomod
-  directory: /crd/hack
-  schedule:
-    interval: weekly
-  labels:
-  - 'area/dependency'
-  - 'release-note-none'
-  - 'ok-to-test'
-  groups:
-    gomod-dependencies:
-      patterns:
-      - '*'
+        - "*"
+      exclude-patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"
+
+


### PR DESCRIPTION
Since k8s deps are tightly coupled and also used to determine versioning of the components, they should ideally be updated together and isolated from other deps. This PR adjusts the dependabot config so that k8s deps are updated in separate PRs from other go deps.