### PR TITLE
CORS-4516: Add Universe Domain support for alternate GCP environments

### DIFF
--- a/providers/gce/credentials_test.go
+++ b/providers/gce/credentials_test.go
@@ -1,0 +1,226 @@
+//go:build !providerless
+// +build !providerless
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"testing"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
+
+func TestCredentialOptions(t *testing.T) {
+	tests := []struct {
+		name            string
+		config          *CloudConfig
+		wantErr         bool
+		description     string
+		expectAuthCreds bool // true if we expect WithAuthCredentialsJSON, false for WithTokenSource
+	}{
+		{
+			name: "service account with type field",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(`{
+					"type": "service_account",
+					"project_id": "test-project",
+					"private_key_id": "key123",
+					"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7W8jYbz0VLFjH\n-----END PRIVATE KEY-----\n",
+					"client_email": "test@test-project.iam.gserviceaccount.com",
+					"client_id": "123456789",
+					"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+					"token_uri": "https://oauth2.googleapis.com/token",
+					"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+					"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test%40test-project.iam.gserviceaccount.com"
+				}`),
+			},
+			wantErr:         false,
+			description:     "should use WithAuthCredentialsJSON for service account with type field",
+			expectAuthCreds: true,
+		},
+		{
+			name: "authorized user with type field",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(`{
+					"type": "authorized_user",
+					"client_id": "client123",
+					"client_secret": "secret123",
+					"refresh_token": "token123"
+				}`),
+			},
+			wantErr:         false,
+			description:     "should use WithAuthCredentialsJSON for authorized user with type field",
+			expectAuthCreds: true,
+		},
+		{
+			name: "credentials without type field",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(`{
+					"project_id": "test-project",
+					"private_key_id": "key123"
+				}`),
+			},
+			wantErr:         true,
+			description:     "should fall back to CredentialsFromJSON but fail due to invalid credentials",
+			expectAuthCreds: false,
+		},
+		{
+			name: "no credentials JSON, use TokenSource",
+			config: &CloudConfig{
+				TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			},
+			wantErr:         false,
+			description:     "should use WithTokenSource when no CredentialsJSON provided",
+			expectAuthCreds: false,
+		},
+		{
+			name: "invalid JSON",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(`invalid json`),
+			},
+			wantErr:         true,
+			description:     "should fail with invalid JSON",
+			expectAuthCreds: false,
+		},
+		{
+			name: "empty credentials with TokenSource fallback",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(``),
+				TokenSource:     oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			},
+			wantErr:         false,
+			description:     "should use TokenSource when credentials JSON is empty",
+			expectAuthCreds: false,
+		},
+		{
+			name: "empty credentials without TokenSource",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(``),
+			},
+			wantErr:         true,
+			description:     "should fail when both credentials JSON and TokenSource are missing",
+			expectAuthCreds: false,
+		},
+		{
+			name:            "no credentials at all",
+			config:          &CloudConfig{},
+			wantErr:         true,
+			description:     "should fail when neither credentials JSON nor TokenSource provided",
+			expectAuthCreds: false,
+		},
+		{
+			name: "external account with type field",
+			config: &CloudConfig{
+				CredentialsJSON: []byte(`{
+					"type": "external_account",
+					"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+					"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+					"token_url": "https://sts.googleapis.com/v1/token",
+					"credential_source": {
+						"file": "/var/run/secrets/token"
+					}
+				}`),
+			},
+			wantErr:         false,
+			description:     "should use WithAuthCredentialsJSON for external account with type field",
+			expectAuthCreds: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, err := credentialOptions(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("credentialOptions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if opts == nil || len(opts) == 0 {
+					t.Errorf("credentialOptions() returned nil or empty options without error")
+					return
+				}
+				// Verify we got a valid ClientOption
+				var _ option.ClientOption = opts[0]
+			}
+		})
+	}
+}
+
+func TestCredentialOptionsPreservesType(t *testing.T) {
+	// Test that different credential types are handled correctly
+	credentialTypes := []string{
+		"service_account",
+		"authorized_user",
+		"external_account",
+	}
+
+	for _, credType := range credentialTypes {
+		t.Run(credType, func(t *testing.T) {
+			var credJSON string
+			switch credType {
+			case "service_account":
+				credJSON = `{
+					"type": "service_account",
+					"project_id": "test-project",
+					"private_key_id": "key123",
+					"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7W8jYbz0VLFjH\n-----END PRIVATE KEY-----\n",
+					"client_email": "test@test-project.iam.gserviceaccount.com",
+					"client_id": "123456789",
+					"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+					"token_uri": "https://oauth2.googleapis.com/token"
+				}`
+			case "authorized_user":
+				credJSON = `{
+					"type": "authorized_user",
+					"client_id": "client123",
+					"client_secret": "secret123",
+					"refresh_token": "token123"
+				}`
+			case "external_account":
+				credJSON = `{
+					"type": "external_account",
+					"audience": "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider",
+					"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+					"token_url": "https://sts.googleapis.com/v1/token",
+					"credential_source": {
+						"file": "/var/run/secrets/token"
+					}
+				}`
+			}
+
+			config := &CloudConfig{
+				CredentialsJSON: []byte(credJSON),
+			}
+
+			opts, err := credentialOptions(config)
+			if err != nil {
+				t.Errorf("credentialOptions() unexpected error for %s: %v", credType, err)
+				return
+			}
+
+			if opts == nil || len(opts) == 0 {
+				t.Errorf("credentialOptions() returned nil or empty options for %s", credType)
+				return
+			}
+
+			// Verify we got a valid ClientOption
+			var _ option.ClientOption = opts[0]
+		})
+	}
+}

