### PR TITLE
Remove unused debug data on token.

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/cred_test.go
+++ b/cmd/gke-gcloud-auth-plugin/cred_test.go
@@ -93,7 +93,7 @@ var (
 
 	baseCacheFileWithAuthzToken = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
-    "access_token": "iam-ya29.gcloud_t0k3n^authz-t0k3n",
+    "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
     "extra_args": ""
 }`
@@ -123,7 +123,7 @@ var (
 
 	wantCacheFileWithAuthzToken = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
-    "access_token": "iam-ya29.gcloud_t0k3n^authz-t0k3n",
+    "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
     "extra_args": ""
 }`
@@ -501,7 +501,7 @@ func TestExecCredential(t *testing.T) {
 					},
 				},
 			},
-			wantToken:     fakeExecCredential("iam-ya29.gcloud_t0k3n^authz-t0k3n", &metav1.Time{Time: newYears}),
+			wantToken:     fakeExecCredential("ya29.gcloud_t0k3n", &metav1.Time{Time: newYears}),
 			wantCacheFile: wantCacheFileWithAuthzToken,
 		},
 		{
@@ -545,7 +545,7 @@ func TestExecCredential(t *testing.T) {
 					},
 				},
 			},
-			wantToken:     fakeExecCredential("iam-ya29.gcloud_t0k3n^authz-t0k3n", &metav1.Time{Time: newYears}),
+			wantToken:     fakeExecCredential("ya29.gcloud_t0k3n", &metav1.Time{Time: newYears}),
 			wantCacheFile: wantCacheFileWithAuthzToken,
 		},
 		{
@@ -574,7 +574,7 @@ func TestExecCredential(t *testing.T) {
 					},
 				},
 			},
-			wantToken:     fakeExecCredential("iam-ya29.gcloud_t0k3n^authz-t0k3n", &metav1.Time{Time: newYears}),
+			wantToken:     fakeExecCredential("ya29.gcloud_t0k3n", &metav1.Time{Time: newYears}),
 			wantCacheFile: wantCacheFileWithAuthzToken,
 		},
 		{

--- a/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
+++ b/cmd/gke-gcloud-auth-plugin/gcloud_token_provider.go
@@ -63,19 +63,7 @@ func (p *gcloudTokenProvider) token() (string, *time.Time, error) {
 		return "", nil, fmt.Errorf("gcloud config config-helper returned an empty access token")
 	}
 
-	// Authorization Token File is not commonly used. Currently, this is for specific internal debugging scenarios.
-	token := gc.Credential.AccessToken
-	var authzTokenFile string
-	var authzTokenBytes []byte
-	if authzTokenFile = gc.Configuration.Properties.Auth.AuthorizationTokenFile; authzTokenFile != "" {
-		authzTokenBytes, err = p.readFile(authzTokenFile)
-		if err != nil {
-			return "", nil, fmt.Errorf("gcloud config sets property auth/authorization_token_file, but can't read file at %s: %w", authzTokenFile, err)
-		}
-		token = fmt.Sprintf("iam-%s^%s", token, authzTokenBytes)
-	}
-
-	return token, &gc.Credential.TokenExpiry, nil
+	return gc.Credential.AccessToken, &gc.Credential.TokenExpiry, nil
 }
 
 func (p *gcloudTokenProvider) useCache() bool {


### PR DESCRIPTION
Extraneous debug data on token is a potential security issue. 
Removing the extraneous data to prevent potential issue.