### PR TITLE
fix: two small typos in error message and test format string

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred.go
@@ -255,7 +255,7 @@ func (p *plugin) accessToken() (string, *metav1.Time, error) {
 
 	token, expiry, err := p.tokenProvider.token()
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed to retrieve access token:: %w", err)
+		return "", nil, fmt.Errorf("failed to retrieve access token: %w", err)
 	}
 
 	if useCache && !expiry.IsZero() {

--- a/providers/gce/gce_loadbalancer_naming_test.go
+++ b/providers/gce/gce_loadbalancer_naming_test.go
@@ -71,7 +71,7 @@ func TestLoadBalancerNames(t *testing.T) {
 				DenyFirewallName: gce.MakeFirewallDenyName(lbName),
 			}
 			if diff := cmp.Diff(tC.want, got); diff != "" {
-				t.Errorf("got != want, (-want, +got):/n%s", diff)
+				t.Errorf("got != want, (-want, +got):\n%s", diff)
 			}
 
 			// https://docs.cloud.google.com/compute/docs/naming-resources#resource-name-format


### PR DESCRIPTION
Two copy-paste typos that slipped through:

1. `cred.go:258` - error message has a double colon and starts with uppercase:
```go
// before
return "", nil, fmt.Errorf("Failed to retrieve access token:: %w", err)
// after
return "", nil, fmt.Errorf("failed to retrieve access token: %w", err)
```
Every other `fmt.Errorf` in that file is lowercase, this one was just missed during refactor. Reproduce: trigger a token fetch failure (e.g. revoke gcloud creds) and check the error message in output.

2. `gce_loadbalancer_naming_test.go:74` - `/n` instead of `\n` in the format string, so when `TestLoadBalancerNames` fails, the diff output is on the same line as the message instead of a new line. Not a logic bug, but makes failing test output hard to read.