--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -21,6 +21,7 @@ package gce
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"runtime"
@@ -292,6 +293,10 @@ type CloudConfig struct {
 	NodeTags           []string
 	NodeInstancePrefix string
 	TokenSource        oauth2.TokenSource
+	// CredentialsJSON is the raw JSON credentials. When provided, it will be used
+	// instead of TokenSource to properly support alternate universe domains.
+	// SECURITY: This field contains sensitive credentials and must not be logged or serialized.
+	CredentialsJSON    []byte `json:"-" datapolicy:"token"`
 	UseMetadataServer  bool
 	AlphaFeatureGate   *AlphaFeatureGate
 	StackType          string
@@ -460,6 +465,40 @@ func GenerateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 	return cloudConfig, err
 }
 
+// credentialOptions returns the appropriate credential option for creating a GCP client.
+// It checks if CredentialsJSON contains a "type" field to determine if it's a typed credential
+// (e.g., service_account, authorized_user, impersonated_service_account, external_account).
+// If typed credentials are present, it uses option.WithAuthCredentialsJSON which properly
+// handles Universe Domain. Otherwise, it falls back to the legacy token source approach for
+// backward compatibility.
+func credentialOptions(config *CloudConfig) ([]option.ClientOption, error) {
+	// If no credentials JSON is provided, use the legacy TokenSource path
+	if len(config.CredentialsJSON) == 0 {
+		if config.TokenSource == nil {
+			return nil, fmt.Errorf("either CredentialsJSON or TokenSource must be provided")
+		}
+		return []option.ClientOption{option.WithTokenSource(config.TokenSource)}, nil
+	}
+
+	// Parse the credentials JSON to check if it contains a "type" field
+	var f struct {
+		Type option.CredentialsType `json:"type"`
+	}
+	if err := json.Unmarshal(config.CredentialsJSON, &f); err == nil && f.Type != "" {
+		// Use the new WithAuthCredentialsJSON which properly handles Universe Domain
+		klog.V(4).Infof("Using WithAuthCredentialsJSON for credential type: %s", f.Type)
+		return []option.ClientOption{option.WithAuthCredentialsJSON(f.Type, config.CredentialsJSON)}, nil
+	}
+
+	// Fall back to the legacy path if no type field is present
+	klog.V(4).Info("No type field in credentials JSON, falling back to legacy credentials path")
+	creds, err := google.CredentialsFromJSON(context.Background(), config.CredentialsJSON, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create credentials from JSON: %w", err)
+	}
+	return []option.ClientOption{option.WithCredentials(creds)}, nil
+}
+
 // CreateGCECloud creates a Cloud object using the specified parameters.
 // If no networkUrl is specified, loads networkName via rest call.
 // If no tokenSource is specified, uses oauth2.DefaultTokenSource.
@@ -482,19 +521,25 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		config.NetworkProjectID = config.ProjectID
 	}
 
-	service, err := compute.NewService(context.Background(), option.WithTokenSource(config.TokenSource))
+	// Get credential options (supports both CredentialsJSON and TokenSource)
+	credOpts, err := credentialOptions(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create credential options: %w", err)
+	}
+
+	service, err := compute.NewService(context.Background(), credOpts...)
 	if err != nil {
 		return nil, err
 	}
 	service.UserAgent = userAgent
 
-	serviceBeta, err := computebeta.NewService(context.Background(), option.WithTokenSource(config.TokenSource))
+	serviceBeta, err := computebeta.NewService(context.Background(), credOpts...)
 	if err != nil {
 		return nil, err
 	}
 	serviceBeta.UserAgent = userAgent
 
-	serviceAlpha, err := computealpha.NewService(context.Background(), option.WithTokenSource(config.TokenSource))
+	serviceAlpha, err := computealpha.NewService(context.Background(), credOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +557,7 @@ func CreateGCECloud(config *CloudConfig) (*Cloud, error) {
 		}
 	}
 
-	containerService, err := container.NewService(context.Background(), option.WithTokenSource(config.TokenSource))
+	containerService, err := container.NewService(context.Background(), credOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add support for alternate GCP Universe Domains (e.g., Google Cloud Dedicated) by using `option.WithAuthCredentialsJSON` when credentials JSON is
  available.

  ## Changes
  
  - Add `CredentialsJSON` field to `CloudConfig` (secured with `datapolicy:"token"` and `json:"-"`)
  - Add `credentialOptions()` helper that:
    - Uses `WithAuthCredentialsJSON()` when credentials have a `type` field (preserves universe domain)
    - Falls back to `WithTokenSource()` for backward compatibility
  - Update all 4 GCP service creations (compute GA/beta/alpha, container)
  - Add comprehensive unit tests for all credential types

  ## Benefits

  ✅ Universe domain automatically extracted from credentials JSON
  ✅ Fully backward compatible
  ✅ Supports all 4 GCP credential types (service_account, authorized_user, impersonated_service_account, external_account)