### PR TITLE
gnp: anchor NetworkAttachment validation regular expression

### DIFF
--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -638,6 +638,22 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			},
 		},
 		{
+			name: "GNP with NetworkAttachment - malformed identifier (unanchored bypass attempt)",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: gkeNetworkParamSetName,
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					NetworkAttachment: "malicious-prefix/projects/test-project/regions/test-region/networkAttachments/testAttachment/malicious-suffix",
+				},
+			},
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "NetworkAttachmentInvalid",
+			},
+		},
+		{
 			name: "GNP with NetworkAttachment - bad format",
 			paramSet: &networkv1.GKENetworkParamSet{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -35,7 +35,7 @@ import (
 var (
 	// networkAttachmentRE enforces the network attachment format to match
 	// projects/PROJECT_ID/regions/REGION/networkAttachments/NETWORK_ATTACHMENT
-	networkAttachmentRE = regexp.MustCompile(`projects/([^/]+)/regions/([^/]+)/networkAttachments/([^/]+)`)
+	networkAttachmentRE = regexp.MustCompile(`^projects/([^/]+)/regions/([^/]+)/networkAttachments/([^/]+)$`)
 )
 
 type gnpValidation struct {


### PR DESCRIPTION
Add start (^) and end ($) anchors to the NetworkAttachment format validation regular expression.

Bypassing the network attachment format validation allowed malformed identifiers to persist in the cluster state. If downstream GCP controllers or automation scripts consume this NetworkAttachment field under the assumption that it's strictly a valid path, it can lead to logical failures or other vulnerabilities.

A new test case has been added to verify that malformed identifiers are now correctly rejected.

Fixes cluster-10822

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).