### PR TITLE
metis: fix bug to scope CIDR allocation checks by network

### DIFF
--- a/metis/pkg/daemon/daemon_server.go
+++ b/metis/pkg/daemon/daemon_server.go
@@ -148,7 +148,7 @@ func (s *adaptiveIpamServer) MaybeAddInitialPodCidr(ctx context.Context, network
 		return nil
 	}
 
-	exists, err := s.store.GetCIDRBlockByCIDR(ctx, initialPodCidr)
+	exists, err := s.store.GetCIDRBlockByCIDRAndNetwork(ctx, initialPodCidr, network)
 	if err != nil {
 		s.logger.Error(err, "failed to check if initial cidr block exists", "network", network, "cidr", initialPodCidr)
 		return status.Errorf(codes.Unavailable, "failed to check if initial cidr block %s exists for network %s: %v", initialPodCidr, network, err)

--- a/metis/pkg/store/schema.sql
+++ b/metis/pkg/store/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS cidr_blocks (
 
     -- The actual IP range allocated from GCE. 
     -- Example: '10.0.1.0/28'
-    cidr TEXT UNIQUE NOT NULL,
+    cidr TEXT NOT NULL,
 
     -- The logical network this block belongs to, matching the CNI networkName.
     -- Example: 'gke-pod-network'
@@ -36,7 +36,9 @@ CREATE TABLE IF NOT EXISTS cidr_blocks (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
     -- Timestamp of the last mutation to this block's state or capacity.
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE(cidr, network)
 );
 
 -- ip_addresses tracks the assignment state, ownership, and cooldown periods 
@@ -47,7 +49,7 @@ CREATE TABLE IF NOT EXISTS ip_addresses (
 
     -- The specific IP address string.
     -- Example: '10.0.1.2'
-    address TEXT UNIQUE NOT NULL,
+    address TEXT NOT NULL,
 
     -- The parent CIDR block this IP belongs to. 
     -- Enforces cascading deletes if the parent block is removed by the daemon.
@@ -80,7 +82,8 @@ CREATE TABLE IF NOT EXISTS ip_addresses (
     -- Timestamp of the last mutation to this IP record.
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
-    FOREIGN KEY (cidr_block_id) REFERENCES cidr_blocks(id) ON DELETE CASCADE
+    FOREIGN KEY (cidr_block_id) REFERENCES cidr_blocks(id) ON DELETE CASCADE,
+    UNIQUE(address, cidr_block_id)
 );
 
 -- Index to optimize the daemon's search for the next available IP address.

--- a/metis/pkg/store/store.go
+++ b/metis/pkg/store/store.go
@@ -343,12 +343,12 @@ func (s *Store) AllocateIPv4(ctx context.Context, network, interfaceName, contai
 	return "", "", fmt.Errorf("%w: failed to allocate ipv4 in any cidr block for network %s", ErrNoAvailableIPs, network)
 }
 
-// GetCIDRBlockByCIDR checks if a CIDR block already exists in the database.
-func (s *Store) GetCIDRBlockByCIDR(ctx context.Context, cidr string) (bool, error) {
+// GetCIDRBlockByCIDRAndNetwork checks if a CIDR block exists for the specific network.
+func (s *Store) GetCIDRBlockByCIDRAndNetwork(ctx context.Context, cidr, network string) (bool, error) {
 	var id int64
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id FROM cidr_blocks WHERE cidr = ? LIMIT 1
-	`, cidr).Scan(&id)
+		SELECT id FROM cidr_blocks WHERE cidr = ? AND network = ? LIMIT 1
+	`, cidr, network).Scan(&id)
 
 	if err == nil {
 		return true, nil

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -414,6 +414,75 @@ func TestStore_AddCIDR_Small(t *testing.T) {
 	}
 }
 
+func TestStore_GetCIDRBlockByCIDRAndNetwork(t *testing.T) {
+	logger := logr.Discard()
+	tempDir := t.TempDir()
+
+	dbPath := filepath.Join(tempDir, "get_cidr_network.sqlite")
+	s, err := NewStore(context.Background(), logger, dbPath)
+	if err != nil {
+		t.Fatalf("NewStore returned unexpected error: %v", err)
+	}
+	defer s.Close()
+
+	network1 := "network-1"
+	network2 := "network-2"
+	cidr := "10.10.0.0/24"
+
+	// Initially shouldn't exist in either network
+	exists, err := s.GetCIDRBlockByCIDRAndNetwork(context.Background(), cidr, network1)
+	if err != nil {
+		t.Fatalf("GetCIDRBlockByCIDRAndNetwork failed: %v", err)
+	}
+	if exists {
+		t.Error("Expected false for network1, got true")
+	}
+
+	// Add CIDR to network1
+	if err := s.AddCIDR(context.Background(), network1, cidr); err != nil {
+		t.Fatalf("AddCIDR failed for network1: %v", err)
+	}
+
+	// Should exist in network1, but not in network2
+	exists, err = s.GetCIDRBlockByCIDRAndNetwork(context.Background(), cidr, network1)
+	if err != nil {
+		t.Fatalf("GetCIDRBlockByCIDRAndNetwork failed for network1: %v", err)
+	}
+	if !exists {
+		t.Error("Expected true for network1, got false")
+	}
+
+	exists, err = s.GetCIDRBlockByCIDRAndNetwork(context.Background(), cidr, network2)
+	if err != nil {
+		t.Fatalf("GetCIDRBlockByCIDRAndNetwork failed for network2: %v", err)
+	}
+	if exists {
+		t.Error("Expected false for network2, got true")
+	}
+
+	// Add same CIDR to network2 (allowed since unique on cidr, network)
+	if err := s.AddCIDR(context.Background(), network2, cidr); err != nil {
+		t.Fatalf("AddCIDR failed for network2: %v", err)
+	}
+
+	// Now it should exist in both networks
+	exists, err = s.GetCIDRBlockByCIDRAndNetwork(context.Background(), cidr, network1)
+	if err != nil {
+		t.Fatalf("GetCIDRBlockByCIDRAndNetwork failed for network1: %v", err)
+	}
+	if !exists {
+		t.Error("Expected true for network1, got false")
+	}
+
+	exists, err = s.GetCIDRBlockByCIDRAndNetwork(context.Background(), cidr, network2)
+	if err != nil {
+		t.Fatalf("GetCIDRBlockByCIDRAndNetwork failed for network2: %v", err)
+	}
+	if !exists {
+		t.Error("Expected true for network2, got false")
+	}
+}
+
 func TestStore_AllocateIPv4_SingleCIDR(t *testing.T) {
 	logger := logr.Discard()
 	tempDir := t.TempDir()


### PR DESCRIPTION
* Scoped CIDR allocation checks: 
Refactored MaybeAddInitialPodCidr to query both the network and CIDR to support cases where multiple distinct networks share the same CIDR range.

* Schema Uniqueness Constraint Update: 
Replaced the individual UNIQUE constraints on cidr in the cidr_blocks table and address in the ip_addresses table with composite constraints (UNIQUE(cidr, network) and UNIQUE(address, cidr_block_id)), preventing state corruption when multi networking is enabled.


cc. @arvindbr8 @gnossen
cc. @zhaoqsh