### PR TITLE
fix: Ensure NodeLifecycleController has correct permissions

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -119,6 +119,9 @@ func main() {
 	}
 
 	controllerInitializers[names.CloudNodeLifecycleController] = app.ControllerInitFuncConstructor{
+		InitContext: app.ControllerInitContext{
+			ClientName: "node-controller",
+		},
 		Constructor: startCloudNodeLifecycleControllerWrapper,
 	}
 

--- a/cmd/cloud-controller-manager/nodelifecyclecontroller.go
+++ b/cmd/cloud-controller-manager/nodelifecyclecontroller.go
@@ -43,7 +43,7 @@ func startCloudNodeLifecycleController(ctx context.Context, initContext app.Cont
 	cloudNodeLifecycleController, err := nodelifecycle.NewCloudNodeLifecycleController(
 		filteringInformer,
 		// cloud node lifecycle controller uses existing cluster role from node-controller
-		completedConfig.ClientBuilder.ClientOrDie("cloud-node-lifecycle-controller"),
+		completedConfig.ClientBuilder.ClientOrDie(initContext.ClientName),
 		cloud,
 		completedConfig.ComponentConfig.KubeCloudShared.NodeMonitorPeriod.Duration,
 	)


### PR DESCRIPTION
This commit fixes a regression introduced in https://github.com/kubernetes/cloud-provider-gcp/pull/1081 where nodes could not be deleted after their underlying GCE instances were removed.

- Fixed a client identity mismatch in the NodeLifecycleController. It was using a incorrect client name instead of the configured `node-controller` identity in [cloud-provider](https://github.com/kubernetes/cloud-provider/blob/04a170344a61a9ebfe190a0d5cfdc2f9d92d26cc/app/controllermanager.go#L454), which lacks the necessary RBAC permissions for node deletion in GKE.

Tested:
1. Delete a GKE nodepool
   - Before the fix: the node object is still in the api-server
   - After this fix: the node object is removed