### PR TITLE
[release-1.36] Cherrypick Set timeout for getInstanceFromProjectInZoneByName to 6 seconds.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/time v0.15.0
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -72,10 +72,10 @@ const (
 	updateRetryTimeout = 250 * time.Millisecond
 
 	// maxUpdateRetryTimeout is the maximum amount of time between timeouts.
-	maxUpdateRetryTimeout = 5 * time.Second
+	maxUpdateRetryTimeout = 15 * time.Second
 
 	// updateMaxRetries is the max retries for a failed node
-	updateMaxRetries = 10
+	updateMaxRetries = 20
 
 	// The no. of workers in parallel to update nodetopology CR
 	nodeTopologyWorkers = 30

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -156,6 +156,7 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 		queue: workqueue.NewRateLimitingQueueWithConfig(
 			workqueue.NewMaxOfRateLimiter(
 				workqueue.NewItemExponentialFailureRateLimiter(updateRetryTimeout, maxUpdateRetryTimeout),
+				// This is the default BucketRatelimiter used by DefaultControllerRateLimiter.
 				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 			workqueue.RateLimitingQueueConfig{Name: workqueueName},

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
+	"golang.org/x/time/rate"
 	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -143,16 +144,22 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 	}
 
 	ca := &cloudCIDRAllocator{
-		client:                client,
-		cloud:                 gceCloud,
-		networksLister:        nwInformer.Lister(),
-		gnpLister:             gnpInformer.Lister(),
-		nodeLister:            nodeInformer.Lister(),
-		nodesSynced:           nodeInformer.Informer().HasSynced,
-		networksSynced:        nwInformer.Informer().HasSynced,
-		gnpsSynced:            gnpInformer.Informer().HasSynced,
-		recorder:              recorder,
-		queue:                 workqueue.NewRateLimitingQueueWithConfig(workqueue.DefaultControllerRateLimiter(), workqueue.RateLimitingQueueConfig{Name: workqueueName}),
+		client:         client,
+		cloud:          gceCloud,
+		networksLister: nwInformer.Lister(),
+		gnpLister:      gnpInformer.Lister(),
+		nodeLister:     nodeInformer.Lister(),
+		nodesSynced:    nodeInformer.Informer().HasSynced,
+		networksSynced: nwInformer.Informer().HasSynced,
+		gnpsSynced:     gnpInformer.Informer().HasSynced,
+		recorder:       recorder,
+		queue: workqueue.NewRateLimitingQueueWithConfig(
+			workqueue.NewMaxOfRateLimiter(
+				workqueue.NewItemExponentialFailureRateLimiter(updateRetryTimeout, maxUpdateRetryTimeout),
+				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			),
+			workqueue.RateLimitingQueueConfig{Name: workqueueName},
+		),
 		stackType:             stackType,
 		enableMultiNetworking: enableMultiNetworking,
 	}

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -34,6 +34,7 @@ import (
 	ntfakeclient "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned/fake"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/time/rate"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -104,6 +105,54 @@ func TestBoundedRetries(t *testing.T) {
 	})
 	for hasNodeInProcessing(ca, nodeName) {
 		// wait for node to finish processing (should terminate and not time out)
+	}
+}
+
+func TestCloudCIDRAllocatorRetryLogic(t *testing.T) {
+	nodeName := "testNode"
+	ca := &cloudCIDRAllocator{
+		queue: workqueue.NewRateLimitingQueueWithConfig(
+			workqueue.NewMaxOfRateLimiter(
+				workqueue.NewItemExponentialFailureRateLimiter(updateRetryTimeout, maxUpdateRetryTimeout),
+				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			),
+			workqueue.RateLimitingQueueConfig{Name: "cloudCIDRAllocatorTest"},
+		),
+	}
+
+	for i := 0; i < updateMaxRetries; i++ {
+		ca.handleErr(fmt.Errorf("test error"), nodeName)
+		if ca.queue.NumRequeues(nodeName) != i+1 {
+			t.Fatalf("expected %d requeues, got %d", i+1, ca.queue.NumRequeues(nodeName))
+		}
+	}
+
+	ca.handleErr(fmt.Errorf("test error"), nodeName)
+	if ca.queue.NumRequeues(nodeName) != 0 {
+		t.Fatalf("expected item to be dropped from queue and requeues reset, but got %d", ca.queue.NumRequeues(nodeName))
+	}
+}
+
+func TestCloudCIDRAllocatorRateLimiter(t *testing.T) {
+	rl := workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(updateRetryTimeout, maxUpdateRetryTimeout),
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+	nodeName := "testNode"
+
+	var lastDelay time.Duration
+	for i := 0; i < updateMaxRetries; i++ {
+		delay := rl.When(nodeName)
+		if delay > maxUpdateRetryTimeout {
+			t.Fatalf("expected delay %v to be <= max retry timeout %v", delay, maxUpdateRetryTimeout)
+		}
+		if delay < lastDelay {
+			t.Fatalf("expected delay %v to be >= previous delay %v", delay, lastDelay)
+		}
+		lastDelay = delay
+	}
+	if lastDelay != maxUpdateRetryTimeout {
+		t.Fatalf("expected final delay to be max retry timeout %v, got %v", maxUpdateRetryTimeout, lastDelay)
 	}
 }
 

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -782,7 +782,7 @@ func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
 }
 
 func (g *Cloud) getInstanceFromProjectInZoneByName(project, zone, name string) (*gceInstance, error) {
-	ctx, cancel := cloud.ContextWithCallTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 
 	name = canonicalizeInstanceName(name)

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -721,4 +722,33 @@ func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
 	// Verify that managedZones has dynamically updated to include both zones
 	expectedZones := []string{"us-central1-b", "us-central1-c"}
 	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
+}
+
+func TestGetInstanceFromProjectInZoneByNameTimeout(t *testing.T) {
+	gce, err := fakeGCECloud(DefaultTestClusterValues())
+	require.NoError(t, err)
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+	mi := mockGCE.Instances().(*cloud.MockInstances)
+
+	var ctxDeadline time.Time
+	var hasDeadline bool
+
+	mi.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockInstances, options ...cloud.Option) (bool, *ga.Instance, error) {
+		ctxDeadline, hasDeadline = ctx.Deadline()
+		return true, &ga.Instance{
+			Name: "test-instance",
+			Zone: "us-central1-c",
+		}, nil
+	}
+
+	startTime := time.Now()
+	_, err = gce.getInstanceFromProjectInZoneByName("test-project", "us-central1-c", "test-instance")
+	require.NoError(t, err)
+
+	require.True(t, hasDeadline, "Context should have a deadline")
+
+	timeoutDuration := ctxDeadline.Sub(startTime)
+	// The timeout should be roughly 6 seconds, use InDelta to allow for some execution time variance
+	assert.InDelta(t, 6*time.Second, timeoutDuration, float64(1*time.Second))
 }

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -722,33 +721,4 @@ func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
 	// Verify that managedZones has dynamically updated to include both zones
 	expectedZones := []string{"us-central1-b", "us-central1-c"}
 	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
