### PR TITLE
metis/store: use Unix epoch milliseconds for all database timestamps

### DIFF
--- a/metis/pkg/store/schema.sql
+++ b/metis/pkg/store/schema.sql
@@ -32,11 +32,11 @@ CREATE TABLE IF NOT EXISTS cidr_blocks (
     -- Expected values: 'Ready', 'Draining', 'Deleting'
     state TEXT NOT NULL DEFAULT 'Ready',
 
-    -- Timestamp of when this block was successfully pulled from the CRD.
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- Unix epoch timestamp in milliseconds when this block was successfully pulled from the CRD.
+    created_at INTEGER DEFAULT (CAST(unixepoch('subsec') * 1000 AS INTEGER)),
 
-    -- Timestamp of the last mutation to this block's state or capacity.
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- Unix epoch timestamp in milliseconds of the last mutation to this block's state or capacity.
+    updated_at INTEGER DEFAULT (CAST(unixepoch('subsec') * 1000 AS INTEGER)),
 
     UNIQUE(cidr, network)
 );
@@ -72,15 +72,15 @@ CREATE TABLE IF NOT EXISTS ip_addresses (
     -- Represents whether the IP is currently held by an active pod.
     is_allocated BOOLEAN DEFAULT FALSE,
 
-    -- Timestamp indicating when a released IP has finished its "cool-down" 
-    -- period and is safe to be reassigned without risking NEG routing collisions.
-    release_at TIMESTAMP, 
+    -- Unix epoch timestamp in milliseconds indicating when a released IP has 
+    -- finished its "cool-down" period and is safe to be reassigned.
+    release_at INTEGER, 
 
-    -- Timestamp of when the IP was assigned to its current container_id.
-    allocated_at TIMESTAMP,
+    -- Unix epoch timestamp in milliseconds when the IP was assigned to its current container_id.
+    allocated_at INTEGER,
 
-    -- Timestamp of the last mutation to this IP record.
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    -- Unix epoch timestamp in milliseconds of the last mutation to this IP record.
+    updated_at INTEGER DEFAULT (CAST(unixepoch('subsec') * 1000 AS INTEGER)),
 
     FOREIGN KEY (cidr_block_id) REFERENCES cidr_blocks(id) ON DELETE CASCADE,
     UNIQUE(address, cidr_block_id)
@@ -98,11 +98,11 @@ CREATE INDEX IF NOT EXISTS idx_ip_idempotency
 -- Automatically update the updated_at timestamp on cidr_blocks mutations.
 CREATE TRIGGER IF NOT EXISTS update_cidr_blocks_updated_at
     AFTER UPDATE ON cidr_blocks FOR EACH ROW BEGIN
-    UPDATE cidr_blocks SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+    UPDATE cidr_blocks SET updated_at = CAST(unixepoch('subsec') * 1000 AS INTEGER) WHERE id = OLD.id;
     END;
 
 -- Automatically update the updated_at timestamp on ip_addresses mutations.
 CREATE TRIGGER IF NOT EXISTS update_ip_addresses_updated_at
     AFTER UPDATE ON ip_addresses FOR EACH ROW BEGIN
-        UPDATE ip_addresses SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
+        UPDATE ip_addresses SET updated_at = CAST(unixepoch('subsec') * 1000 AS INTEGER) WHERE id = OLD.id;
     END;

--- a/metis/pkg/store/store.go
+++ b/metis/pkg/store/store.go
@@ -117,7 +117,9 @@ func NewStore(ctx context.Context, log logr.Logger, dbPath string) (*Store, erro
 		// performance than FULL mode, sacrificing only a few milliseconds of
 		// un-checkpointed durability.
 		// See: https://www.sqlite.org/pragma.html#pragma_synchronous
-		"&_synchronous=1"
+		"&_synchronous=1" +
+		// Force UTC timezone location for standard time.Time mappings.
+		"&_loc=UTC"
 
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
@@ -396,7 +398,7 @@ func (s *Store) ReleaseIPByOwner(ctx context.Context, network, containerID, inte
 
 	var releaseAt interface{}
 	if releaseCooldown > 0 {
-		releaseAt = time.Now().Add(releaseCooldown)
+		releaseAt = time.Now().UTC().Add(releaseCooldown)
 	} else {
 		releaseAt = nil
 	}

--- a/metis/pkg/store/store.go
+++ b/metis/pkg/store/store.go
@@ -480,7 +480,7 @@ func (s *Store) allocateIPTx(ctx context.Context, tx *sql.Tx, cidrBlockID int64,
 		SET is_allocated = TRUE, container_id = ?, interface_name = ?, allocated_at = CURRENT_TIMESTAMP 
 		WHERE id = (
 			SELECT id FROM ip_addresses 
-			WHERE cidr_block_id = ? AND is_allocated = FALSE AND (release_at IS NULL OR release_at <= CURRENT_TIMESTAMP)
+			WHERE cidr_block_id = ? AND is_allocated = FALSE AND (release_at IS NULL OR julianday(release_at) <= julianday('now'))
 			ORDER BY id ASC
 			LIMIT 1
 		)

--- a/metis/pkg/store/store.go
+++ b/metis/pkg/store/store.go
@@ -37,7 +37,7 @@ var schemaSQL string
 const (
 	// dbSchemaVersion tracks the SQLite schema version to allow safe local
 	// migrations and prevent state corruption across daemon restarts.
-	dbSchemaVersion = 1
+	dbSchemaVersion = 4
 	maxOpenConns    = 10
 	maxIdleConns    = 10
 	// DefaultBusyTimeout is the default timeout for SQLite busy handler.
@@ -398,7 +398,7 @@ func (s *Store) ReleaseIPByOwner(ctx context.Context, network, containerID, inte
 
 	var releaseAt interface{}
 	if releaseCooldown > 0 {
-		releaseAt = time.Now().UTC().Add(releaseCooldown)
+		releaseAt = time.Now().UTC().Add(releaseCooldown).UnixMilli()
 	} else {
 		releaseAt = nil
 	}
@@ -475,17 +475,18 @@ func (s *Store) allocateIPTx(ctx context.Context, tx *sql.Tx, cidrBlockID int64,
 
 	// 2. Find the first available entry and mark it as allocated
 	var address string
+	nowMilli := time.Now().UTC().UnixMilli()
 	err = tx.QueryRowContext(ctx, `
 		UPDATE ip_addresses 
-		SET is_allocated = TRUE, container_id = ?, interface_name = ?, allocated_at = CURRENT_TIMESTAMP 
+		SET is_allocated = TRUE, container_id = ?, interface_name = ?, allocated_at = ? 
 		WHERE id = (
 			SELECT id FROM ip_addresses 
-			WHERE cidr_block_id = ? AND is_allocated = FALSE AND (release_at IS NULL OR julianday(release_at) <= julianday('now'))
+			WHERE cidr_block_id = ? AND is_allocated = FALSE AND (release_at IS NULL OR release_at <= ?)
 			ORDER BY id ASC
 			LIMIT 1
 		)
 		RETURNING address
-	`, containerID, interfaceName, cidrBlockID).Scan(&address)
+	`, containerID, interfaceName, nowMilli, cidrBlockID, nowMilli).Scan(&address)
 
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/metis/pkg/store/store.go
+++ b/metis/pkg/store/store.go
@@ -37,7 +37,7 @@ var schemaSQL string
 const (
 	// dbSchemaVersion tracks the SQLite schema version to allow safe local
 	// migrations and prevent state corruption across daemon restarts.
-	dbSchemaVersion = 4
+	dbSchemaVersion = 1
 	maxOpenConns    = 10
 	maxIdleConns    = 10
 	// DefaultBusyTimeout is the default timeout for SQLite busy handler.
@@ -117,9 +117,7 @@ func NewStore(ctx context.Context, log logr.Logger, dbPath string) (*Store, erro
 		// performance than FULL mode, sacrificing only a few milliseconds of
 		// un-checkpointed durability.
 		// See: https://www.sqlite.org/pragma.html#pragma_synchronous
-		"&_synchronous=1" +
-		// Force UTC timezone location for standard time.Time mappings.
-		"&_loc=UTC"
+		"&_synchronous=1"
 
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -1455,12 +1455,12 @@ func TestStore_ReleaseIP_TimezoneRobustness(t *testing.T) {
 		t.Fatalf("AllocateIP failed: %v", err)
 	}
 
-	// Release IP with 2-second cooldown.
+	// Release IP with 1-second cooldown.
 	// Since TZ is America/Los_Angeles, the local time is 7-8 hours behind UTC.
 	// If there is a timezone bug, SQLite's raw CURRENT_TIMESTAMP will compare
 	// a future local time string against a larger current UTC time string,
 	// causing the cooldown to be immediately bypassed!
-	cooldownDuration := 2 * time.Second
+	cooldownDuration := 1 * time.Second
 	count, err := s.ReleaseIPByOwner(context.Background(), network, containerID, interfaceName, cooldownDuration)
 	if err != nil {
 		t.Fatalf("ReleaseIPByOwner failed: %v", err)

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -701,7 +701,7 @@ func TestStore_ReleaseIPByOwner(t *testing.T) {
 	}
 
 	var isAlloc bool
-	var releaseAt sql.NullTime
+	var releaseAt sql.NullInt64
 	err = s.db.QueryRow("SELECT is_allocated, release_at FROM ip_addresses WHERE address = ?", ip).Scan(&isAlloc, &releaseAt)
 	if err != nil {
 		t.Fatalf("QueryRow failed for IP status: %v", err)
@@ -709,7 +709,7 @@ func TestStore_ReleaseIPByOwner(t *testing.T) {
 	if isAlloc {
 		t.Error("Expected IP to be unallocated")
 	}
-	if !releaseAt.Valid || releaseAt.Time.IsZero() {
+	if !releaseAt.Valid || releaseAt.Int64 == 0 {
 		t.Error("Expected release_at to be valid and non-zero")
 	}
 }

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -709,8 +709,8 @@ func TestStore_ReleaseIPByOwner(t *testing.T) {
 	if isAlloc {
 		t.Error("Expected IP to be unallocated")
 	}
-	if !releaseAt.Valid {
-		t.Error("Expected release_at to be valid")
+	if !releaseAt.Valid || releaseAt.Time.IsZero() {
+		t.Error("Expected release_at to be valid and non-zero")
 	}
 }
 

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -21,6 +21,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -1409,3 +1410,99 @@ func TestStore_CheckAllocation(t *testing.T) {
 		t.Error("Expected error for wrong interface name, got nil")
 	}
 }
+
+func TestStore_ReleaseIP_TimezoneRobustness(t *testing.T) {
+	// 1. Save original TZ and local location
+	origTZ := os.Getenv("TZ")
+	origLocal := time.Local
+	defer func() {
+		os.Setenv("TZ", origTZ)
+		time.Local = origLocal
+	}()
+
+	// 2. Force timezone to be America/Los_Angeles (UTC-7 / UTC-8, i.e., behind UTC)
+	os.Setenv("TZ", "America/Los_Angeles")
+	time.Local = nil // Force Go to reload timezone location from TZ env
+
+	logger := logr.Discard()
+	tempDir := t.TempDir()
+	dbPath := filepath.Join(tempDir, "timezone_test.sqlite")
+
+	s, err := NewStore(context.Background(), logger, dbPath)
+	if err != nil {
+		t.Fatalf("NewStore failed: %v", err)
+	}
+	defer s.Close()
+
+	network := "timezone-network"
+	cidr := "10.0.1.0/24"
+
+	if err := s.AddCIDR(context.Background(), network, cidr); err != nil {
+		t.Fatalf("AddCIDR failed: %v", err)
+	}
+
+	containerID := "tz-container"
+	interfaceName := "eth0"
+
+	// Allocate first (should get 10.0.1.2)
+	ip, _, err := s.AllocateIP(context.Background(), AllocateIPParams{
+		Network:       network,
+		InterfaceName: interfaceName,
+		ContainerID:   containerID,
+		IPFamily:      IPv4,
+	})
+	if err != nil {
+		t.Fatalf("AllocateIP failed: %v", err)
+	}
+
+	// Release IP with 2-second cooldown.
+	// Since TZ is America/Los_Angeles, the local time is 7-8 hours behind UTC.
+	// If there is a timezone bug, SQLite's raw CURRENT_TIMESTAMP will compare
+	// a future local time string against a larger current UTC time string,
+	// causing the cooldown to be immediately bypassed!
+	cooldownDuration := 2 * time.Second
+	count, err := s.ReleaseIPByOwner(context.Background(), network, containerID, interfaceName, cooldownDuration)
+	if err != nil {
+		t.Fatalf("ReleaseIPByOwner failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("Expected 1 released IP, got %d", count)
+	}
+
+	// Attempt to immediately allocate for a NEW container.
+	// It should NOT pick the same IP because it's under active cooldown.
+	// Since we have other IPs in the block, it should allocate the next one (10.0.1.3).
+	ipNew, _, err := s.AllocateIP(context.Background(), AllocateIPParams{
+		Network:       network,
+		InterfaceName: interfaceName,
+		ContainerID:   "tz-new-container",
+		IPFamily:      IPv4,
+	})
+	if err != nil {
+		t.Fatalf("AllocateIP failed for new container: %v", err)
+	}
+
+	if ipNew == ip {
+		t.Errorf("BUG: Cooldown was bypassed! Allocated same IP %s immediately while still in cooldown.", ip)
+	}
+
+	// Wait for cooldown to expire
+	time.Sleep(cooldownDuration + 500*time.Millisecond)
+
+	// Now allocate again for another container. Since the first IP has finished its cooldown,
+	// and SQLite query uses ORDER BY id ASC, it should reuse the cooled-down IP (10.0.1.2)!
+	ipReuse, _, err := s.AllocateIP(context.Background(), AllocateIPParams{
+		Network:       network,
+		InterfaceName: interfaceName,
+		ContainerID:   "tz-reuse-container",
+		IPFamily:      IPv4,
+	})
+	if err != nil {
+		t.Fatalf("AllocateIP failed after cooldown: %v", err)
+	}
+
+	if ipReuse != ip {
+		t.Errorf("Expected IP to be reused after cooldown expired, got %s instead of %s", ipReuse, ip)
+	}
+}
+

--- a/metis/pkg/store/store_test.go
+++ b/metis/pkg/store/store_test.go
@@ -1505,4 +1505,3 @@ func TestStore_ReleaseIP_TimezoneRobustness(t *testing.T) {
 		t.Errorf("Expected IP to be reused after cooldown expired, got %s instead of %s", ipReuse, ip)
 	}
 }
-


### PR DESCRIPTION
## Problem
The IPAM store previously stored timestamps (`release_at`, `allocated_at`, `created_at`, `updated_at`) as `TIMESTAMP` string fields in SQLite. This design introduced some critical challenges.

Go's `time.Time` driver mappings write high-precision ISO8601 strings with a timezone suffix (e.g., `"2026-05-21T00:57:13.905476552Z"`), whereas SQLite's native `CURRENT_TIMESTAMP` yields `"YYYY-MM-DD HH:MM:SS"`. String comparisons (e.g. `release_at <= CURRENT_TIMESTAMP`) fail lexicographically because of formatting mismatches (such as the presence of the `"T"` character).

Also, differences between the host OS timezones, Go's local location settings, and raw SQLite datetime functions made comparisons error-prone.

## Solution
Migrate all timestamps in the database and application logic to store **Unix epoch milliseconds** (`INTEGER`). This standardizes all timestamps as simple, timezone-agnostic integers, allowing trivial numeric comparisons at high precision.
