### PR TITLE
Ensure internal load balancer subnet annotations adhere to resource naming standards

### DIFF
--- a/providers/gce/gce_annotations.go
+++ b/providers/gce/gce_annotations.go
@@ -21,6 +21,7 @@ package gce
 
 import (
 	"fmt"
+	"regexp"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -106,10 +107,15 @@ const (
 	targetPoolKey = serviceStatusPrefix + "/" + targetPoolResource
 )
 
-var l4ResourceAnnotationKeys = []string{
-	backendServiceKey,
-	targetPoolKey,
-}
+var (
+	l4ResourceAnnotationKeys = []string{
+		backendServiceKey,
+		targetPoolKey,
+	}
+
+	// subnetworkRegexp validates that a subnetwork name follows standard GCP naming conventions.
+	subnetworkRegexp = regexp.MustCompile(`^[a-z]([-a-z0-9]*[a-z0-9])?$`)
+)
 
 // GetLoadBalancerAnnotationType returns the type of GCP load balancer which should be assembled.
 func GetLoadBalancerAnnotationType(service *v1.Service) LoadBalancerType {
@@ -192,6 +198,10 @@ func GetLoadBalancerAnnotationAllowGlobalAccess(service *v1.Service) bool {
 // GetLoadBalancerAnnotationSubnet returns the configured subnet to assign LoadBalancer IP from.
 func GetLoadBalancerAnnotationSubnet(service *v1.Service) string {
 	if val, exists := service.Annotations[ServiceAnnotationILBSubnet]; exists {
+		if len(val) > 63 || !subnetworkRegexp.MatchString(val) {
+			klog.Warningf("Annotation %q value %q contains invalid characters or exceeds 63 characters for a subnetwork name", ServiceAnnotationILBSubnet, val)
+			return ""
+		}
 		return val
 	}
 	return ""

--- a/providers/gce/gce_annotations_test.go
+++ b/providers/gce/gce_annotations_test.go
@@ -22,6 +22,7 @@ package gce
 import (
 	"maps"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -314,6 +315,90 @@ func TestComputeNewAnnotationsIfNeeded(t *testing.T) {
 					assert.True(t, reflect.DeepEqual(originalAnnotations, tc.svc.Annotations), "Original svc.Annotations instance should not change when no update is needed")
 				}
 			}
+		})
+	}
+}
+
+func TestGetLoadBalancerAnnotationSubnet(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		annotations    map[string]string
+		expectedSubnet string
+	}{
+		{
+			desc:           "no annotation",
+			annotations:    nil,
+			expectedSubnet: "",
+		},
+		{
+			desc: "valid standard subnet name",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "my-custom-subnet",
+			},
+			expectedSubnet: "my-custom-subnet",
+		},
+		{
+			desc: "valid subnet name ending in digit",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "subnet-123",
+			},
+			expectedSubnet: "subnet-123",
+		},
+		{
+			desc: "malformed path with dots and slashes",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "../../../other-project/regions/us-central1/subnetworks/other-subnet",
+			},
+			expectedSubnet: "",
+		},
+		{
+			desc: "invalid characters spaces",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "my subnet",
+			},
+			expectedSubnet: "",
+		},
+		{
+			desc: "invalid starting character",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "1-subnet",
+			},
+			expectedSubnet: "",
+		},
+		{
+			desc: "invalid uppercase character",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: "Subnet",
+			},
+			expectedSubnet: "",
+		},
+		{
+			desc: "exceeds 63 characters limit",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: strings.Repeat("a", 64),
+			},
+			expectedSubnet: "",
+		},
+		{
+			desc: "exactly 63 characters limit",
+			annotations: map[string]string{
+				ServiceAnnotationILBSubnet: strings.Repeat("a", 63),
+			},
+			expectedSubnet: strings.Repeat("a", 63),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			svc := &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-svc",
+					Namespace:   "test-ns",
+					Annotations: tc.annotations,
+				},
+			}
+			actual := GetLoadBalancerAnnotationSubnet(svc)
+			assert.Equal(t, tc.expectedSubnet, actual)
 		})
 	}
 }


### PR DESCRIPTION
### Description

This pull request introduces stricter validation for custom subnetwork names provided via the `networking.gke.io/internal-load-balancer-subnet` Service annotation. 

Currently, values specified in the annotation are extracted without standard formatting checks. To improve configuration reliability and ensure all downstream API requests conform to Google Compute Engine (GCE) specifications, this change validates the annotation value against standard GCE resource identifier rules (RFC1035) and maximum length limits using an allow-list regular expression.

If an annotation value contains malformed characters or sequences, a clear diagnostic warning is logged, and the controller gracefully defaults to standard subnetwork mapping behavior.

### Motivation and Context
- Enforces early validation to prevent sending malformed configuration strings to cloud APIs.
- Improves diagnostic clarity by warning users when their specified subnetwork identifiers do not follow standard GCP resource naming guidelines.

### Verification & Testing
- **Unit Tests**: Added comprehensive test cases in `TestGetLoadBalancerAnnotationSubnet` verifying standard valid names, boundary conditions, and explicit rejection of malformed strings.
- **Regression Testing**: Verified all existing tests in the GCE provider package pass successfully.
