### PR TITLE
feat: add kops-based periodic test scenario for e2e-latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,10 @@ IMAGE_REPO ?= gcr.io/$(GCP_PROJECT)
 KOPS_STATE_STORE ?= gs://kops-state-$(GCP_PROJECT)
 IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 
+# Defaults for kOps E2E tests
+KOPS_FOCUS_REGEX ?= "\[Conformance\]"
+KOPS_SKIP_REGEX ?= "\[Serial\]"
+
 .PHONY: kops-simple
 kops-simple: ## Run kOps simple E2E test scenario.
 	./e2e/scenarios/kops-simple
@@ -410,6 +414,6 @@ kops-e2e-test: kops-tool ## Run E2E tests on kOps cluster.
 		-- \
 		--parallel=30 \
 		--test-package-version="${K8S_VERSION}" \
-		--skip-regex="\[Serial\]" \
-		--focus-regex="\[Conformance\]"
+		--skip-regex="$(KOPS_SKIP_REGEX)" \
+		--focus-regex="$(KOPS_FOCUS_REGEX)"
 

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-kops.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-kops.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+cd $GOPATH/src/cloud-provider-gcp
+e2e/add-kubernetes-to-workspace.sh
+
+export KOPS_FOCUS_REGEX="" # Run all non-skipped tests
+export KOPS_SKIP_REGEX='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]'
+export CLUSTER_NAME="kops-e2e-latest.k8s.local"
+
+e2e/scenarios/kops-simple


### PR DESCRIPTION
This PR adds a new periodic test script ci-cloud-provider-gcp-e2e-latest-kops.sh to run general E2E tests using kOps, leaving existing tests unchanged. It also parameterizes the kops-e2e-test Makefile target to support custom focus and skip regexes needed for this new test. This partially solves #1018.