### PR TITLE
gce: dynamically refresh GCE managed zones on node informer events

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -1072,4 +1072,3 @@ func (g *Cloud) refreshManagedZones() error {
 
 	return nil
 }
-

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -144,9 +144,13 @@ type Cloud struct {
 	region           string
 	regional         bool
 	localZone        string // The zone in which we are running
-	// managedZones will be set to the 1 zone if running a single zone cluster
-	// it will be set to ALL zones in region for any multi-zone cluster
-	// Use GetAllCurrentZones to get only zones that contain nodes
+	// Lock for access to managedZones
+	managedZonesLock sync.RWMutex
+	// managedZones represents GCE zones CCM can manage (dynamically
+	// refreshed). Used to scan GCE for project resources to avoid
+	// bootstrap (finding first node) and scale-to-zero (cleaning
+	// volumes in empty zones) issues. For scheduling/placement,
+	// use GetAllCurrentZones() (active nodes) instead.
 	managedZones []string
 	networkURL   string
 	// unsafeIsLegacyNetwork should be used only via IsLegacyNetwork() accessor,
@@ -169,8 +173,10 @@ type Cloud struct {
 	manager                  diskServiceManager
 	// Lock for access to nodeZones
 	nodeZonesLock sync.Mutex
-	// nodeZones is a mapping from Zone to a sets.String of Node's names in the Zone
-	// it is updated by the nodeInformer
+	// nodeZones maps GCE zones to active K8s Node names, dynamically
+	// updated by nodeInformer. Used via GetAllCurrentZones() for
+	// scheduling and topology-aware volume placement to ensure
+	// resources are only created in zones with active node capacity.
 	nodeZones          map[string]sets.String
 	nodeInformerSynced cache.InformerSynced
 	// sharedResourceLock is used to serialize GCE operations that may mutate shared state to
@@ -834,7 +840,6 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 
 func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
 	g.nodeZonesLock.Lock()
-	defer g.nodeZonesLock.Unlock()
 	if prevNode != nil {
 		prevZone := getZone(prevNode)
 		if prevZone != emptyZone {
@@ -844,18 +849,40 @@ func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
 			}
 		}
 	}
+	var newZone string
 	if newNode != nil {
-		newZone := getZone(newNode)
+		newZone = getZone(newNode)
 		if newZone != emptyZone {
 			if g.nodeZones[newZone] == nil {
 				g.nodeZones[newZone] = sets.NewString()
 			}
 			g.nodeZones[newZone].Insert(newNode.ObjectMeta.Name)
-			if !slices.Contains(g.managedZones, newZone) {
-				klog.Warningf("Initializing node %s in an unmanaged zone %s. Managed zones: %v", newNode.ObjectMeta.Name, newZone, g.managedZones)
-			}
 		}
 	}
+	g.nodeZonesLock.Unlock()
+
+	if newNode == nil || newZone == emptyZone {
+		return
+	}
+
+	if slices.Contains(g.getManagedZones(), newZone) {
+		return
+	}
+
+	klog.Infof("Node %s in unmanaged zone %s; triggering GCE zone refresh.",
+		newNode.ObjectMeta.Name, newZone)
+	if err := g.refreshManagedZones(); err != nil {
+		klog.Errorf("Failed to refresh GCE managed zones: %v", err)
+		return
+	}
+
+	if !slices.Contains(g.getManagedZones(), newZone) {
+		klog.Warningf("Node %s in unmanaged zone %s even after refresh. Managed: %v",
+			newNode.ObjectMeta.Name, newZone, g.getManagedZones())
+		return
+	}
+
+	klog.Infof("Successfully verified and added zone %s to CCM managed scope.", newZone)
 }
 
 // HasClusterID returns true if the cluster has a clusterID
@@ -1009,3 +1036,40 @@ func (manager *gceServiceManager) getProjectsAPIEndpoint() string {
 
 	return projectsAPIEndpoint
 }
