### PR TITLE
Fix shared HC name eval to fix leak of shared HC firewall

### DIFF
--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -599,7 +599,7 @@ func (g *Cloud) ensureTargetPoolAndHealthCheck(tpExists, tpNeedsRecreation bool,
 				return fmt.Errorf("failed to ensure health check for %v port %d path %v: %v", loadBalancerName, hcToCreate.Port, hcToCreate.RequestPath, err)
 			}
 			// Check whether it is nodes health check, which has different name from the load-balancer.
-			isNodesHealthCheck := hcToCreate.Name != serviceName.Name
+			isNodesHealthCheck := hcToCreate.Name != loadBalancerName
 			if isNodesHealthCheck {
 				// Lock to prevent necessary nodes health check / firewall gets deleted.
 				g.sharedResourceLock.Lock()

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -2709,3 +2709,74 @@ func TestEnsureExternalLoadBalancerMetrics(t *testing.T) {
 	lm.exportNetLBMetrics()
 	verifyL4NetLBMetric(t, 0, StatusError, DenyFirewallStatusNone)
 }
+
+// TestEnsureExternalLoadBalancerLocalNoOpUpdate ensures that the local health check and firewall are not changed when there is no update
+// to the etp=Local service.
+func TestEnsureExternalLoadBalancerLocalNoOpUpdate(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	nodeNames := []string{"test-node-1"}
+
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	svc := fakeLoadbalancerService("")
+	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+	svc.Spec.HealthCheckNodePort = int32(10101)
+	svc.Spec.Type = v1.ServiceTypeLoadBalancer
+
+	svc, err = gce.client.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = createExternalLoadBalancer(gce, svc, nodeNames, vals.ClusterName, vals.ClusterID, vals.ZoneName)
+	assert.NoError(t, err)
+
+	loadBalancerName := gce.GetLoadBalancerName(context.TODO(), "", svc)
+
+	// Verification 1
+	// Verify that the local health check is created.
+	hc, err := gce.GetHTTPHealthCheck(loadBalancerName)
+	require.NoError(t, err)
+	assert.Equal(t, loadBalancerName, hc.Name)
+	assert.Equal(t, int64(10101), hc.Port)
+	assert.Equal(t, "/healthz", hc.RequestPath)
+
+	// Verify that the local health check firewall is created.
+	localHcSwName := MakeHealthCheckFirewallName(vals.ClusterID, loadBalancerName, false)
+	localFw, err := gce.GetFirewall(localHcSwName)
+	require.NoError(t, err)
+	assert.NotNil(t, localFw)
+
+	// Verify that the SHARED nodes health check and its firewall are NOT created.
+	sharedHcName := MakeNodesHealthCheckName(vals.ClusterID)
+	_, err = gce.GetHTTPHealthCheck(sharedHcName)
+	assert.True(t, isNotFound(err))
+
+	sharedHcSwName := MakeHealthCheckFirewallName(vals.ClusterID, sharedHcName, true)
+	_, err = gce.GetFirewall(sharedHcSwName)
+	assert.True(t, isNotFound(err))
+
+	// Call gce.ensureExternalLoadBalancer again for no-op update
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+
+	_, err = gce.ensureExternalLoadBalancer(vals.ClusterName, vals.ClusterID, svc, nil, nodes)
+	assert.NoError(t, err)
+
+	// Verification 2
+	// Re-verify all conditions
+	hc, err = gce.GetHTTPHealthCheck(loadBalancerName)
+	require.NoError(t, err)
+	assert.Equal(t, loadBalancerName, hc.Name)
+
+	localFw, err = gce.GetFirewall(localHcSwName)
+	require.NoError(t, err)
+	assert.NotNil(t, localFw)
+
+	_, err = gce.GetHTTPHealthCheck(sharedHcName)
+	assert.True(t, isNotFound(err))
+
+	_, err = gce.GetFirewall(sharedHcSwName)
+	assert.True(t, isNotFound(err))
+}


### PR DESCRIPTION
The typo took the wrong name in evaluation leading to always return true, even for etp: Local LBs. This leads to creating shared HC Firewalls, which are left when cleanup logic is never triggered for them.

I've also run the new test without the logic change, meaning `isNodesHealthCheck := hcToCreate.Name != serviceName.Name` and it has failed.