### PR TITLE
Sync go.work.sum in dependabot PRs

### DIFF
--- a/.github/dependabot-sync.yml
+++ b/.github/dependabot-sync.yml
@@ -1,0 +1,37 @@
+name: Dependabot Go Work Sync
+
+on:
+  pull_request:
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
+
+permissions:
+  contents: write
+
+jobs:
+  go-work-sync:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.work'
+
+      - name: Sync Go Workspace
+        run: go work sync
+        
+      - name: Commit and Push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add go.work.sum
+          # Only commit if there are actual changes
+          git diff --quiet && git diff --staged --quiet || git commit -m "chore: update go.work.sum"
+          git push


### PR DESCRIPTION
Dependabot doesn't update go.work.sum so automated PRs always fail. This PR adds a GitHub Actions workflow to sync go.work.sum for automated PRs from dependabot to work around this limitation.