### PR TITLE
Add additional input validation in Metis daemon

### DIFF
--- a/metis/pkg/daemon/daemon_server.go
+++ b/metis/pkg/daemon/daemon_server.go
@@ -76,6 +76,9 @@ func (s *adaptiveIpamServer) AllocatePodIP(ctx context.Context, req *adaptiveipa
 	var ipv4Alloc *adaptiveipam.PodIP
 	var err error
 	if req.Ipv4Config != nil {
+		if req.Ipv4Config.ContainerId == "" || req.Ipv4Config.InterfaceName == "" {
+			return nil, status.Error(codes.InvalidArgument, "container_id and interface_name must not be empty")
+		}
 		ipv4Alloc, err = s.allocateIPv4(ctx, req)
 		if err != nil {
 			return nil, err
@@ -173,6 +176,10 @@ func (s *adaptiveIpamServer) DeallocatePodIP(ctx context.Context, req *adaptivei
 		"interfaceName", req.InterfaceName,
 		"podName", req.PodName,
 		"podNamespace", req.PodNamespace)
+
+	if req.ContainerId == "" || req.InterfaceName == "" {
+		return nil, status.Error(codes.InvalidArgument, "container_id and interface_name must not be empty")
+	}
 
 	count, err := s.store.ReleaseIPByOwner(ctx, req.Network, req.ContainerId, req.InterfaceName, s.releaseCooldown)
 	if err != nil {

--- a/metis/pkg/daemon/daemon_server_test.go
+++ b/metis/pkg/daemon/daemon_server_test.go
@@ -463,3 +463,81 @@ func TestAdaptiveIpamServer_CheckPodIP(t *testing.T) {
 		t.Fatal("Expected non-nil response")
 	}
 }
+
+func TestAdaptiveIpamServer_AllocatePodIP_Validation(t *testing.T) {
+	server := &adaptiveIpamServer{}
+
+	tests := []struct {
+		name          string
+		containerID   string
+		interfaceName string
+	}{
+		{"empty both", "", ""},
+		{"empty container", "", "eth0"},
+		{"empty interface", "cont1", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &adaptiveipam.AllocatePodIPRequest{
+				Network:      "test-network",
+				PodName:      "test-pod",
+				PodNamespace: "default",
+				Ipv4Config: &adaptiveipam.IPConfig{
+					InterfaceName: tc.interfaceName,
+					ContainerId:   tc.containerID,
+				},
+			}
+
+			_, err := server.AllocatePodIP(context.Background(), req)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Expected gRPC status error, got: %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("Expected status code InvalidArgument, got %v", st.Code())
+			}
+		})
+	}
+}
+
+func TestAdaptiveIpamServer_DeallocatePodIP_Validation(t *testing.T) {
+	server := &adaptiveIpamServer{}
+
+	tests := []struct {
+		name          string
+		containerID   string
+		interfaceName string
+	}{
+		{"empty both", "", ""},
+		{"empty container", "", "eth0"},
+		{"empty interface", "cont1", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &adaptiveipam.DeallocatePodIPRequest{
+				Network:       "test-network",
+				InterfaceName: tc.interfaceName,
+				ContainerId:   tc.containerID,
+				PodName:       "test-pod",
+				PodNamespace:  "default",
+			}
+
+			_, err := server.DeallocatePodIP(context.Background(), req)
+			if err == nil {
+				t.Fatal("Expected error, got nil")
+			}
+			st, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Expected gRPC status error, got: %v", err)
+			}
+			if st.Code() != codes.InvalidArgument {
+				t.Errorf("Expected status code InvalidArgument, got %v", st.Code())
+			}
+		})
+	}
+}

--- a/metis/pkg/daemon/daemon_server_test.go
+++ b/metis/pkg/daemon/daemon_server_test.go
@@ -673,10 +673,14 @@ func TestAdaptiveIpamServer_AllocatePodIP_Validation(t *testing.T) {
 		name          string
 		containerID   string
 		interfaceName string
+		testIPv6      bool
 	}{
-		{"empty both", "", ""},
-		{"empty container", "", "eth0"},
-		{"empty interface", "cont1", ""},
+		{"ipv4 empty both", "", "", false},
+		{"ipv4 empty container", "", "eth0", false},
+		{"ipv4 empty interface", "cont1", "", false},
+		{"ipv6 empty both", "", "", true},
+		{"ipv6 empty container", "", "eth0", true},
+		{"ipv6 empty interface", "cont1", "", true},
 	}
 
 	for _, tc := range tests {
@@ -685,10 +689,17 @@ func TestAdaptiveIpamServer_AllocatePodIP_Validation(t *testing.T) {
 				Network:      "test-network",
 				PodName:      "test-pod",
 				PodNamespace: "default",
-				Ipv4Config: &adaptiveipam.IPConfig{
+			}
+			if tc.testIPv6 {
+				req.Ipv6Config = &adaptiveipam.IPConfig{
 					InterfaceName: tc.interfaceName,
 					ContainerId:   tc.containerID,
-				},
+				}
+			} else {
+				req.Ipv4Config = &adaptiveipam.IPConfig{
+					InterfaceName: tc.interfaceName,
+					ContainerId:   tc.containerID,
+				}
 			}
 
 			_, err := server.AllocatePodIP(context.Background(), req)


### PR DESCRIPTION
This PR adds additional input validation in the Metis daemon to improve robustness.

## Changes
- Added validation for required fields in `AllocatePodIP` and `DeallocatePodIP` requests.
- Added unit tests to verify the validation logic.


cc: @YifeiZhuang @gnossen