### PR TITLE
Sanitize GIT_VERSION in Makefiles to prevent shell injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 LOCAL_BIN := $(PROJECT_DIR)/bin
 GCP_PROJECT ?= $(shell gcloud config get-value project)
 
-GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||')
+GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||' | tr -cd '[:alnum:].-')
 GIT_COMMIT := $(shell git rev-parse HEAD)
 BUILD_DATE := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 BUCKET_NAME ?= k8s-staging-cloud-provider-gcp

--- a/metis/Makefile
+++ b/metis/Makefile
@@ -10,7 +10,7 @@ OCI_TARBALL_PATH ?= metis.tar
 ADDITIONAL_IMAGE_TAGS ?=
 
 # Version metadata strictly computed by the internal repository state
-GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||')
+GIT_VERSION := $(shell git describe --tags --always --dirty | sed 's|.*/||' | tr -cd '[:alnum:].-')
 GIT_COMMIT  := $(shell git rev-parse HEAD)
 BUILD_DATE  := $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 


### PR DESCRIPTION
The PR involves adding a sanitization step to the GIT_VERSION variable definition using `tr -cd '[:alnum:].-'` to strip any characters that are not alphanumeric, dots, or hyphens.

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).