### PR TITLE
IPAM: Fix index out of range panic in extractDefaultNwCIDRs

### DIFF
--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -170,7 +170,7 @@ out:
 	for _, inf := range interfaces {
 		// extra the subnetwork name from the URL
 		parts := strings.Split(inf.Subnetwork, "/subnetworks/")
-		if parts[1] != defaultSubnet {
+		if len(parts) < 2 || parts[1] != defaultSubnet {
 			continue
 		}
 		for _, ipRange := range inf.AliasIpRanges {

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
+	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/cloud-provider-gcp/pkg/controller/testutil"
+	"k8s.io/cloud-provider-gcp/providers/gce"
 )
 
 const (
@@ -414,5 +416,30 @@ func TestGetUpNetworks(t *testing.T) {
 				t.Errorf("expected %v, but got %v", test.expected, result)
 			}
 		})
+	}
+}
+
+func TestExtractDefaultNwCIDRs(t *testing.T) {
+	ca := &cloudCIDRAllocator{
+		cloud: &gce.Cloud{},
+	}
+	interfaces := []*compute.NetworkInterface{
+		{
+			Subnetwork: "invalid-subnetwork-url",
+		},
+		{
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/default",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					SubnetworkRangeName: "RangeA",
+					IpCidrRange:         "10.0.0.0/24",
+				},
+			},
+		},
+	}
+	// This should not panic and should successfully ignore the invalid subnetwork URL and extract default CIDR
+	res := ca.extractDefaultNwCIDRs(interfaces, "default", "RangeA")
+	if len(res) != 1 || res[0] != "10.0.0.0/24" {
+		t.Errorf("Expected [10.0.0.0/24], got %v", res)
 	}
 }


### PR DESCRIPTION
# Description
Fixes a potential `index out of range` panic in `extractDefaultNwCIDRs` in `multinetwork_cloud_cidr_allocator.go`. 

## Problem
When splitting the subnetwork URL from a network interface using `strings.Split(inf.Subnetwork, "/subnetworks/")`, the code directly accessed `parts[1]` without checking the length of the resulting slice. If a network interface has an empty, malformed, or invalid subnetwork URL, this results in a runtime panic.

## Solution
Add a safety check to verify `len(parts) >= 2` before accessing index `1` to safely skip invalid subnetworks. 

## Verification
- Added a unit test `TestExtractDefaultNwCIDRs` in `multinetwork_cloud_cidr_allocator_test.go` validating that `extractDefaultNwCIDRs` safely ignores invalid/malformed subnetwork URLs without panicking and successfully processes valid ones.


cc: @YifeiZhuang @gnossen