### PR TITLE
fix(metis/makefile): create tagless OCI archives

### DIFF
--- a/metis/Makefile
+++ b/metis/Makefile
@@ -97,7 +97,6 @@ build-tarball: init-buildx ## Build the multi-arch image as an OCI tarball.
 	@echo "Building OCI tarball for multi-arch image: $(IMAGE_NAME)..."
 	docker buildx build --platform $(ALL_PLATFORMS) \
 		$(DOCKER_BUILD_ARGS) \
-		$(DOCKER_TAG_ARGS) \
 		--output=type=oci,dest=$(OCI_TARBALL_PATH) \
 		--provenance=false \
 		--sbom=false .


### PR DESCRIPTION
This PR fixes the build-tarball target in the metis/Makefile to create tagless OCI archives. This resolves a critical build issue where tagged OCI archives caused a `found loop in OCI Index` error in Cloud Build.

cc: @YifeiZhuang @gnossen