### PR TITLE
feat: Explicitly ignore non-GCE provider IDs

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -407,6 +407,10 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 		return fmt.Errorf("failed to get instance from provider: %v", err)
 	}
 	if instance == nil {
+		if ca.cloud.IsNodeUnmanagedByProviderID(node.Spec.ProviderID) {
+			klog.V(4).Infof("Skipping CIDR allocation for unmanaged node %s", nodeName)
+			return nil
+		}
 		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
 		return fmt.Errorf("failed to get instance from provider for node %s: instance not found", nodeName)
 	}

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -406,6 +406,10 @@ func (ca *cloudCIDRAllocator) updateCIDRAllocation(nodeName string) error {
 		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
 		return fmt.Errorf("failed to get instance from provider: %v", err)
 	}
+	if instance == nil {
+		nodeutil.RecordNodeStatusChange(ca.recorder, node, "CIDRNotAvailable")
+		return fmt.Errorf("failed to get instance from provider for node %s: instance not found", nodeName)
+	}
 
 	cidrStrings := make([]string, 0)
 

--- a/pkg/controller/nodeipam/ipam/node_topology_syncer.go
+++ b/pkg/controller/nodeipam/ipam/node_topology_syncer.go
@@ -116,7 +116,9 @@ func (syncer *NodeTopologySyncer) reconcile() error {
 		if err != nil {
 			return err
 		}
-		zoneSet.Insert(zone)
+		if zone != "" {
+			zoneSet.Insert(zone)
+		}
 	}
 	updatedNodeTopologyCR.Status.Zones = zoneSet.List()
 

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -85,6 +85,12 @@ func makeHostURL(projectsAPIEndpoint, projectID, zone, host string) string {
 }
 
 // ToInstanceReferences returns instance references by links
