### PR TITLE
metis/daemon: restrict Unix domain socket permissions

### DIFF
--- a/metis/pkg/daemon/daemon_server.go
+++ b/metis/pkg/daemon/daemon_server.go
@@ -233,6 +233,12 @@ func (s *adaptiveIpamServer) start() error {
 	}
 	defer listener.Close()
 
+	// Explicitly restrict socket permissions to owner-only (0600) to prevent
+	// unauthorized local processes from interacting with the daemon.
+	if err := os.Chmod(sockPath, 0600); err != nil {
+		return fmt.Errorf("failed to set permissions on socket %s: %w", sockPath, err)
+	}
+
 	s.grpcServer = grpc.NewServer()
 	adaptiveipam.RegisterAdaptiveIpamServer(s.grpcServer, s)
 


### PR DESCRIPTION
### Description

This PR explicitly restricts the file permissions of the Metis IPAM daemon's Unix domain socket to `0600` (read/write for the owner only) immediately after creation.

### Why is this change needed?

Currently, the Unix domain socket is created without explicit permission overrides, meaning its permissions are determined entirely by the active system `umask`. In environments with a permissive default `umask`, the socket file could be created with read/write permissions for other unprivileged local users or containers on the node.

Since the Metis daemon performs privileged IPAM allocations, allowing unprivileged local processes to interact with the socket presents a security risk. 

Restricting the socket to `0600` ensures that:
1. The daemon (owner) can read/write to the socket.
2. Host-level privileged processes (like the CNI plugin executed by `kubelet` as `root`) can still access it.
3. Unprivileged local users and processes are blocked.

cc: @YifeiZhuang @gnossen