### PR TITLE
Add GitHub Release workflow and config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Features
+      labels:
+        - feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+        - fix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # Important for generating release notes
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          draft: true
+          generate_release_notes: true


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to create draft releases when a tag matching `v*` is pushed. It also adds configuration for auto-generating release notes categorized into Features and Bug Fixes.

Desired Behavior:
- Release Notes: Automatically generated and categorized into 'Features' and 'Bug Fixes'. Excludes Dependabot and PRs labeled 'ignore-for-release'.
- Release Artifacts: Rely on GitHub's default behavior to automatically provide source code archives (zip and tar.gz).

Tested by pushing a test tag v0.0.0-test to the fork repository and verifying that it triggered the workflow to create a draft release.

Closes #1000