### PR TITLE
Upgrade Go to 1.26.4 and runtime base to debian13 in Metis Dockerfile

### DIFF
--- a/metis/Dockerfile
+++ b/metis/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.26.3 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.4 AS builder
 
 # Install cross-compilers for amd64 and arm64
 RUN apt-get update && apt-get install -y \
@@ -45,7 +45,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 # Always verify any base image upgrades by running `make test-glibc-floor`.
 #
 # See metis/Makefile for the full historical context and version baseline.
-FROM gcr.io/distroless/cc-debian12
+FROM gcr.io/distroless/cc-debian13
 WORKDIR /
 COPY --from=builder /app/metis /bin/metis
 ENTRYPOINT ["/bin/metis"]


### PR DESCRIPTION
This fixes:
- Go stdlib CVEs (by upgrading Go builder to 1.26.4)
- OpenSSL CVEs (by upgrading runtime base to distroless cc-debian13)

Verified that the built binary remains compatible with GLIBC 2.35 (Ubuntu 22.04 floor).

/assign @YifeiZhuang 