+
+// getManagedZones returns a thread-safe copy of the GCE managed zones list.
+func (g *Cloud) getManagedZones() []string {
+	g.managedZonesLock.RLock()
+	defer g.managedZonesLock.RUnlock()
+
+	cp := make([]string, len(g.managedZones))
+	copy(cp, g.managedZones)
+	return cp
+}
+
+// refreshManagedZones queries the GCE API to update the managed zones list.
+func (g *Cloud) refreshManagedZones() error {
+	zones, err := g.ListZonesInRegion(g.region)
+	if err != nil {
+		return fmt.Errorf("failed to refresh managed zones: %v", err)
+	}
+
+	var zoneNames []string
+	for _, zone := range zones {
+		zoneNames = append(zoneNames, zone.Name)
+	}
+
+	g.managedZonesLock.Lock()
+	defer g.managedZonesLock.Unlock()
+
+	oldZones := sets.NewString(g.managedZones...)
+	newZones := sets.NewString(zoneNames...)
+
+	if !oldZones.Equal(newZones) {
+		klog.Infof("Managed zones updated. Old: %v, New: %v", g.managedZones, zoneNames)
+		g.managedZones = zoneNames
+	}
+
+	return nil
+}
+

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -596,15 +596,9 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 	gce.c = cloud.NewGCE(gce.s)
 
 	if len(config.ManagedZones) == 0 {
-		zones, err := gce.ListZonesInRegion(gce.region)
-		if err != nil {
+		if err := gce.refreshManagedZones(); err != nil {
 			return nil, err
 		}
-		var zoneNames []string
-		for _, z := range zones {
-			zoneNames = append(zoneNames, z.Name)
-		}
-		gce.managedZones = zoneNames
 	} else {
 		gce.managedZones = config.ManagedZones
 	}
@@ -847,8 +841,8 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	g.nodeInformerSynced = nodeInformer.HasSynced
 }
 
