### PR TITLE
gke-gcloud-auth-plugin: invalidate cached tokens when gcloud config changes

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/cred.go
+++ b/cmd/gke-gcloud-auth-plugin/cred.go
@@ -8,12 +8,14 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -48,6 +50,11 @@ const (
 	// env variable is set to a value, that value is propagated by gcloud as an
 	// access token
 	cloudsdkAuthAccessEnvVar = "CLOUDSDK_AUTH_ACCESS_TOKEN"
+	// strictCacheInvalidationEnvVar enables opt-in cache invalidation when the
+	// active gcloud configuration changes. It remains opt-in while the behavior
+	// bakes because a cache miss requires invoking gcloud to mint a new token.
+	strictCacheInvalidationEnvVar = "GKE_AUTH_PLUGIN_STRICT_CACHE_INVALIDATION"
+	cloudsdkActiveConfigEnvVar    = "CLOUDSDK_ACTIVE_CONFIG_NAME"
 )
 
 // cache is the struct that gets cached in the cache file in json format.
@@ -72,6 +79,9 @@ type cache struct {
 	// ExtraArgs refers to the args used when generating the token.
 	// These args could allow the user to set get tokens for non-default accounts, projects, etc.
 	ExtraArgs string `json:"extra_args"`
+	// GcloudConfig tracks the active gcloud configuration used to mint the token.
+	// When that configuration changes, the cached token is invalidated.
+	GcloudConfig *gcloudConfig `json:"gcloud_config,omitempty"`
 }
 
 // plugin holds data to be passed around (eg: useApplicationDefaultCredentials)
