### PR TITLE
fix(e2e): use correct GOPATH subdirectory for cloud-provider-gcp

### DIFF
--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest-with-gcepd.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-cd $GOPATH/src/cloud-provider-gcp
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX='\[Conformance\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-conformance-latest.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-cd $GOPATH/src/cloud-provider-gcp
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX='\[Conformance\]'

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-cd $GOPATH/src/cloud-provider-gcp
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX="" # Run all non-skipped tests

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-kubernetes-master.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-cd $GOPATH/src/cloud-provider-gcp
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX="" # Run all non-skipped tests

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
@@ -20,7 +20,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-cd $GOPATH/src/cloud-provider-gcp
+cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX="" # Run all non-skipped tests


### PR DESCRIPTION
This commit fixes the periodic scripts to use the correct path, resolving "No such file or directory" errors during execution.