+// IsNodeUnmanagedByProviderID returns true if the node is not managed by GCE cloud provider.
+// All managed node's providerIDs are in format 'gce://<project-id>/<zone>/<instance-name>'
+func (g *Cloud) IsNodeUnmanagedByProviderID(providerID string) bool {
+	return !strings.HasPrefix(providerID, ProviderName+"://")
+}
+
 func (g *Cloud) ToInstanceReferences(zone string, instanceNames []string) (refs []*compute.InstanceReference) {
 	for _, ins := range instanceNames {
 		instanceLink := makeHostURL(g.projectsBasePath, g.projectID, zone, ins)
@@ -233,6 +239,9 @@ func (g *Cloud) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v
 // NodeAddressesByProviderID will not be called from the node that is requesting this ID.
 // i.e. metadata service and other local methods cannot be used here
 func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return []v1.NodeAddress{}, nil
+	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
@@ -320,6 +329,9 @@ func getIPV6AddressFromInterface(nic *compute.NetworkInterface) string {
 // node that is requesting this ID. i.e. metadata service and other local
 // methods cannot be used here
 func (g *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return "", nil
+	}
 	instance, err := g.instanceByProviderID(providerID)
 	if err != nil {
 		return "", err
@@ -331,6 +343,9 @@ func (g *Cloud) InstanceTypeByProviderID(ctx context.Context, providerID string)
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (g *Cloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return true, nil
+	}
 	_, err := g.instanceByProviderID(providerID)
 	if err != nil {
 		if err == cloudprovider.InstanceNotFound {
@@ -586,6 +601,9 @@ func (g *Cloud) CurrentNodeName(ctx context.Context, hostname string) (types.Nod
 // `node` for allocation to pods. Returns a list of the form
 // "<ip>/<netmask>".
 func (g *Cloud) AliasRangesByProviderID(providerID string) (cidrs []string, err error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return nil, nil
+	}
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 
@@ -944,6 +962,9 @@ func (g *Cloud) GetNodeTags(nodeNames []string) ([]string, error) {
 
 // NodeNetworkInterfacesByProviderID returns a list of node interfaces that exist on the node.
 func (g *Cloud) InstanceByProviderID(providerID string) (res *compute.Instance, err error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return nil, nil
+	}
 	ctx, cancel := cloud.ContextWithCallTimeout()
 	defer cancel()
 

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -87,7 +87,7 @@ func makeHostURL(projectsAPIEndpoint, projectID, zone, host string) string {
 // IsNodeUnmanagedByProviderID returns true if the node is not managed by GCE cloud provider.
 // All managed node's providerIDs are in format 'gce://<project-id>/<zone>/<instance-name>'
 func (g *Cloud) IsNodeUnmanagedByProviderID(providerID string) bool {
-	return !strings.HasPrefix(providerID, ProviderName+"://")
+	return providerID != "" && !strings.HasPrefix(providerID, ProviderName+"://")
 }
 
 // ToInstanceReferences returns instance references by links

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -285,11 +285,17 @@ func (g *Cloud) instanceByProviderID(providerID string) (*gceInstance, error) {
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
 func (g *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
+		return false, nil
+	}
 	return false, cloudprovider.NotImplemented
 }
 
 // InstanceShutdown returns true if the instance is in safe state to detach volumes
 func (g *Cloud) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	if node.Spec.ProviderID != "" && g.IsNodeUnmanagedByProviderID(node.Spec.ProviderID) {
+		return false, nil
+	}
 	return false, cloudprovider.NotImplemented
 }
 

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -84,13 +84,13 @@ func makeHostURL(projectsAPIEndpoint, projectID, zone, host string) string {
 	return projectsAPIEndpoint + strings.Join([]string{projectID, "zones", zone, "instances", host}, "/")
 }
 
-// ToInstanceReferences returns instance references by links
 // IsNodeUnmanagedByProviderID returns true if the node is not managed by GCE cloud provider.
 // All managed node's providerIDs are in format 'gce://<project-id>/<zone>/<instance-name>'
 func (g *Cloud) IsNodeUnmanagedByProviderID(providerID string) bool {
 	return !strings.HasPrefix(providerID, ProviderName+"://")
 }
 
+// ToInstanceReferences returns instance references by links
 func (g *Cloud) ToInstanceReferences(zone string, instanceNames []string) (refs []*compute.InstanceReference) {
 	for _, ins := range instanceNames {
 		instanceLink := makeHostURL(g.projectsBasePath, g.projectID, zone, ins)

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -523,6 +523,44 @@ func TestInstanceByProviderID(t *testing.T) {
 	}
 }
 
+func TestUnmanagedNodes(t *testing.T) {
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+
+	unmanagedID := "aws://region/aws-node"
+	ctx := context.Background()
+
+	t.Run("InstanceExistsByProviderID", func(t *testing.T) {
+		exists, err := gce.InstanceExistsByProviderID(ctx, unmanagedID)
+		assert.NoError(t, err)
+		assert.True(t, exists, "Unmanaged nodes should be assumed to exist")
+	})
+
+	t.Run("InstanceTypeByProviderID", func(t *testing.T) {
+		mType, err := gce.InstanceTypeByProviderID(ctx, unmanagedID)
+		assert.NoError(t, err)
+		assert.Equal(t, "", mType)
+	})
+
+	t.Run("NodeAddressesByProviderID", func(t *testing.T) {
+		addrs, err := gce.NodeAddressesByProviderID(ctx, unmanagedID)
+		assert.NoError(t, err)
+		assert.Empty(t, addrs)
+	})
+
+	t.Run("InstanceByProviderID", func(t *testing.T) {
+		inst, err := gce.InstanceByProviderID(unmanagedID)
+		assert.NoError(t, err)
+		assert.Nil(t, inst)
+	})
+
+	t.Run("AliasRangesByProviderID", func(t *testing.T) {
+		ranges, err := gce.AliasRangesByProviderID(unmanagedID)
+		assert.NoError(t, err)
+		assert.Nil(t, ranges)
+	})
+}
+
 func TestGetZone(t *testing.T) {
 	testCases := []struct {
 		nodeLabels   map[string]string

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -527,38 +527,63 @@ func TestUnmanagedNodes(t *testing.T) {
 	gce, err := fakeGCECloud(DefaultTestClusterValues())
 	require.NoError(t, err)
 
-	unmanagedID := "aws://region/aws-node"
-	ctx := context.Background()
+	testCases := []struct {
+		name        string
+		providerID  string
+		expectExist bool
+		expectErr   bool
+	}{
+		{
+			name:        "aws provider ID",
+			providerID:  "aws://region/aws-node",
+			expectExist: true,
+		},
+		{
+			name:        "azure provider ID",
+			providerID:  "azure:///subscriptions/subid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/azure-test-node",
+			expectExist: true,
+		},
+		{
+			name:        "empty provider ID",
+			providerID:  "",
+			expectExist: false,
+			expectErr:   true,
+		},
+	}
 
-	t.Run("InstanceExistsByProviderID", func(t *testing.T) {
-		exists, err := gce.InstanceExistsByProviderID(ctx, unmanagedID)
-		assert.NoError(t, err)
-		assert.True(t, exists, "Unmanaged nodes should be assumed to exist")
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
 
-	t.Run("InstanceTypeByProviderID", func(t *testing.T) {
-		mType, err := gce.InstanceTypeByProviderID(ctx, unmanagedID)
-		assert.NoError(t, err)
-		assert.Equal(t, "", mType)
-	})
+			t.Run("InstanceExistsByProviderID", func(t *testing.T) {
+				exists, err := gce.InstanceExistsByProviderID(ctx, tc.providerID)
+				if tc.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Equal(t, tc.expectExist, exists)
+				}
+			})
 
-	t.Run("NodeAddressesByProviderID", func(t *testing.T) {
-		addrs, err := gce.NodeAddressesByProviderID(ctx, unmanagedID)
-		assert.NoError(t, err)
-		assert.Empty(t, addrs)
-	})
+			if !tc.expectErr {
+				mType, err := gce.InstanceTypeByProviderID(ctx, tc.providerID)
+				assert.NoError(t, err)
+				assert.Equal(t, "", mType)
 
-	t.Run("InstanceByProviderID", func(t *testing.T) {
-		inst, err := gce.InstanceByProviderID(unmanagedID)
-		assert.NoError(t, err)
-		assert.Nil(t, inst)
-	})
+				addrs, err := gce.NodeAddressesByProviderID(ctx, tc.providerID)
+				assert.NoError(t, err)
+				assert.Empty(t, addrs)
 
-	t.Run("AliasRangesByProviderID", func(t *testing.T) {
-		ranges, err := gce.AliasRangesByProviderID(unmanagedID)
-		assert.NoError(t, err)
-		assert.Nil(t, ranges)
-	})
+				inst, err := gce.InstanceByProviderID(tc.providerID)
+				assert.NoError(t, err)
+				assert.Nil(t, inst)
+
+				ranges, err := gce.AliasRangesByProviderID(tc.providerID)
+				assert.NoError(t, err)
+				assert.Nil(t, ranges)
+			}
+		})
+	}
 }
 
 func TestGetZone(t *testing.T) {

--- a/providers/gce/gce_test.go
+++ b/providers/gce/gce_test.go
@@ -300,6 +300,12 @@ func TestGetZoneByProviderID(t *testing.T) {
 			fail:         true,
 			description:  "invalid name of the GCE zone",
 		},
+		{
+			providerID:   "aws://region/aws-node",
+			expectedZone: cloudprovider.Zone{},
+			fail:         false,
+			description:  "non-GCE provider ID",
+		},
 	}
 
 	gce := &Cloud{
@@ -309,7 +315,7 @@ func TestGetZoneByProviderID(t *testing.T) {
 	for _, test := range tests {
 		zone, err := gce.GetZoneByProviderID(context.TODO(), test.providerID)
 		if (err != nil) != test.fail {
-			t.Errorf("Expected to fail=%t, provider ID %v, tests %s", test.fail, test, test.description)
+			t.Errorf("Expected to fail=%t, got err=%v, provider ID %v, tests %s", test.fail, err, test.providerID, test.description)
 		}
 
 		if test.fail {

--- a/providers/gce/gce_zones.go
+++ b/providers/gce/gce_zones.go
@@ -48,6 +48,9 @@ func (g *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
 func (g *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+	if !strings.HasPrefix(providerID, ProviderName+"://") {
+		return cloudprovider.Zone{}, nil
+	}
 	_, zone, _, err := splitProviderID(providerID)
 	if err != nil {
 		return cloudprovider.Zone{}, err

--- a/providers/gce/gce_zones.go
+++ b/providers/gce/gce_zones.go
@@ -48,7 +48,7 @@ func (g *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 // This is particularly useful in external cloud providers where the kubelet
 // does not initialize node data.
 func (g *Cloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
-	if !strings.HasPrefix(providerID, ProviderName+"://") {
+	if g.IsNodeUnmanagedByProviderID(providerID) {
 		return cloudprovider.Zone{}, nil
 	}
 	_, zone, _, err := splitProviderID(providerID)


### PR DESCRIPTION
Tested: 

1. Build a image with modified code.
1. Create a GKE cluster. 
2. Then ssh into the controlplane
3. replace the cloud-controller-manager image.
4. register a AWS node

Result
- Before this change, the aws VM node is removed automatically
- After this change, the AWS VM node remains.

b/504642039