### PR TITLE
metis: Refine update-proto.sh to enforce specific protoc version

### DIFF
--- a/tools/update-proto.sh
+++ b/tools/update-proto.sh
@@ -33,10 +33,21 @@ TOOLS_BIN="${_TMP_DIR}/bin"
 mkdir -p "${TOOLS_BIN}"
 export PATH="${TOOLS_BIN}:${PATH}"
 
-# Install protoc if not present
-if ! command -v protoc &> /dev/null; then
-  echo "protoc not found, installing locally..."
-  PROTOC_VERSION="34.1"
+# Install protoc if not present or version mismatches
+PROTOC_VERSION="34.1"
+need_install=true
+if command -v protoc &> /dev/null; then
+  curr_version=$(protoc --version | awk '{print $2}')
+  if [[ "$curr_version" == "$PROTOC_VERSION" ]]; then
+    need_install=false
+    echo "Found protoc version $curr_version, skipping installation."
+  else
+    echo "Found protoc version $curr_version, but want $PROTOC_VERSION."
+  fi
+fi
+
+if $need_install; then
+  echo "Installing protoc locally..."
   PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
   PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}"
   
@@ -56,14 +67,11 @@ if ! command -v protoc &> /dev/null; then
   rm -rf "${TMP_PROTOC_DIR}"
 fi
 
-# Install protoc-gen-go and protoc-gen-go-grpc if not present
-if ! command -v protoc-gen-go &> /dev/null || ! command -v protoc-gen-go-grpc &> /dev/null; then
-  echo "protoc-gen-go/grpc not found, installing..."
+  echo "Installing protoc-gen-go/grpc..."
   export GOBIN="${TOOLS_BIN}"
   
   go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-fi
 
 # Find all proto files outside of vendor and temporary/artifact directories
 proto_files=$(find . -name "*.proto" -not -path "./vendor/*" -not -path "./_*" )


### PR DESCRIPTION
### Description

This PR refines the `tools/update-proto.sh` script to ensure reproducible protobuf code generation across different developer environments and CI. 

Currently, the script only installs `protoc` if it is completely missing from the host. If a developer has an older version of `protoc` installed system-wide (e.g., `3.21.12`), the script will use it, producing different generated code than the CI environment (which uses `34.1`).

### Key Changes

- **Version Check**: Updated the script to not only check if `protoc` is installed, but also verify that its version matches the requested `PROTOC_VERSION` (`34.1`).
- **Forced Local Installation on Mismatch**: If the version mismatches or is not found, it downloads the correct release asset from GitHub and installs it locally in `_tmp/bin`, overriding the system version for the duration of the script.
- **Generator Updates**: Removed the guard checks for `protoc-gen-go` and `protoc-gen-go-grpc` to ensure the latest versions of these generators are fetched via `go install` every time.

### Verification Results

1. Verified locally on a machine with an older `protoc` version: The script successfully detected the mismatch, downloaded version `34.1`, and placed it in `_tmp/bin`.
2. Verified that the generated `.pb.go` files now perfectly match what the CI expects, resolving `verify-up-to-date` failures.

/hold for reviews from @YifeiZhuang
/label tide/merge-method-squash