### PR TITLE
fix flaky test TestNodeTopologyCR_DeleteNode

### DIFF
--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -334,6 +334,16 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 	defer close(stopCh)
 	fakeInformerFactory.Start(stopCh)
 	go cloudAllocator.Run(stopCh)
+
+	// Wait for default node to be processed and default subnet to be added to CR.
+	// This avoids race condition with adding mscnode concurrently.
+	if err := wait.PollImmediate(time.Millisecond*500, wait.ForeverTestTimeout, func() (bool, error) {
+		ok, _ := verifySubnetsInCR(t, []string{"subnet-def"}, nodeTopologyClient)
+		return ok, nil
+	}); err != nil {
+		t.Fatalf("Failed to wait for default subnet in CR: %v", err)
+	}
+
 	mscnode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "testNode",


### PR DESCRIPTION

### Description
This PR fixes a flakiness issue in `TestNodeTopologyCR_DeleteNode` caused by a race condition between concurrent workers updating the status of the same `NodeTopology` custom resource in a test environment using a fake client.

### Root Cause
The test `TestNodeTopologyCR_DeleteNode` in [cloud_cidr_allocator_test.go](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go) was failing intermittently with a timeout.

The allocator starts 30 parallel workers for the `nodeTopologyQueue`. The test enqueues two nodes (`nodeTopologyDefautNode` and `testNode`) almost simultaneously. Both workers try to update the status of the single "default" `NodeTopology` CR.
1. Worker A (processing `nodeTopologyDefautNode`) reads the CR status (empty), and prepares to write `["subnet-def"]`.
2. Worker B (processing `testNode`) reads the CR status (empty), and prepares to write `["subnet-def", "subnet1"]`.
3. In a real cluster, the API server would return a conflict error (409) to whichever worker writes second, forcing a retry.
4. In the test environment, the `fakeClient` does not enforce resource versions. The last writer simply overwrites the previous update without error.
5. If Worker A writes last, it removes `"subnet1"` added by Worker B. The test then times out waiting for `"subnet1"` to appear.

### Sample Failure
[prow job](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/cloud-provider-gcp/1151/cloud-provider-gcp-tests/2057506728324370432)
```
cloud_cidr_allocator_test.go:355: Add node topology CR not working as expected: timed out waiting for the condition
--- FAIL: TestNodeTopologyCR_DeleteNode (30.00s)
```

### Solution
Added a wait for the default subnet (`subnet-def`) to be present in the `NodeTopology` CR before adding the second node (`testNode`). This ensures that Worker A finishes its update before Worker B starts, eliminating the race condition in the test environment.

### Verification
Verified by running the test 10 times. All runs passed successfully without flakes.