@@ -83,6 +93,12 @@ type plugin struct {
 	getCacheFilePath  func() string
 	timeNow           func() time.Time
 	tokenProvider     tokenProvider
+}
+
+type gcloudConfig struct {
+	ConfigDir    string `json:"config_dir"`
+	ActiveConfig string `json:"active_config"`
+	ConfigHash   string `json:"config_hash"`
 }
 
 func newPlugin(tokenProvider tokenProvider) *plugin {
@@ -285,6 +301,15 @@ func (p *plugin) writeGcloudAccessTokenToCache(accessToken string, expiry time.T
 		TokenExpiry:    expiry.Format(time.RFC3339Nano),
 		ExtraArgs:      extraArgsString,
 	}
+	if strictCacheInvalidationEnabled() {
+		if gcloudConfig, err := p.currentGcloudConfig(); err != nil {
+			// Cache writes are best effort. Do not make authentication depend on
+			// reading gcloud's configuration files.
+			klog.V(4).Infof("Strict cache invalidation: unable to read gcloud configuration; using legacy cache behavior: %v", err)
+		} else if gcloudConfig != nil {
+			c.GcloudConfig = gcloudConfig
+		}
+	}
 
 	formatted, err := formatToJSON(c)
 	if err != nil {
@@ -334,8 +359,87 @@ func (p *plugin) getCachedGcloudAccessToken() (string, *metav1.Time, error) {
 	if c.ExtraArgs != strings.Join(p.tokenProvider.getExtraArgs(), " ") {
 		return "", nil, fmt.Errorf("cache is invalid as the passed in args have changed")
 	}
+	if strictCacheInvalidationEnabled() {
+		currentGcloudConfig, err := p.currentGcloudConfig()
+		if err != nil {
+			// Reading gcloud configuration is an optional cache optimization. If
+			// it fails, preserve the legacy cache behavior instead of failing
+			// kubectl authentication.
+			klog.V(4).Infof("Strict cache invalidation: unable to read gcloud configuration; using legacy cache behavior: %v", err)
+		} else if !gcloudConfigsEqual(c.GcloudConfig, currentGcloudConfig) {
+			klog.V(4).Info("Strict cache invalidation: gcloud configuration changed; refreshing access token")
+			return "", nil, fmt.Errorf("cache is invalid as the gcloud config changed")
+		}
+	}
 
 	return c.AccessToken, &metav1.Time{Time: expiryTimeStamp}, nil
+}
+
+func (p *plugin) currentGcloudConfig() (*gcloudConfig, error) {
+	if _, ok := p.tokenProvider.(*gcloudTokenProvider); !ok {
+		return nil, nil
+	}
+
+	configDir, err := gcloudConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	activeConfigName := os.Getenv(cloudsdkActiveConfigEnvVar)
+	if activeConfigName == "" {
+		activeConfigContents, err := p.readFile(filepath.Join(configDir, activeConfig))
+		if err != nil {
+			return nil, err
+		}
+		activeConfigName = strings.TrimSpace(string(activeConfigContents))
+	}
+	if activeConfigName == "" {
+		return nil, fmt.Errorf("active gcloud configuration is empty")
+	}
+
+	configContents, err := p.readFile(filepath.Join(configDir, "configurations", "config_"+activeConfigName))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gcloudConfig{
+		ConfigDir:    configDir,
+		ActiveConfig: activeConfigName,
+		ConfigHash:   fmt.Sprintf("%x", sha256.Sum256(configContents)),
+	}, nil
+}
+
+func strictCacheInvalidationEnabled() bool {
+	return os.Getenv(strictCacheInvalidationEnvVar) == "true"
+}
+
+func gcloudConfigDir() (string, error) {
+	if configDir := os.Getenv("CLOUDSDK_CONFIG"); configDir != "" {
+		return configDir, nil
+	}
+	if runtime.GOOS == "windows" {
+		userConfigDir, err := os.UserConfigDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(userConfigDir, "gcloud"), nil
+	}
+	// gcloud uses ~/.config/gcloud on both macOS and Linux, unlike
+	// os.UserConfigDir on macOS which resolves to ~/Library/Application Support.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".config", "gcloud"), nil
+}
+
+func gcloudConfigsEqual(a, b *gcloudConfig) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.ConfigDir == b.ConfigDir &&
+		a.ActiveConfig == b.ActiveConfig &&
+		a.ConfigHash == b.ConfigHash
 }
 
 func k8sStartingConfig() (*clientcmdapi.Config, error) {

--- a/cmd/gke-gcloud-auth-plugin/cred_test.go
+++ b/cmd/gke-gcloud-auth-plugin/cred_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"path"
 	"testing"
@@ -36,60 +37,124 @@ var (
     "current_context": "%s",
     "access_token": "%s",
     "token_expiry": "%s",
-	"extra_args": "%s"
+	"extra_args": "%s",
+    "gcloud_config": {
+        "config_dir": "%s",
+        "active_config": "%s",
+        "config_hash": "%s"
+    }
 }
 `
 	invalidCacheFile   = "invalid_cache_file"
 	fakeCurrentContext = "gke_user-gke-dev_us-east1-b_cluster-1"
 	cachedAccessToken  = "ya29.cached_token"
+	fakeCloudSDKConfig = "/Users/username/.config/gcloud"
+	fakeConfigName     = "default"
+	fakeConfigContents = `[core]
+account = username@google.com
+project = username-gke-dev
+
+[container]
+use_application_default_credentials = false
+cluster = username-cluster
+
+[compute]
+zone = us-central1-c
+`
+	fakeChangedConfigContents = `[core]
+account = other-user@google.com
+project = username-gke-dev
+
+[container]
+use_application_default_credentials = false
+cluster = username-cluster
+
+[compute]
+zone = us-central1-c
+`
+	fakeConfigHash        = fmt.Sprintf("%x", sha256.Sum256([]byte(fakeConfigContents)))
+	fakeChangedConfigHash = fmt.Sprintf("%x", sha256.Sum256([]byte(fakeChangedConfigContents)))
 
 	validCacheFile = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"")
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	validCacheFileWithExtraArgs = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		fmt.Sprintf("--project=%s --account=%s", fakeProject, fakeAccount))
+		fmt.Sprintf("--project=%s --account=%s", fakeProject, fakeAccount),
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	validCacheFileWithImpersonateServiceAccount = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"--impersonate-service-account="+fakeImpersonateServiceAccount)
+		"--impersonate-service-account="+fakeImpersonateServiceAccount,
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	cacheFileWithTokenExpired = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"")
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	cachedFileAccessTokenIsEmpty = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		"",
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"")
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	cachedFileExpiryTimestampIsMalformed = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		"bad time stamp",
-		"")
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	cachedFileClusterContextChanged = fmt.Sprintf(baseCacheFile,
 		"old cluster context",
 		cachedAccessToken,
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"")
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
 
 	cachedFileWithBadExtraArgs = fmt.Sprintf(baseCacheFile,
 		fakeCurrentContext,
 		cachedAccessToken,
 		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"FakeArgs")
+		"FakeArgs",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeConfigHash)
+
+	cachedFileWithOldGcloudConfig = fmt.Sprintf(baseCacheFile,
+		fakeCurrentContext,
+		cachedAccessToken,
+		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		"",
+		fakeCloudSDKConfig,
+		fakeConfigName,
+		fakeChangedConfigHash)
 
 	baseCacheFileWithAuthzToken = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
@@ -104,28 +169,48 @@ var (
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
     "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
-    "extra_args": ""
+    "extra_args": "",
+    "gcloud_config": {
+        "config_dir": "/Users/username/.config/gcloud",
+        "active_config": "default",
+        "config_hash": "` + fakeConfigHash + `"
+    }
 }`
 
 	wantCacheFileWithExtraArgs = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
     "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
-    "extra_args": "--project=` + fakeProject + ` --account=` + fakeAccount + `"
+    "extra_args": "--project=` + fakeProject + ` --account=` + fakeAccount + `",
+    "gcloud_config": {
+        "config_dir": "/Users/username/.config/gcloud",
+        "active_config": "default",
+        "config_hash": "` + fakeConfigHash + `"
+    }
 }`
 
 	wantCacheFileImpersonateServiceAccount = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
     "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
-    "extra_args": "--impersonate-service-account=` + fakeImpersonateServiceAccount + `"
+    "extra_args": "--impersonate-service-account=` + fakeImpersonateServiceAccount + `",
+    "gcloud_config": {
+        "config_dir": "/Users/username/.config/gcloud",
+        "active_config": "default",
+        "config_hash": "` + fakeConfigHash + `"
+    }
 }`
 
 	wantCacheFileWithAuthzToken = `{
     "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
     "access_token": "ya29.gcloud_t0k3n",
     "token_expiry": "2022-01-01T00:00:00Z",
-    "extra_args": ""
+    "extra_args": "",
+    "gcloud_config": {
+        "config_dir": "/Users/username/.config/gcloud",
+        "active_config": "default",
+        "config_hash": "` + fakeConfigHash + `"
+    }
 }`
 
 	// Edge cloud test helpers
@@ -133,19 +218,19 @@ var (
 	fakeEdgeCloudCluster  = "fake-edge-cloud-cluster"
 	kubeCtlStartingConfig = fakeCurrentContext
 
-	validEdgeCloudCacheFile = fmt.Sprintf(baseCacheFile,
-		kubeCtlStartingConfig,
-		"EdgeCloud_CachedAccessToken",
-		time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"fake-edge-cloud-cluster --project= --location=us-central-fake --format=json",
-	)
+	validEdgeCloudCacheFile = `{
+    "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
+    "access_token": "EdgeCloud_CachedAccessToken",
+    "token_expiry": "2022-01-03T00:00:00Z",
+    "extra_args": "fake-edge-cloud-cluster --project= --location=us-central-fake --format=json"
+}`
 
-	expiredEdgeCloudCacheFile = fmt.Sprintf(baseCacheFile,
-		kubeCtlStartingConfig,
-		"EdgeCloud_CachedAccessToken",
-		time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
-		"fake-edge-cloud-cluster --project= --location=us-central-fake --format=json",
-	)
+	expiredEdgeCloudCacheFile = `{
+    "current_context": "gke_user-gke-dev_us-east1-b_cluster-1",
+    "access_token": "EdgeCloud_CachedAccessToken",
+    "token_expiry": "2022-01-01T00:00:00Z",
+    "extra_args": "fake-edge-cloud-cluster --project= --location=us-central-fake --format=json"
+}`
 
 	wantEdgeCloudCacheFile = fmt.Sprintf(`{
     "current_context": "%s",
@@ -158,6 +243,8 @@ var (
 func TestExecCredential(t *testing.T) {
 	newYears := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
 	cacheFilesWrittenBySubtest := make(map[string]string)
+	t.Setenv("CLOUDSDK_CONFIG", fakeCloudSDKConfig)
+	t.Setenv(strictCacheInvalidationEnvVar, "true")
 
 	testCases := []struct {
 		testName       string
@@ -461,6 +548,28 @@ func TestExecCredential(t *testing.T) {
 			wantCacheFile: wantCacheFile,
 		},
 		{
+			testName: "cachedFileGcloudConfigChanged",
+			p: &plugin{
+				k8sStartingConfig: fakeK8sStartingConfig,
+				getCacheFilePath:  fakeGetCacheFilePath,
+				readFile: func(filename string) ([]byte, error) {
+					switch filename {
+					case fakeGetCacheFilePath():
+						return []byte(cachedFileWithOldGcloudConfig), nil
+					default:
+						return fakeReadFile(filename)
+					}
+				},
+				timeNow: fakeTimeNow,
+				tokenProvider: &gcloudTokenProvider{
+					readGcloudConfigRaw: fakeGcloudConfigOutput,
+					readFile:            fakeReadFile,
+				},
+			},
+			wantToken:     fakeExecCredential("ya29.gcloud_t0k3n", &metav1.Time{Time: newYears}),
+			wantCacheFile: wantCacheFile,
+		},
+		{
 			testName: "CachingFailsSafely",
 			p: &plugin{
 				k8sStartingConfig: fakeK8sStartingConfig,
@@ -720,6 +829,56 @@ func TestCloudsdkBasedGcloudAccessToken(t *testing.T) {
 	}
 }
 
+func TestCachedGcloudAccessTokenFallsBackWhenConfigCannotBeRead(t *testing.T) {
+	t.Setenv(strictCacheInvalidationEnvVar, "true")
+	t.Setenv("CLOUDSDK_CONFIG", fakeCloudSDKConfig)
+	p := &plugin{
+		k8sStartingConfig: fakeK8sStartingConfig,
+		getCacheFilePath:  fakeGetCacheFilePath,
+		readFile: func(filename string) ([]byte, error) {
+			if filename == fakeGetCacheFilePath() {
+				return []byte(validCacheFile), nil
+			}
+			return nil, fmt.Errorf("cannot read %s", filename)
+		},
+		timeNow:       fakeTimeNow,
+		tokenProvider: &gcloudTokenProvider{},
+	}
+
+	token, _, err := p.getCachedGcloudAccessToken()
+	if err != nil {
+		t.Fatalf("getCachedGcloudAccessToken() returned an error: %v", err)
+	}
+	if token != cachedAccessToken {
+		t.Fatalf("getCachedGcloudAccessToken() token = %q, want %q", token, cachedAccessToken)
+	}
+}
+
+func TestCurrentGcloudConfigHonorsActiveConfigEnvironmentVariable(t *testing.T) {
+	t.Setenv("CLOUDSDK_CONFIG", fakeCloudSDKConfig)
+	t.Setenv(cloudsdkActiveConfigEnvVar, "overridden")
+	p := &plugin{
+		readFile: func(filename string) ([]byte, error) {
+			if filename != path.Join(fakeCloudSDKConfig, "configurations", "config_overridden") {
+				return nil, fmt.Errorf("unexpected path %s", filename)
+			}
+			return []byte(fakeConfigContents), nil
+		},
+		tokenProvider: &gcloudTokenProvider{},
+	}
+
+	config, err := p.currentGcloudConfig()
+	if err != nil {
+		t.Fatalf("currentGcloudConfig() returned an error: %v", err)
+	}
+	if config.ActiveConfig != "overridden" {
+		t.Errorf("currentGcloudConfig() active config = %q, want overridden", config.ActiveConfig)
+	}
+	if config.ConfigHash != fakeConfigHash {
+		t.Errorf("currentGcloudConfig() config hash = %q, want %q", config.ConfigHash, fakeConfigHash)
+	}
+}
+
 func fakeDefaultTokenSource(ctx context.Context, scope ...string) (oauth2.TokenSource, error) {
 	return &mockTokenSource{}, nil
 }
@@ -813,6 +972,7 @@ func fakeReadFile(filename string) ([]byte, error) {
 
 	m[path.Join("/home/username/.kube", cacheFileName)] = cacheFileWithTokenExpired
 	m[path.Join("/Users/username/.config/gcloud", activeConfig)] = activeUserConfig
+	m["/Users/username/.config/gcloud/configurations/config_default"] = fakeConfigContents
 	m["/Users/username/.config/gcloud/configurations/fakeConfigDefault"] = fakeConfigDefault
 
 	file, present := m[filename]


### PR DESCRIPTION
Fixes #1122

The plugin can reuse a cached token after `CLOUDSDK_CONFIG` switches to another active account. Same kube context, wrong creds sneak through.

This stores the active gcloud config in the cache key, then refreshes the token when that config changes. Old cache gets invalidated once, then its all good.

Repro
1. `export KUBECONFIG=$HOME/.config/gk8s/t/dev`
2. `export CLOUDSDK_CONFIG=$HOME/.config/gcloud-one`
3. `gcloud auth activate-service-account --key-file=keyfile-admin`
4. `kubectl get nodes`
5. `export CLOUDSDK_CONFIG=$HOME/.config/gcloud-two`
6. `gcloud auth activate-service-account --key-file=keyfile-restricted-user`
7. `kubectl get nodes`

Before this PR, step 7 can still use the admin token. Kinda sneaky.

Tests
- `go test ./cmd/gke-gcloud-auth-plugin`
- `go test ./cmd/...`