### PR TITLE
Only notify about mixed protocol support for owned LBs

### DIFF
--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -166,29 +166,6 @@ func (g *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, svc 
 		return nil, err
 	}
 
-	// Services with multiples protocols are not supported by this controller, warn the users and sets
-	// the corresponding Service Status Condition.
-	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1435-mixed-protocol-lb
-	if err := checkMixedProtocol(svc.Spec.Ports); err != nil {
-		if hasLoadBalancerPortsError(svc) {
-			return nil, err
-		}
-		klog.Warningf("Ignoring service %s/%s using different ports protocols", svc.Namespace, svc.Name)
-		g.eventRecorder.Event(svc, v1.EventTypeWarning, v1.LoadBalancerPortsErrorReason, "LoadBalancers with multiple protocols are not supported.")
-		svcApplyStatus := corev1apply.ServiceStatus().WithConditions(
-			metav1apply.Condition().
-				WithType(v1.LoadBalancerPortsError).
-				WithStatus(metav1.ConditionTrue).
-				WithReason(v1.LoadBalancerPortsErrorReason).
-				WithLastTransitionTime(metav1.Now()).
-				WithMessage("LoadBalancer with multiple protocols are not supported"))
-		svcApply := corev1apply.Service(svc.Name, svc.Namespace).WithStatus(svcApplyStatus)
-		if _, errApply := g.client.CoreV1().Services(svc.Namespace).ApplyStatus(ctx, svcApply, metav1.ApplyOptions{FieldManager: "gce-cloud-controller", Force: true}); errApply != nil {
-			return nil, errApply
-		}
-		return nil, err
-	}
-
 	klog.V(4).Infof("EnsureLoadBalancer(%v, %v, %v, %v, %v): ensure %v loadbalancer", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, desiredScheme)
 
 	existingFwdRule, err := g.GetRegionForwardingRule(loadBalancerName, g.region)
@@ -282,7 +259,6 @@ func servicePatchBytes(oldSvc, newSvc *v1.Service) ([]byte, error) {
 		return nil, fmt.Errorf("failed to CreateTwoWayMergePatch for svc %s/%s: %v", oldSvc.Namespace, oldSvc.Name, err)
 	}
 	return patchBytes, nil
-
 }
 
 // UpdateLoadBalancer is an implementation of LoadBalancer.UpdateLoadBalancer.
@@ -300,26 +276,6 @@ func (g *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, svc 
 	clusterID, err := g.ClusterID.GetID()
 	if err != nil {
 		return err
-	}
-
-	// Services with multiples protocols are not supported by this controller, warn the users and sets
-	// the corresponding Service Status Condition, but keep processing the Update to not break upgrades.
-	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1435-mixed-protocol-lb
-	if err := checkMixedProtocol(svc.Spec.Ports); err != nil && !hasLoadBalancerPortsError(svc) {
-		klog.Warningf("Ignoring update for service %s/%s using different ports protocols", svc.Namespace, svc.Name)
-		g.eventRecorder.Event(svc, v1.EventTypeWarning, v1.LoadBalancerPortsErrorReason, "LoadBalancer with multiple protocols are not supported.")
-		svcApplyStatus := corev1apply.ServiceStatus().WithConditions(
-			metav1apply.Condition().
-				WithType(v1.LoadBalancerPortsError).
-				WithStatus(metav1.ConditionTrue).
-				WithReason(v1.LoadBalancerPortsErrorReason).
-				WithLastTransitionTime(metav1.Now()).
-				WithMessage("LoadBalancer with multiple protocols are not supported"))
-		svcApply := corev1apply.Service(svc.Name, svc.Namespace).WithStatus(svcApplyStatus)
-		if _, errApply := g.client.CoreV1().Services(svc.Namespace).ApplyStatus(ctx, svcApply, metav1.ApplyOptions{FieldManager: "gce-cloud-controller", Force: true}); errApply != nil {
-			// the error is retried by the controller loop
-			return errApply
-		}
 	}
 
 	klog.V(4).Infof("UpdateLoadBalancer(%v, %v, %v, %v, %v): updating with %v nodes [node names limited, total number of nodes: %d]", clusterName, svc.Namespace, svc.Name, loadBalancerName, g.region, loggableNodeNames(nodes), len(nodes))
@@ -410,4 +366,51 @@ func computeNewAnnotationsIfNeeded(svc *v1.Service, newAnnotations map[string]st
 		return nil, false
 	}
 	return newObjectMeta, true
+}
+
+// processMixedProtocolCheck checks if the Service Ports use different protocols and updates
+// the corresponding Service Status Condition.
+//
+// Services with multiples protocols are not supported by this controller, warn the users and sets
+// the corresponding Service Status Condition.
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1435-mixed-protocol-lb
+//
+// For updates we want to keep processing to not break them.
+//
+// Originally introduced in https://github.com/kubernetes/cloud-provider-gcp/pull/475
+func (g *Cloud) processMixedProtocolCheck(ctx context.Context, svc *v1.Service, isUpdate bool) error {
+	err := checkMixedProtocol(svc.Spec.Ports)
+	if err == nil {
+		return nil
+	}
+	if hasLoadBalancerPortsError(svc) {
+		if isUpdate {
+			return nil
+		}
+		return err
+	}
+
+	klog.Warningf("Ignoring %s/%s using different ports protocols, isUpdate: %t", svc.Namespace, svc.Name, isUpdate)
+
+	if g.eventRecorder != nil {
+		g.eventRecorder.Event(svc, v1.EventTypeWarning, v1.LoadBalancerPortsErrorReason, "LoadBalancer with multiple protocols are not supported.")
+	}
+
+	svcApplyStatus := corev1apply.ServiceStatus().WithConditions(
+		metav1apply.Condition().
+			WithType(v1.LoadBalancerPortsError).
+			WithStatus(metav1.ConditionTrue).
+			WithReason(v1.LoadBalancerPortsErrorReason).
+			WithLastTransitionTime(metav1.Now()).
+			WithMessage("LoadBalancer with multiple protocols are not supported"))
+	svcApply := corev1apply.Service(svc.Name, svc.Namespace).WithStatus(svcApplyStatus)
+
+	if _, errApply := g.client.CoreV1().Services(svc.Namespace).ApplyStatus(ctx, svcApply, metav1.ApplyOptions{FieldManager: "gce-cloud-controller", Force: true}); errApply != nil {
+		return errApply
+	}
+
+	if isUpdate {
+		return nil
+	}
+	return err
 }

