### PR TITLE
[gke-gcloud-auth-plugin] Add environment variable to override cache path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ _rundir/
 _tmp/
 /bin/
 __pycache__/
+/tools/golint
+

--- a/cmd/gke-gcloud-auth-plugin/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -348,6 +349,10 @@ func writeCacheFile(content string) error {
 }
 
 func getCacheFilePath() string {
+	if override := os.Getenv("GKE_GCLOUD_AUTH_PLUGIN_CACHE_OVERRIDE"); override != "" {
+		return override
+	}
+
 	po := clientcmd.NewDefaultPathOptions()
 	kubeconfig := po.GetDefaultFilename()
 	dir := filepath.Dir(kubeconfig)

--- a/cmd/gke-gcloud-auth-plugin/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred.go
@@ -48,6 +48,9 @@ const (
 	// env variable is set to a value, that value is propagated by gcloud as an
 	// access token
 	cloudsdkAuthAccessEnvVar = "CLOUDSDK_AUTH_ACCESS_TOKEN"
+
+	// cacheFilePathOverrideEnvVar is an env variable to override the cache file path.
+	cacheFilePathOverrideEnvVar = "GKE_GCLOUD_AUTH_PLUGIN_CACHE_OVERRIDE"
 )
 
 // cache is the struct that gets cached in the cache file in json format.
@@ -367,6 +370,10 @@ func writeCacheFile(content string) error {
 }
 
 func getCacheFilePath() string {
+	if override := os.Getenv(cacheFilePathOverrideEnvVar); override != "" {
+		return override
+	}
+
 	po := clientcmd.NewDefaultPathOptions()
 	kubeconfig := po.GetDefaultFilename()
 	dir := filepath.Dir(kubeconfig)

--- a/cmd/gke-gcloud-auth-plugin/cred_test.go
+++ b/cmd/gke-gcloud-auth-plugin/cred_test.go
@@ -721,6 +721,17 @@ func TestCloudsdkBasedGcloudAccessToken(t *testing.T) {
 	}
 }
 
+func TestGetCacheFilePathOverride(t *testing.T) {
+	overridePath := "/tmp/my_custom_cache_path"
+	os.Setenv("GKE_GCLOUD_AUTH_PLUGIN_CACHE_OVERRIDE", overridePath)
+	defer os.Setenv("GKE_GCLOUD_AUTH_PLUGIN_CACHE_OVERRIDE", "")
+
+	path := getCacheFilePath()
+	if path != overridePath {
+		t.Errorf("getCacheFilePath() = %v, want %v", path, overridePath)
+	}
+}
+
 func fakeDefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSource, error) {
 	return &mockTokenSource{}, nil
 }

--- a/cmd/gke-gcloud-auth-plugin/cred_test.go
+++ b/cmd/gke-gcloud-auth-plugin/cred_test.go
@@ -720,6 +720,16 @@ func TestCloudsdkBasedGcloudAccessToken(t *testing.T) {
 	}
 }
 
+func TestGetCacheFilePathOverride(t *testing.T) {
+	overridePath := "/tmp/my_custom_cache_path"
+	t.Setenv(cacheFilePathOverrideEnvVar, overridePath)
+
+	path := getCacheFilePath()
+	if path != overridePath {
+		t.Errorf("getCacheFilePath() = %v, want %v", path, overridePath)
+	}
+}
+
 func fakeDefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSource, error) {
 	return &mockTokenSource{}, nil
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/cloud-provider-gcp/issues/920