-// recordNodeZoneChange updates the active node footprint in nodeZones under lock and returns the node's zone.
-func (g *Cloud) recordNodeZoneChange(prevNode, newNode *v1.Node) string {
+// updateNodeZonesMap updates the active node footprint in nodeZones under lock and returns the node's zone.
+func (g *Cloud) updateNodeZonesMap(prevNode, newNode *v1.Node) string {
 	g.nodeZonesLock.Lock()
 	defer g.nodeZonesLock.Unlock()
 	if prevNode != nil {
@@ -874,7 +868,7 @@ func (g *Cloud) recordNodeZoneChange(prevNode, newNode *v1.Node) string {
 }
 
 func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
-	newZone := g.recordNodeZoneChange(prevNode, newNode)
+	newZone := g.updateNodeZonesMap(prevNode, newNode)
 
 	if !g.dynamicZones {
 		return

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -143,6 +143,7 @@ type Cloud struct {
 	projectID        string
 	region           string
 	regional         bool
+	dynamicZones     bool
 	localZone        string // The zone in which we are running
 	// Lock for access to managedZones
 	managedZonesLock sync.RWMutex
@@ -464,6 +465,10 @@ func GenerateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 // If no tokenSource is specified, uses oauth2.DefaultTokenSource.
 // If managedZones is nil / empty all zones in the region will be managed.
 func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
+	// If ManagedZones was empty at startup, it means the cluster was configured
+	// as a Regional or Multi-zone cluster and should dynamically refresh zones.
+	dynamicZones := len(config.ManagedZones) == 0
+
 	// Remove any pre-release version and build metadata from the semver,
 	// leaving only the MAJOR.MINOR.PATCH portion. See http://semver.org/.
 	version := strings.TrimLeft(strings.Split(strings.Split(version.Get().GitVersion, "-")[0], "+")[0], "v")
@@ -550,16 +555,6 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 	// the provider is initialized also for Kubelets (and there can be thousands
 	// of them) we defer to lazy initialization here.
 
-	if len(config.ManagedZones) == 0 {
-		config.ManagedZones, err = getZonesForRegion(service, config.ProjectID, config.Region)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if len(config.ManagedZones) > 1 {
-		klog.Infof("managing multiple zones: %v", config.ManagedZones)
-	}
-
 	operationPollRateLimiter := flowcontrol.NewTokenBucketRateLimiter(5, 5) // 5 qps, 5 burst.
 
 	gce := &Cloud{
@@ -574,7 +569,7 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		region:                   config.Region,
 		regional:                 config.Regional,
 		localZone:                config.Zone,
-		managedZones:             config.ManagedZones,
+		dynamicZones:             dynamicZones,
 		networkURL:               networkURL,
 		unsafeIsLegacyNetwork:    isLegacyNetwork,
 		unsafeSubnetworkURL:      subnetURL,
@@ -599,6 +594,20 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		RateLimiter:   &gceRateLimiter{gce},
 	}
 	gce.c = cloud.NewGCE(gce.s)
+
+	if len(config.ManagedZones) == 0 {
+		zones, err := gce.ListZonesInRegion(gce.region)
+		if err != nil {
+			return nil, err
+		}
+		var zoneNames []string
+		for _, z := range zones {
+			zoneNames = append(zoneNames, z.Name)
+		}
+		gce.managedZones = zoneNames
+	} else {
+		gce.managedZones = config.ManagedZones
+	}
 
 	return gce, nil
 }
@@ -838,8 +847,10 @@ func (g *Cloud) SetInformers(informerFactory informers.SharedInformerFactory) {
 	g.nodeInformerSynced = nodeInformer.HasSynced
 }
 
-func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
+// recordNodeZoneChange updates the active node footprint in nodeZones under lock and returns the node's zone.
+func (g *Cloud) recordNodeZoneChange(prevNode, newNode *v1.Node) string {
 	g.nodeZonesLock.Lock()
+	defer g.nodeZonesLock.Unlock()
 	if prevNode != nil {
 		prevZone := getZone(prevNode)
 		if prevZone != emptyZone {
@@ -859,7 +870,15 @@ func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
 			g.nodeZones[newZone].Insert(newNode.ObjectMeta.Name)
 		}
 	}
-	g.nodeZonesLock.Unlock()
+	return newZone
+}
+
+func (g *Cloud) updateNodeZones(prevNode, newNode *v1.Node) {
+	newZone := g.recordNodeZoneChange(prevNode, newNode)
+
+	if !g.dynamicZones {
+		return
+	}
 
 	if newNode == nil || newZone == emptyZone {
 		return
@@ -994,30 +1013,6 @@ func getProjectID(svc *compute.Service, projectNumberOrID string) (string, error
 	return proj.Name, nil
 }
 
-func getZonesForRegion(svc *compute.Service, projectID, region string) ([]string, error) {
-	// TODO: use PageToken to list all not just the first 500
-	listCall := svc.Zones.List(projectID)
-
-	// Filtering by region doesn't seem to work
-	// (tested in https://cloud.google.com/compute/docs/reference/latest/zones/list)
-	// listCall = listCall.Filter("region eq " + region)
-
-	var zones []string
-	accumulator := func(response *compute.ZoneList) error {
-		for _, zone := range response.Items {
-			regionName := lastComponent(zone.Region)
-			if regionName == region {
-				zones = append(zones, zone.Name)
-			}
-		}
-		return nil
-	}
-	err := listCall.Pages(context.TODO(), accumulator)
-	if err != nil {
-		return nil, fmt.Errorf("unexpected response listing zones: %v", err)
-	}
-	return zones, nil
-}
 
 func findSubnetForRegion(subnetURLs []string, region string) string {
 	for _, url := range subnetURLs {
@@ -1037,7 +1032,7 @@ func (manager *gceServiceManager) getProjectsAPIEndpoint() string {
 	return projectsAPIEndpoint
 }
 
-// getManagedZones returns a thread-safe copy of the GCE managed zones list.
+// getManagedZones returns a goroutine-safe copy of the GCE managed zones list.
 func (g *Cloud) getManagedZones() []string {
 	g.managedZonesLock.RLock()
 	defer g.managedZonesLock.RUnlock()

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -1013,7 +1013,6 @@ func getProjectID(svc *compute.Service, projectNumberOrID string) (string, error
 	return proj.Name, nil
 }
 
-
 func findSubnetForRegion(subnetURLs []string, region string) string {
 	for _, url := range subnetURLs {
 		if thisRegion := getRegionInURL(url); thisRegion == region {

--- a/providers/gce/gce_clusters.go
+++ b/providers/gce/gce_clusters.go
@@ -35,7 +35,7 @@ func newClustersMetricContext(request, zone string) *metricContext {
 func (g *Cloud) ListClusters(ctx context.Context) ([]string, error) {
 	allClusters := []string{}
 
-	for _, zone := range g.managedZones {
+	for _, zone := range g.getManagedZones() {
 		clusters, err := g.listClustersInZone(zone)
 		if err != nil {
 			return nil, err
@@ -57,8 +57,8 @@ func (g *Cloud) GetManagedClusters(ctx context.Context) ([]*container.Cluster, e
 		if err != nil {
 			return nil, err
 		}
-	} else if len(g.managedZones) >= 1 {
-		for _, zone := range g.managedZones {
+	} else if len(g.getManagedZones()) >= 1 {
+		for _, zone := range g.getManagedZones() {
 			clusters, err := g.getClustersInLocation(zone)
 			if err != nil {
 				return nil, err

--- a/providers/gce/gce_disks.go
+++ b/providers/gce/gce_disks.go
@@ -949,7 +949,7 @@ func (g *Cloud) GetDiskByNameUnknownZone(diskName string) (*Disk, error) {
 	// on create)
 
 	var found *Disk
-	for _, zone := range g.managedZones {
+	for _, zone := range g.getManagedZones() {
 		disk, err := g.findDiskByName(diskName, zone)
 		if err != nil {
 			return nil, err
@@ -978,7 +978,7 @@ func (g *Cloud) GetDiskByNameUnknownZone(diskName string) (*Disk, error) {
 		return found, nil
 	}
 	klog.Warningf("GCE persistent disk %q not found in managed zones (%s)",
-		diskName, strings.Join(g.managedZones, ","))
+		diskName, strings.Join(g.getManagedZones(), ","))
 
 	return nil, cloudprovider.DiskNotFound
 }

--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	compute "google.golang.org/api/compute/v1"
 	option "google.golang.org/api/option"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -89,6 +90,7 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		networkURL:          vals.NetworkURL,
 		unsafeSubnetworkURL: vals.SubnetworkURL,
 		stackType:           vals.StackType,
+		nodeZones:           map[string]sets.String{},
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c

--- a/providers/gce/gce_fake.go
+++ b/providers/gce/gce_fake.go
@@ -87,6 +87,7 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		metricsCollector:    newLoadBalancerMetrics(),
 		projectsBasePath:    getProjectsBasePath(service.BasePath),
 		regional:            vals.Regional,
+		dynamicZones:        vals.Regional,
 		networkURL:          vals.NetworkURL,
 		unsafeSubnetworkURL: vals.SubnetworkURL,
 		stackType:           vals.StackType,

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -529,7 +529,7 @@ func (g *Cloud) GetAllZonesFromCloudProvider() (sets.String, error) {
 	defer cancel()
 
 	zones := sets.NewString()
-	for _, zone := range g.managedZones {
+	for _, zone := range g.getManagedZones() {
 		instances, err := g.c.Instances().List(ctx, zone, filter.None)
 		if err != nil {
 			return sets.NewString(), err
@@ -715,7 +715,7 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 		found[name] = nil
 	}
 
-	for _, zone := range g.managedZones {
+	for _, zone := range g.getManagedZones() {
 		if remaining == 0 {
 			break
 		}
@@ -763,10 +763,10 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 
 // Gets the named instance, returning cloudprovider.InstanceNotFound if the instance is not found
 func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
-	klog.Infof("Searching node %s in managed zones %v", name, g.managedZones)
+	klog.Infof("Searching node %s in managed zones %v", name, g.getManagedZones())
 
 	// Avoid changing behaviour when not managing multiple zones
-	for _, zone := range g.managedZones {
+	for _, zone := range g.getManagedZones() {
 		instance, err := g.getInstanceFromProjectInZoneByName(g.projectID, zone, name)
 		if err != nil {
 			if isHTTPErrorCode(err, http.StatusNotFound) {

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -721,4 +721,3 @@ func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
 	expectedZones := []string{"us-central1-b", "us-central1-c"}
 	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
 }
-

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -692,6 +692,7 @@ func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
 	vals := DefaultTestClusterValues()
 	gce, err := fakeGCECloud(vals)
 	require.NoError(t, err)
+	gce.dynamicZones = true
 
 	// Initial managed zones should only contain the default zone
 	assert.Equal(t, []string{"us-central1-b"}, gce.getManagedZones())

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -687,3 +687,38 @@ func TestProjectFromNodeProviderID(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	// Initial managed zones should only contain the default zone
+	assert.Equal(t, []string{"us-central1-b"}, gce.getManagedZones())
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+
+	// Mock GCE zones.List call via MockZones to return us-central1-c in addition to the default us-central1-b
+	keyC := meta.GlobalKey("key-c")
+	mockGCE.MockZones.Objects[*keyC] = &cloud.MockZonesObj{
+		Obj: &ga.Zone{Name: "us-central1-c", Region: gce.getRegionLink("us-central1")},
+	}
+
+	// Create a node registering in "us-central1-c"
+	nodeInNewZone := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-in-c",
+			Labels: map[string]string{
+				v1.LabelTopologyZone: "us-central1-c",
+			},
+		},
+	}
+
+	// Trigger node informer addition event
+	gce.updateNodeZones(nil, nodeInNewZone)
+
+	// Verify that managedZones has dynamically updated to include both zones
+	expectedZones := []string{"us-central1-b", "us-central1-c"}
+	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
+}
+


### PR DESCRIPTION
### What this PR does / why we need it
This PR implements a dynamic zone refresh mechanism for the GCE cloud provider in the Cloud Controller Manager (CCM). 
Currently, CCM caches the GCE zones it manages (`managedZones`) exactly once at startup and never refreshes them. When a new zone is enabled in the GCP region (e.g., when adding a node pool in a new zone), all zonal VM/node lookups (`getInstanceByName`) and persistent volume operations (`GetDiskByNameUnknownZone`) fail in the new zone because the cache is stale. Previously, this required a manual Kubernetes Control Plane (KCP) restart to get CCM to recognize the new zone.

### How it solves it
We introduce a zero-downtime, thread-safe, on-demand zone refresh:
1. **Thread Safety**: Added `sync.RWMutex` (`managedZonesLock`) to the GCE `Cloud` struct and refactored all read occurrences to use a thread-safe getter (`getManagedZones()`).
2. **Mock-Friendly API**: Refactored the zone listing refresh to use the modern `ListZonesInRegion` interface instead of the legacy raw `getZonesForRegion` API, allowing standard GCE mock testing.
3. **Event-Driven Trigger**: Hooked the refresh into the node informer (`updateNodeZones`). When a node registers in a zone that is missing from CCM's cache, CCM dynamically triggers `refreshManagedZones()` to fetch the expanded zone list. 
4. **Deadlock Prevention**: Structurally optimized `updateNodeZones` to compute local state and manually release the `nodeZonesLock` *before* triggering any GCE API calls.

### Special notes for your reviewer
* The node informer was chosen as the trigger because GKE volume provisioning requires a node to exist in a zone before volumes can be targeted there. This event-driven hook provides zero idle GCE API overhead.
* I added a complete unit test `TestUpdateNodeZonesDynamicRefresh` in `gce_instances_test.go` which simulates the node informer events pipeline and verifies the dynamic cache refresh.**

cc: @YifeiZhuang @zhaoqsh @gnossen