### PR TITLE
kops: verify GCS bucket ownership to prevent bucket squatting

### DIFF
--- a/tools/kops/pkg/kops/gcp.go
+++ b/tools/kops/pkg/kops/gcp.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -34,16 +35,43 @@ func EnsureStateStore(c *Config) error {
 
 	fmt.Printf("Ensuring KOPS_STATE_STORE exists: %s\n", c.StateStore)
 
-	// Check if bucket exists
-	lsCmd := exec.Command("gsutil", "ls", "-p", c.GCPProject, c.StateStore)
-	if err := lsCmd.Run(); err != nil {
-		// Assume it doesn't exist, try to create it
+	// Get expected project number for ownership verification
+	var expectedProjNum string
+	if c.GCPProject != "" {
+		var err error
+		expectedProjNum, err = getProjectNumber(c.GCPProject)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Check if bucket exists and verify ownership
+	lsCmd := exec.Command("gsutil", "ls", "-L", "-b", c.StateStore)
+	lsOutput, err := lsCmd.CombinedOutput()
+	if err != nil {
+		// Assume it doesn't exist (or is not accessible), try to create it
 		fmt.Printf("Bucket %s does not exist, creating...\n", c.StateStore)
 		mbCmd := exec.Command("gsutil", "mb", "-p", c.GCPProject, "-l", c.GCPLocation, c.StateStore)
 		mbCmd.Stdout = os.Stdout
 		mbCmd.Stderr = os.Stderr
 		if err := mbCmd.Run(); err != nil {
 			return fmt.Errorf("failed to create bucket: %v", err)
+		}
+	} else if expectedProjNum != "" {
+		// Bucket exists, verify ownership
+		actualProjNum := ""
+		for _, line := range strings.Split(string(lsOutput), "\n") {
+			if strings.Contains(line, "Project number:") {
+				parts := strings.Split(line, ":")
+				if len(parts) > 1 {
+					actualProjNum = strings.TrimSpace(parts[1])
+					break
+				}
+			}
+		}
+
+		if actualProjNum != "" && actualProjNum != expectedProjNum {
+			return fmt.Errorf("bucket %s exists but is owned by another project (project number: %s, expected: %s). This may be a bucket squatting attack.", c.StateStore, actualProjNum, expectedProjNum)
 		}
 	}
 
@@ -80,6 +108,19 @@ func EnsureStateStore(c *Config) error {
 	}
 
 	return nil
+}
+
+// getProjectNumber returns the project number for a given project ID or number.
+func getProjectNumber(projectID string) (string, error) {
+	if _, err := strconv.ParseUint(projectID, 10, 64); err == nil {
+		return projectID, nil
+	}
+	projNumCmd := exec.Command("gcloud", "projects", "describe", projectID, "--format", "value(projectNumber)")
+	projNumBytes, err := projNumCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project number for %s: %v", projectID, err)
+	}
+	return strings.TrimSpace(string(projNumBytes)), nil
 }
 
 // EnsureSSHKey ensures that an SSH key exists for kOps.

--- a/tools/kops/pkg/kops/gcp.go
+++ b/tools/kops/pkg/kops/gcp.go
@@ -71,7 +71,7 @@ func EnsureStateStore(c *Config) error {
 		}
 
 		if actualProjNum != "" && actualProjNum != expectedProjNum {
-			return fmt.Errorf("bucket %s exists but is owned by another project (project number: %s, expected: %s). This may be a bucket squatting attack.", c.StateStore, actualProjNum, expectedProjNum)
+			return fmt.Errorf("bucket %s exists but is owned by another project (project number: %s, expected: %s): this may be a bucket squatting attack", c.StateStore, actualProjNum, expectedProjNum)
 		}
 	}
 


### PR DESCRIPTION
This PR adds a check to EnsureStateStore to verify that the GCS bucket used for kOps state is owned by the expected GCP project.

### Design Decisions
- **Ownership Verification**: Instead of just checking if the bucket exists, we now use `gsutil ls -L -b` to get the bucket metadata and parse the "Project number" field.
- **Project Resolution**: We resolve the configured GCP Project ID to its Project Number using `gcloud projects describe` to ensure a reliable comparison.
- **Fail-Safe**: If the bucket exists but the project number doesn't match, we return an error. This prevents the tool from proceeding with a potentially compromised state store.
- **Consistency**: We continue to use `gsutil` and `gcloud` CLI tools, matching the established patterns in the kops sub-package.

Fixes cluster-12237

This PR was generated by **Overseer** (powered by the gemini-3-flash-preview model).