-}
-
-func TestGetInstanceFromProjectInZoneByNameTimeout(t *testing.T) {
-	gce, err := fakeGCECloud(DefaultTestClusterValues())
-	require.NoError(t, err)
-
-	mockGCE := gce.c.(*cloud.MockGCE)
-	mi := mockGCE.Instances().(*cloud.MockInstances)
-
-	var ctxDeadline time.Time
-	var hasDeadline bool
-
-	mi.GetHook = func(ctx context.Context, key *meta.Key, m *cloud.MockInstances, options ...cloud.Option) (bool, *ga.Instance, error) {
-		ctxDeadline, hasDeadline = ctx.Deadline()
-		return true, &ga.Instance{
-			Name: "test-instance",
-			Zone: "us-central1-c",
-		}, nil
-	}
-
-	startTime := time.Now()
-	_, err = gce.getInstanceFromProjectInZoneByName("test-project", "us-central1-c", "test-instance")
-	require.NoError(t, err)
-
-	require.True(t, hasDeadline, "Context should have a deadline")
-
-	timeoutDuration := ctxDeadline.Sub(startTime)
-	// The timeout should be roughly 6 seconds, use InDelta to allow for some execution time variance
-	assert.InDelta(t, 6*time.Second, timeoutDuration, float64(1*time.Second))
 }


### PR DESCRIPTION
Removed "// indirect" comment in go.mod