### PR TITLE
fix(metis): include DOCKER_TAG_ARGS in build-tarball target

### DIFF
--- a/metis/Makefile
+++ b/metis/Makefile
@@ -97,6 +97,7 @@ build-tarball: init-buildx ## Build the multi-arch image as an OCI tarball.
 	@echo "Building OCI tarball for multi-arch image: $(IMAGE_NAME)..."
 	docker buildx build --platform $(ALL_PLATFORMS) \
 		$(DOCKER_BUILD_ARGS) \
+		$(DOCKER_TAG_ARGS) \
 		--output=type=oci,dest=$(OCI_TARBALL_PATH) \
 		--provenance=false \
 		--sbom=false .


### PR DESCRIPTION
### What does this PR do? 

Adds the missing $(DOCKER_TAG_ARGS) to the docker buildx build invocation within the build-tarball target in metis/Makefile.

### Why is it needed? 

When building an OCI tarball for the multi-arch image via make build-tarball, the tags were not being propagated to the docker build step. This resulted in the exported OCI archive holding an untagged image, hence using a latest tag

Passing $(DOCKER_TAG_ARGS) ensures that the OCI tarball metadata maintains the correct image tags (e.g., GIT_VERSION and SHORT_SHA), aligning it with the behavior of push-image.

/hold for reviews from @YifeiZhuang @gnossen
/label tide/merge-method-squash