### PR TITLE
Skip irrelevant failing test cases in periodic tests

### DIFF
--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest-with-gcepd.sh
@@ -24,7 +24,7 @@ cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX="" # Run all non-skipped tests
-export KOPS_SKIP_REGEX='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Driver: nfs\]|\[Driver: nfs3\]|NFS|Flexvolumes'
+source "$(git rev-parse --show-toplevel)/dev/ci/periodics/common.sh"
 export CLUSTER_NAME="kops-e2e-gcepd.k8s.local"
 export TEST_ARGS="--minStartupPods=8 --enabled-volume-drivers=gcepd"
 

--- a/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
+++ b/dev/ci/periodics/ci-cloud-provider-gcp-e2e-latest.sh
@@ -24,7 +24,7 @@ cd $GOPATH/src/k8s.io/cloud-provider-gcp
 e2e/add-kubernetes-to-workspace.sh
 
 export KOPS_FOCUS_REGEX="" # Run all non-skipped tests
-export KOPS_SKIP_REGEX='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Driver: nfs\]|\[Driver: nfs3\]|NFS|Flexvolumes'
+source "$(git rev-parse --show-toplevel)/dev/ci/periodics/common.sh"
 export CLUSTER_NAME="kops-e2e-latest.k8s.local"
 
 e2e/scenarios/kops-simple

--- a/dev/ci/periodics/common.sh
+++ b/dev/ci/periodics/common.sh
@@ -14,18 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Use published release tars for cloud-provider-gcp if/once they exist
-set -o errexit
-set -o nounset
-set -o pipefail
-set -o xtrace
-
-cd $GOPATH/src/k8s.io/cloud-provider-gcp
-e2e/add-kubernetes-to-workspace.sh
-
-export KOPS_FOCUS_REGEX="" # Run all non-skipped tests
-source "$(git rev-parse --show-toplevel)/dev/ci/periodics/common.sh"
-export CLUSTER_NAME="kops-e2e-master.k8s.local"
-export TEST_ARGS="--minStartupPods=8"
-
-e2e/scenarios/kops-simple
+# Common E2E test skip regex to avoid duplication across periodic scripts.
+export KOPS_SKIP_REGEX='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[Driver: nfs\]|\[Driver: nfs3\]|NFS|Flexvolumes|Services should function for service endpoints using hostNetwork|RuntimeClass should run a Pod requesting a RuntimeClass with scheduling without taints'


### PR DESCRIPTION
This PR skips two test cases that are failing in periodic E2E tests after migrating from kubetest2-gce to kops. These test cases are not relevant to the cloud-controller-manager (CCM) and are due to difference between the test environments.

The two skipped test cases are:
- `[sig-network] Networking Granular Checks: Services should function for service endpoints using hostNetwork`
- `[sig-node] RuntimeClass should run a Pod requesting a RuntimeClass with scheduling without taints`

Fixes #1165

---
This PR was generated by **Overseer** (powered by the gemini-3.5-flash model).