### PR TITLE
Add docker package ecosystem in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,16 @@ updates:
       exclude-patterns:
         - "k8s.io/*"
         - "sigs.k8s.io/*"
+- package-ecosystem: "docker"
+  directories:
+  - "/"
+  - "/metis"
+  schedule:
+    interval: "weekly"
+  labels:
+  - "ok-to-test"
+  - 'area/dependency'
+  - 'release-note-none'
 - package-ecosystem: "github-actions"
   directory: "/"
   target-branch: "release-1.36"
@@ -66,6 +76,17 @@ updates:
       exclude-patterns:
         - "k8s.io/*"
         - "sigs.k8s.io/*"
+- package-ecosystem: "docker"
+  directories:
+  - "/"
+  - "/metis"
+  target-branch: "release-1.36"
+  schedule:
+    interval: "weekly"
+  labels:
+  - "ok-to-test"
+  - 'area/dependency'
+  - 'release-note-none'
 
 
 


### PR DESCRIPTION
This is to automate builder and base image updates to pick up CVE fixes.