--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -67,6 +67,10 @@ func (g *Cloud) ensureExternalLoadBalancer(clusterName string, clusterID string,
 		return nil, cloudprovider.ImplementedElsewhere
 	}
 
+	if err := g.processMixedProtocolCheck(context.TODO(), apiService, false); err != nil {
+		return nil, err
+	}
+
 	nm := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
 	metricsState := L4NetLBServiceState{
 		Status:       StatusError,
@@ -320,6 +324,10 @@ func (g *Cloud) updateExternalLoadBalancer(clusterName string, service *v1.Servi
 	// Skip service handling if it uses Regional Backend Services and handled by other controllers
 	if !shouldProcessNetLB(service, nil, g.enableRBSDefaultForL4NetLB) {
 		return cloudprovider.ImplementedElsewhere
+	}
+
+	if err := g.processMixedProtocolCheck(context.TODO(), service, true); err != nil {
+		return err
 	}
 
 	if err := addFinalizer(service, g.client.CoreV1(), NetLBFinalizerV1); err != nil {

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -80,6 +80,10 @@ func (g *Cloud) ensureInternalLoadBalancer(clusterName, clusterID string, svc *v
 		}
 	}
 
+	if err := g.processMixedProtocolCheck(context.TODO(), svc, false); err != nil {
+		return nil, err
+	}
+
 	nm := types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}
 
 	var serviceState L4ILBServiceState
@@ -353,6 +357,10 @@ func (g *Cloud) updateInternalLoadBalancer(clusterName, clusterID string, svc *v
 	if svc.Spec.LoadBalancerClass != nil && !hasLoadBalancerClass(svc, LegacyRegionalInternalLoadBalancerClass) {
 		klog.V(2).Infof("Skipped updateInternalLoadBalancer for service %s/%s as service contains %q loadBalancerClass.", svc.Namespace, svc.Name, *svc.Spec.LoadBalancerClass)
 		return cloudprovider.ImplementedElsewhere
+	}
+
+	if err := g.processMixedProtocolCheck(context.TODO(), svc, true); err != nil {
+		return err
 	}
 	g.sharedResourceLock.Lock()
 	defer g.sharedResourceLock.Unlock()

--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -318,10 +318,6 @@ func TestUpdateLoadBalancerMixedProtocols(t *testing.T) {
 	require.NoError(t, err)
 
 	apiService := fakeLoadbalancerService("")
-	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
-		Protocol: v1.ProtocolUDP,
-		Port:     int32(8080),
-	})
 	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Create(context.TODO(), apiService, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -329,6 +325,13 @@ func TestUpdateLoadBalancerMixedProtocols(t *testing.T) {
 	// before the new controller is running and later the Service is updated
 	_, err = createExternalLoadBalancer(gce, apiService, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
 	assert.NoError(t, err)
+
+	apiService.Spec.Ports = append(apiService.Spec.Ports, v1.ServicePort{
+		Protocol: v1.ProtocolUDP,
+		Port:     int32(8080),
+	})
+	apiService, err = gce.client.CoreV1().Services(apiService.Namespace).Update(context.TODO(), apiService, metav1.UpdateOptions{})
+	require.NoError(t, err)
 
 	err = gce.UpdateLoadBalancer(context.Background(), vals.ClusterName, apiService, nodes)
 	if err != nil {


### PR DESCRIPTION
This pushes the checkMixedProtocol call after the logic that checks if the service should be provisioned by ccm's service controller. This prevents adding warning message and condition to load balancer services that are managed by other controllers, including ingress-gce which supports mixed protocol services.