### PR TITLE
Use kops in periodic tests

### DIFF
--- a/dev/ci/periodics/ci-cloud-provider-gcp-kops-conformance-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-kops-conformance-latest.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+cd $GOPATH/src/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+export DELETE_CLUSTER=${DELETE_CLUSTER:-true}
+export GINKGO_FOCUS_REGEX="\[Conformance\]"
+e2e/scenarios/kops-simple

--- a/dev/ci/periodics/ci-cloud-provider-gcp-kops-e2e-latest-with-kubernetes-master.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-kops-e2e-latest-with-kubernetes-master.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+cd $GOPATH/src/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+export DELETE_CLUSTER=${DELETE_CLUSTER:-true}
+export K8S_VERSION="master"
+e2e/scenarios/kops-simple

--- a/dev/ci/periodics/ci-cloud-provider-gcp-kops-e2e-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-kops-e2e-latest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+cd $GOPATH/src/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+export DELETE_CLUSTER=${DELETE_CLUSTER:-true}
+e2e/scenarios/kops-simple


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR uses a kops for periodic tests.

I’m keeping this migration intentionally incremental:
- the new kops-based tests are added first
- the old kubetest2-gce-based are not removed in this PR
- gcepd tests are intentionally not migrated in this first step

The plan is to merge this PR first, observe how the new periodic jobs behave in CI, and only then remove the old periodic flow in a separate cleanup/chore PR if the new path proves stable.

#### Which issue(s) this PR fixes:
#1018

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```