### PR TITLE
[release-1.36] Cherrypick: Implement self-contained GWI token exchange in auth-provider-gcp (#1202)

### DIFF
--- a/cmd/auth-provider-gcp/app/getcredentials.go
+++ b/cmd/auth-provider-gcp/app/getcredentials.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -40,8 +41,13 @@ const (
 
 // CredentialOptions contains a representation of the options passed to the credential provider.
 type CredentialOptions struct {
-	AuthFlow string
+	AuthFlow         string
+	IdentityProvider string
+	ProjectID        string
 }
+
+// ErrProjectIDRequired is returned when --identity-provider is set but --project-id is empty.
+var ErrProjectIDRequired = errors.New("--project-id is required when --identity-provider is set")
 
 // AuthFlowFlagError represents an error that occurred during flag validation.
 type AuthFlowFlagError struct {
@@ -81,22 +87,22 @@ func NewGetCredentialsCommand() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "get-credentials",
 		Short: "Get authentication credentials",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateFlags(&options)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return getCredentials(options.AuthFlow)
+			return getCredentials(options)
 		},
 	}
 	defineFlags(cmd, &options)
-	if err := validateFlags(&options); err != nil {
-		return nil, err
-	}
 	return cmd, nil
 }
 
-func providerFromFlow(flow string) (credentialconfig.DockerConfigProvider, error) {
+func providerFromFlow(flow string, req credentialproviderapi.CredentialProviderRequest, options CredentialOptions) (credentialconfig.DockerConfigProvider, error) {
 	transport := utilnet.SetTransportDefaults(&http.Transport{})
 	switch flow {
 	case gcrAuthFlow:
-		return provider.MakeRegistryProvider(transport), nil
+		return provider.MakeRegistryProvider(transport, req.ServiceAccountToken, req.ServiceAccountAnnotations, options.IdentityProvider, options.ProjectID), nil
 	case dockerConfigAuthFlow:
 		return provider.MakeDockerConfigProvider(transport), nil
 	case dockerConfigURLAuthFlow:
@@ -106,11 +112,10 @@ func providerFromFlow(flow string) (credentialconfig.DockerConfigProvider, error
 	}
 }
 
-func getCredentials(authFlow string) error {
-	klog.V(2).Infof("get-credentials (authFlow %s)", authFlow)
-	authProvider, err := providerFromFlow(authFlow)
-	if err != nil {
-		return err
+func getCredentials(options CredentialOptions) error {
+	klog.V(2).Infof("get-credentials (authFlow %s)", options.AuthFlow)
+	if options.IdentityProvider != "" {
+		klog.V(2).Infof("auth-provider-gcp: Workload Identity flow is enabled (identity-provider: %q)", options.IdentityProvider)
 	}
 	unparsedRequest, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
@@ -121,7 +126,11 @@ func getCredentials(authFlow string) error {
 	if err != nil {
 		return fmt.Errorf("error unmarshaling auth credential request: %w", err)
 	}
-	authCredentials, err := provider.GetResponse(authRequest.Image, authProvider)
+	authProvider, err := providerFromFlow(options.AuthFlow, authRequest, options)
+	if err != nil {
+		return err
+	}
+	authCredentials, err := provider.GetResponse(authRequest, authProvider)
 	if err != nil {
 		return fmt.Errorf("error getting authentication response from provider: %w", err)
 	}
@@ -137,11 +146,19 @@ func getCredentials(authFlow string) error {
 
 func defineFlags(credCmd *cobra.Command, options *CredentialOptions) {
 	credCmd.Flags().StringVarP(&options.AuthFlow, "authFlow", "a", gcrAuthFlow, fmt.Sprintf("authentication flow (valid values are %q, %q, and %q)", gcrAuthFlow, dockerConfigAuthFlow, dockerConfigURLAuthFlow))
+	credCmd.Flags().StringVar(&options.IdentityProvider, "identity-provider", "", "Target Identity Provider URL to request federated tokens from. Only takes effect when --authFlow=gcr. If configured, it enables Workload Identity flow.")
+	credCmd.Flags().StringVar(&options.ProjectID, "project-id", "", "The GCP Project ID. Required when --identity-provider is configured.")
 }
 
 func validateFlags(options *CredentialOptions) error {
 	if options.AuthFlow != gcrAuthFlow && options.AuthFlow != dockerConfigAuthFlow && options.AuthFlow != dockerConfigURLAuthFlow {
 		return &AuthFlowFlagError{flagValue: options.AuthFlow}
+	}
+	if options.IdentityProvider != "" && options.AuthFlow != gcrAuthFlow {
+		klog.Warningf("auth-provider-gcp: --identity-provider was set but --authFlow is %q. This flag only has effect when --authFlow=gcr.", options.AuthFlow)
+	}
+	if options.IdentityProvider != "" && options.ProjectID == "" {
+		return ErrProjectIDRequired
 	}
 	return nil
 }

--- a/cmd/auth-provider-gcp/app/getcredentials_test.go
+++ b/cmd/auth-provider-gcp/app/getcredentials_test.go
@@ -21,36 +21,44 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	credentialproviderapi "k8s.io/kubelet/pkg/apis/credentialprovider/v1"
 )
 
 func TestValidateAuthFlow(t *testing.T) {
 	type FlagResult struct {
-		Name  string
-		Flow  string
-		Error error
+		Name    string
+		Options CredentialOptions
+		Error   error
 	}
 	tests := []FlagResult{
-		{Name: "validate gcr auth flow", Flow: gcrAuthFlow},
-		{Name: "validate docker-cfg auth flow option", Flow: dockerConfigAuthFlow},
-		{Name: "validate docker-cfg-url auth flow option", Flow: dockerConfigURLAuthFlow},
-		{Name: "bad auth flow option", Flow: "bad-flow", Error: &AuthFlowFlagError{flagValue: "bad-flow"}},
-		{Name: "empty auth flow option", Flow: "", Error: &AuthFlowFlagError{flagValue: ""}},
-		{Name: "case-sensitive auth flow", Flow: "Gcrauthflow", Error: &AuthFlowFlagError{flagValue: "Gcrauthflow"}},
+		{Name: "validate gcr auth flow", Options: CredentialOptions{AuthFlow: gcrAuthFlow}},
+		{Name: "validate docker-cfg auth flow option", Options: CredentialOptions{AuthFlow: dockerConfigAuthFlow}},
+		{Name: "validate docker-cfg-url auth flow option", Options: CredentialOptions{AuthFlow: dockerConfigURLAuthFlow}},
+		{Name: "bad auth flow option", Options: CredentialOptions{AuthFlow: "bad-flow"}, Error: &AuthFlowFlagError{flagValue: "bad-flow"}},
+		{Name: "empty auth flow option", Options: CredentialOptions{AuthFlow: ""}, Error: &AuthFlowFlagError{flagValue: ""}},
+		{Name: "case-sensitive auth flow", Options: CredentialOptions{AuthFlow: "Gcrauthflow"}, Error: &AuthFlowFlagError{flagValue: "Gcrauthflow"}},
+		{Name: "identity-provider and project-id with gcr flow", Options: CredentialOptions{AuthFlow: gcrAuthFlow, IdentityProvider: "https://container.googleapis.com/...", ProjectID: "my-project"}},
+		{Name: "identity-provider and project-id with dockercfg flow", Options: CredentialOptions{AuthFlow: dockerConfigAuthFlow, IdentityProvider: "https://container.googleapis.com/...", ProjectID: "my-project"}},
+		{Name: "identity-provider and project-id with dockercfg-url flow", Options: CredentialOptions{AuthFlow: dockerConfigURLAuthFlow, IdentityProvider: "https://container.googleapis.com/...", ProjectID: "my-project"}},
+		{Name: "identity-provider without project-id with gcr flow", Options: CredentialOptions{AuthFlow: gcrAuthFlow, IdentityProvider: "https://container.googleapis.com/..."}, Error: ErrProjectIDRequired},
+		{Name: "identity-provider without project-id with dockercfg flow", Options: CredentialOptions{AuthFlow: dockerConfigAuthFlow, IdentityProvider: "https://container.googleapis.com/..."}, Error: ErrProjectIDRequired},
+		{Name: "identity-provider without project-id with dockercfg-url flow", Options: CredentialOptions{AuthFlow: dockerConfigURLAuthFlow, IdentityProvider: "https://container.googleapis.com/..."}, Error: ErrProjectIDRequired},
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := validateFlags(&CredentialOptions{AuthFlow: tc.Flow})
+			err := validateFlags(&tc.Options)
 			if tc.Error != nil {
 				if err == nil {
-					t.Fatalf("with flow %q did not get expected error %q", tc.Flow, err)
+					t.Fatalf("with options %+v did not get expected error %q", tc.Options, tc.Error)
 				}
 				if !errors.Is(err, tc.Error) {
-					t.Fatalf("with flow %q got unexpected error type %q (expected %q)", tc.Flow, reflect.TypeOf(err), reflect.TypeOf(tc.Error))
+					t.Fatalf("with options %+v got unexpected error type %q (expected %q)", tc.Options, reflect.TypeOf(err), reflect.TypeOf(tc.Error))
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("with flow %q unexpected error %q", tc.Flow, err)
+				t.Fatalf("with options %+v unexpected error %q", tc.Options, err)
 			}
 		})
 	}
@@ -72,7 +80,7 @@ func TestProviderFromFlow(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			provider, err := providerFromFlow(tc.Flow)
+			provider, err := providerFromFlow(tc.Flow, credentialproviderapi.CredentialProviderRequest{}, CredentialOptions{AuthFlow: tc.Flow})
 			if tc.Error != nil {
 				if err == nil {
 					t.Fatalf("with flow %q did not get expected error %q", tc.Flow, err)
@@ -130,7 +138,7 @@ func TestFlowError(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := providerFromFlow(tc.Flow)
+			_, err := providerFromFlow(tc.Flow, credentialproviderapi.CredentialProviderRequest{}, CredentialOptions{AuthFlow: tc.Flow})
 			if !errors.Is(err, &tc.ExpectedError) {
 				t.Fatalf("did not get expected error %q (got %q instead", &tc.ExpectedError, err)
 			}

--- a/cmd/auth-provider-gcp/provider/provider.go
+++ b/cmd/auth-provider-gcp/provider/provider.go
@@ -35,23 +35,35 @@ const (
 	cacheDurationKey          = "KUBE_SIDECAR_CACHE_DURATION"
 	cacheTypeKey              = "KUBE_SIDECAR_CACHE_TYPE"
 	metadataHTTPClientTimeout = time.Second * 10
+	stsHTTPClientTimeout      = time.Second * 30
 	apiKind                   = "CredentialProviderResponse"
 	apiVersion                = "credentialprovider.kubelet.k8s.io/v1"
 )
 
 // MakeRegistryProvider returns a ContainerRegistryProvider with the given transport.
-func MakeRegistryProvider(transport *http.Transport) *gcpcredential.ContainerRegistryProvider {
-	httpClient := makeHTTPClient(transport)
+func MakeRegistryProvider(transport *http.Transport, token string, annotations map[string]string, identityProvider string, projectID string) *gcpcredential.ContainerRegistryProvider {
+	isAnnotated := annotations[gcpcredential.EnableWIImagePullAnnotation] == "true"
+
+	timeout := metadataHTTPClientTimeout
+	if identityProvider != "" && isAnnotated && token != "" {
+		timeout = stsHTTPClientTimeout
+	}
+
+	httpClient := makeHTTPClient(transport, timeout)
 	provider := &gcpcredential.ContainerRegistryProvider{
-		MetadataProvider:     gcpcredential.MetadataProvider{Client: httpClient},
-		UseRegistryFromImage: true,
+		MetadataProvider:          gcpcredential.MetadataProvider{Client: httpClient},
+		UseRegistryFromImage:      true,
+		KSAToken:                  token,
+		ServiceAccountAnnotations: annotations,
+		IdentityProvider:          identityProvider,
+		ProjectID:                 projectID,
 	}
 	return provider
 }
 
 // MakeDockerConfigProvider returns a DockerConfigKeyProvider with the given transport.
 func MakeDockerConfigProvider(transport *http.Transport) *gcpcredential.DockerConfigKeyProvider {
-	httpClient := makeHTTPClient(transport)
+	httpClient := makeHTTPClient(transport, metadataHTTPClientTimeout)
 	provider := &gcpcredential.DockerConfigKeyProvider{
 		MetadataProvider: gcpcredential.MetadataProvider{Client: httpClient},
 	}
@@ -60,17 +72,17 @@ func MakeDockerConfigProvider(transport *http.Transport) *gcpcredential.DockerCo
 
 // MakeDockerConfigURLProvider returns a DockerConfigURLKeyProvider with the given transport.
 func MakeDockerConfigURLProvider(transport *http.Transport) *gcpcredential.DockerConfigURLKeyProvider {
-	httpClient := makeHTTPClient(transport)
+	httpClient := makeHTTPClient(transport, metadataHTTPClientTimeout)
 	provider := &gcpcredential.DockerConfigURLKeyProvider{
 		MetadataProvider: gcpcredential.MetadataProvider{Client: httpClient},
 	}
 	return provider
 }
 
-func makeHTTPClient(transport *http.Transport) *http.Client {
+func makeHTTPClient(transport *http.Transport, timeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: transport,
-		Timeout:   metadataHTTPClientTimeout,
+		Timeout:   timeout,
 	}
 }
 
@@ -109,8 +121,8 @@ func getCacheKeyType() (credentialproviderapi.PluginCacheKeyType, error) {
 }
 
 // GetResponse queries the given provider for credentials.
-func GetResponse(image string, provider credentialconfig.DockerConfigProvider) (*credentialproviderapi.CredentialProviderResponse, error) {
-	cfg := provider.Provide(image)
+func GetResponse(req credentialproviderapi.CredentialProviderRequest, provider credentialconfig.DockerConfigProvider) (*credentialproviderapi.CredentialProviderResponse, error) {
+	cfg := provider.Provide(req.Image)
 	response := &credentialproviderapi.CredentialProviderResponse{Auth: make(map[string]credentialproviderapi.AuthConfig)}
 	for url, dockerConfig := range cfg {
 		response.Auth[url] = credentialproviderapi.AuthConfig{Username: dockerConfig.Username, Password: dockerConfig.Password}

--- a/cmd/auth-provider-gcp/provider/provider_test.go
+++ b/cmd/auth-provider-gcp/provider/provider_test.go
@@ -16,9 +16,12 @@ limitations under the License.
 package provider
 
 import (
+	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -81,8 +84,8 @@ func TestContainerRegistry(t *testing.T) {
 			return url.Parse(server.URL + req.URL.Path)
 		},
 	})
-	provider := MakeRegistryProvider(transport)
-	response, err := GetResponse(dummyImage, provider)
+	provider := MakeRegistryProvider(transport, "", nil, "", "")
+	response, err := GetResponse(credentialproviderapi.CredentialProviderRequest{Image: dummyImage}, provider)
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
 	}
@@ -104,6 +107,121 @@ func TestContainerRegistry(t *testing.T) {
 		}
 		if dummyToken != auth.Password {
 			t.Errorf("Expected password %s not found (password: %s)", dummyToken, auth.Password)
+		}
+	}
+}
+
+func TestContainerRegistry_WorkloadIdentity(t *testing.T) {
+	registryURL := strings.Split(dummyImage, "/")[0]
+	gcpRegistryURL := "container.cloud.google.com"
+
+	ksaToken := "dummyHeader.eyJpc3MiOiAiaHR0cHM6Ly9jb250YWluZXIuZ29vZ2xlYXBpcy5jb20vdjEvcHJvamVjdHMvbXktcHJvamVjdC9sb2NhdGlvbnMvdXMtY2VudHJhbDEvY2x1c3RlcnMvbXktY2x1c3RlciJ9.dummySignature"
+	federatedToken := "federated-token-xyz"
+
+	// 1. Mock Metadata Server (HTTP)
+	metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defaultPrefix := "/computeMetadata/v1/instance/service-accounts/default/"
+		switch r.URL.Path {
+		case "/computeMetadata/v1/instance/attributes/cluster-name":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "my-cluster")
+		case "/computeMetadata/v1/instance/attributes/cluster-location":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "us-central1")
+		case "/computeMetadata/v1/project/project-id":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "my-project")
+		case defaultPrefix + "scopes":
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `["%s.read_write"]`, gcpcredential.StorageScopePrefix)
+		case defaultPrefix + "email":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, email)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected metadata path %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer metadataServer.Close()
+
+	// 2. Mock STS Server (HTTPS/TLS)
+	stsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/token" {
+			var reqPayload struct {
+				Audience           string `json:"audience"`
+				GrantType          string `json:"grant_type"`
+				RequestedTokenType string `json:"requested_token_type"`
+				SubjectToken       string `json:"subject_token"`
+				SubjectTokenType   string `json:"subject_token_type"`
+			}
+			err := json.NewDecoder(r.Body).Decode(&reqPayload)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			expectedAudience := "identitynamespace:my-project.svc.id.goog:https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster"
+			if reqPayload.Audience != expectedAudience {
+				http.Error(w, fmt.Sprintf("unexpected audience %q", reqPayload.Audience), http.StatusBadRequest)
+				return
+			}
+			if reqPayload.SubjectToken != ksaToken {
+				http.Error(w, fmt.Sprintf("unexpected subject token %q", reqPayload.SubjectToken), http.StatusBadRequest)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"access_token": %q, "expires_in": 3600, "token_type": "Bearer"}`, federatedToken)
+		} else {
+			http.Error(w, fmt.Sprintf("unexpected STS path %s", r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer stsServer.Close()
+
+	// Parse ports to use in DialContext
+	_, metadataPort, _ := net.SplitHostPort(metadataServer.Listener.Addr().String())
+	_, stsPort, _ := net.SplitHostPort(stsServer.Listener.Addr().String())
+
+	// 3. Configure Transport to redirect traffic
+	transport := utilnet.SetTransportDefaults(&http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == "metadata.google.internal.:80" || addr == "metadata.google.internal:80" {
+				return net.Dial(network, net.JoinHostPort("127.0.0.1", metadataPort))
+			}
+			if addr == "sts.googleapis.com:443" {
+				return net.Dial(network, net.JoinHostPort("127.0.0.1", stsPort))
+			}
+			return net.Dial(network, addr)
+		},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // trust the mock TLS certificate
+		},
+	})
+
+	provider := MakeRegistryProvider(transport, ksaToken, map[string]string{
+		"iam.gke.io/enable-wi-image-pull": "true",
+	}, "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster", "my-project")
+
+	req := credentialproviderapi.CredentialProviderRequest{
+		Image: dummyImage,
+	}
+
+	response, err := GetResponse(req, provider)
+	if err != nil {
+		t.Fatalf("Unexpected error while getting response: %s", err.Error())
+	}
+
+	if !hasURL(registryURL, response) || !hasURL(gcpRegistryURL, response) {
+		t.Errorf("expected URLs not found in response: %v", response.Auth)
+	}
+
+	for _, auth := range response.Auth {
+		if expectedUsername != auth.Username {
+			t.Errorf("Expected username %s, got %s", expectedUsername, auth.Username)
+		}
+		if federatedToken != auth.Password {
+			t.Errorf("Expected federated token %s, got %s", federatedToken, auth.Password)
 		}
 	}
 }
@@ -144,7 +262,7 @@ func TestConfigProvider(t *testing.T) {
 		},
 	})
 	provider := MakeDockerConfigProvider(transport)
-	response, err := GetResponse(dummyImage, provider)
+	response, err := GetResponse(credentialproviderapi.CredentialProviderRequest{Image: dummyImage}, provider)
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
 	}
@@ -201,7 +319,7 @@ func TestConfigURLProvider(t *testing.T) {
 	})
 
 	provider := MakeDockerConfigURLProvider(transport)
-	response, err := GetResponse(dummyImage, provider)
+	response, err := GetResponse(credentialproviderapi.CredentialProviderRequest{Image: dummyImage}, provider)
 	if err != nil {
 		t.Fatalf("Unexpected error while getting response: %s", err.Error())
 	}
@@ -215,5 +333,32 @@ func TestConfigURLProvider(t *testing.T) {
 		if password != auth.Password {
 			t.Errorf("Expected password %s not found (password: %s)", password, auth.Password)
 		}
+	}
+}
+
+func TestMakeRegistryProvider(t *testing.T) {
+	transport := &http.Transport{}
+	token := "test-token-123"
+	annotations := map[string]string{
+		"test-annotation": "test-value",
+	}
+
+	provider := MakeRegistryProvider(transport, token, annotations, "test-provider", "test-project-123")
+
+	if provider.KSAToken != token {
+		t.Errorf("expected KSAToken to be %q, got %q", token, provider.KSAToken)
+	}
+
+	val, ok := provider.ServiceAccountAnnotations["test-annotation"]
+	if !ok || val != "test-value" {
+		t.Errorf("expected ServiceAccountAnnotations to contain test-annotation=test-value, got %v", provider.ServiceAccountAnnotations)
+	}
+
+	if provider.IdentityProvider != "test-provider" {
+		t.Errorf("expected IdentityProvider to be %q, got %q", "test-provider", provider.IdentityProvider)
+	}
+
+	if provider.ProjectID != "test-project-123" {
+		t.Errorf("expected ProjectID to be %q, got %q", "test-project-123", provider.ProjectID)
 	}
 }

--- a/pkg/gcpcredential/gcpcredential.go
+++ b/pkg/gcpcredential/gcpcredential.go
@@ -17,7 +17,11 @@ limitations under the License.
 package gcpcredential
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os/exec"
@@ -44,6 +48,10 @@ const (
 	StorageScopePrefix       = "https://www.googleapis.com/auth/devstorage"
 	cloudPlatformScopePrefix = "https://www.googleapis.com/auth/cloud-platform"
 	defaultServiceAccount    = "default/"
+	// EnableWIImagePullAnnotation is the KSA annotation key to opt-in to Workload Identity image pulling
+	EnableWIImagePullAnnotation = "iam.gke.io/enable-wi-image-pull"
+	// googleSTSEndpoint is the GCP STS token exchange endpoint
+	googleSTSEndpoint = "https://sts.googleapis.com/v1/token"
 )
 
 // GCEProductNameFile is the product file path that contains the cloud service name.
@@ -56,6 +64,7 @@ var containerRegistryUrls = []string{"container.cloud.google.com", "gcr.io", "*.
 
 var metadataHeader = &http.Header{
 	"Metadata-Flavor": []string{"Google"},
+	"User-Agent":      []string{"GKE auth-provider-gcp image pull"},
 }
 
 // MetadataProvider is a DockerConfigProvider that reads its configuration from Google
@@ -83,6 +92,12 @@ type DockerConfigURLKeyProvider struct {
 type ContainerRegistryProvider struct {
 	MetadataProvider
 	UseRegistryFromImage bool
+
+	// Workload Identity context passed via constructor
+	KSAToken                  string
+	ServiceAccountAnnotations map[string]string
+	IdentityProvider          string
+	ProjectID                 string
 }
 
 // Returns true if it finds a local GCE VM.
@@ -232,8 +247,54 @@ type TokenBlob struct {
 	AccessToken string `json:"access_token"`
 }
 
+// DTO definitions for public GCP STS and IAM token exchanges
+type stsTokenExchangeRequest struct {
+	Audience           string `json:"audience,omitempty"`
+	GrantType          string `json:"grant_type"`
+	RequestedTokenType string `json:"requested_token_type"`
+	Scope              string `json:"scope,omitempty"`
+	SubjectToken       string `json:"subject_token"`
+	SubjectTokenType   string `json:"subject_token_type"`
+}
+
+type stsTokenExchangeResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
 // Provide implements DockerConfigProvider
 func (g *ContainerRegistryProvider) Provide(image string) credentialconfig.DockerConfig {
+	if g.IdentityProvider == "" || g.ServiceAccountAnnotations[EnableWIImagePullAnnotation] != "true" {
+		klog.V(4).Infof("Standard flow active: Workload Identity is disabled, using Node Service Account for image: %s", image)
+		return g.provideNodeSACredentials(image)
+	}
+
+	if g.KSAToken == "" {
+		klog.Errorf("auth-provider-gcp: Workload Identity opted-in but KSA token is unset. Failing fast without fallback.")
+		return credentialconfig.DockerConfig{} // Returns empty config (causes authentication failure)
+	}
+
+	// Trigger Workload Identity flow
+	cfg := credentialconfig.DockerConfig{}
+	klog.V(4).Infof("auth-provider-gcp: Triggering Workload Identity exchange for image: %s", image)
+	accessToken, err := g.executeWorkloadIdentityExchange(context.Background(), image)
+	if err != nil {
+		// Strict Fail-Fast: Since it was opted-in, do NOT fall back to GCE Node SA if exchange fails
+		klog.Errorf("auth-provider-gcp: Workload Identity exchange failed for opted-in KSA (%v). Failing fast without fallback.", err)
+		return cfg // Returns empty config (causes authentication failure)
+	}
+
+	klog.V(4).Infof("auth-provider-gcp: Workload Identity exchange successful!")
+	entry := credentialconfig.DockerConfigEntry{
+		Username: "_token",
+		Password: accessToken,
+	}
+	g.populateConfig(cfg, image, entry)
+	return cfg
+}
+
+func (g *ContainerRegistryProvider) provideNodeSACredentials(image string) credentialconfig.DockerConfig {
 	cfg := credentialconfig.DockerConfig{}
 
 	tokenJSONBlob, err := credentialconfig.ReadURL(metadataToken, g.Client, metadataHeader)
@@ -260,6 +321,11 @@ func (g *ContainerRegistryProvider) Provide(image string) credentialconfig.Docke
 		Email:    string(email),
 	}
 
+	g.populateConfig(cfg, image, entry)
+	return cfg
+}
+
+func (g *ContainerRegistryProvider) populateConfig(cfg credentialconfig.DockerConfig, image string, entry credentialconfig.DockerConfigEntry) {
 	// If UseRegistryFromImage is true, we will directly give the credential to the registry of the image.
 	// Currently, this is only used by auth-provider-gcp.
 	if g.UseRegistryFromImage {
@@ -267,10 +333,74 @@ func (g *ContainerRegistryProvider) Provide(image string) credentialconfig.Docke
 			cfg[registry] = entry
 		}
 	}
-
 	// Add our entry for each of the supported container registry URLs
 	for _, k := range containerRegistryUrls {
 		cfg[k] = entry
 	}
-	return cfg
+}
+
+// executeWorkloadIdentityExchange handles the direct workload identity token exchange
+func (g *ContainerRegistryProvider) executeWorkloadIdentityExchange(ctx context.Context, image string) (string, error) {
+	if g.ProjectID == "" {
+		return "", fmt.Errorf("project-id must be configured for Workload Identity exchange")
+	}
+
+	// Trade KSA token for a Google Federated Token via STS
+	klog.V(4).Infof("auth-provider-gcp: Executing STS exchange for Project ID: %s", g.ProjectID)
+	federatedToken, err := g.exchangeKSATokenForFederated(ctx, g.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("failed KSA->Federated STS exchange: %w", err)
+	}
+	klog.V(4).Infof("auth-provider-gcp: STS exchange successful (Google Federated Token acquired)")
+
+	return federatedToken, nil
+}
+
+func (g *ContainerRegistryProvider) exchangeKSATokenForFederated(ctx context.Context, projectID string) (string, error) {
+	// Audience format: identitynamespace:<POOL_ID>:<PROVIDER_URL>
+	audience := fmt.Sprintf("identitynamespace:%s.svc.id.goog:%s", projectID, g.IdentityProvider)
+	klog.V(4).Infof("auth-provider-gcp: Constructed STS Full Audience: %s", audience)
+
+	payload := stsTokenExchangeRequest{
+		Audience:           audience,
+		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
+		RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		Scope:              "https://www.googleapis.com/auth/cloud-platform",
+		SubjectToken:       g.KSAToken,
+		SubjectTokenType:   "urn:ietf:params:oauth:token-type:jwt",
+	}
+
+	return g.callSTSEndpoint(ctx, payload)
+}
+
+func (g *ContainerRegistryProvider) callSTSEndpoint(ctx context.Context, payload stsTokenExchangeRequest) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", googleSTSEndpoint, bytes.NewBuffer(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "GKE auth-provider-gcp image pull")
+
+	resp, err := g.Client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("STS token exchange failed with status %d: %s", resp.StatusCode, string(respBytes))
+	}
+
+	var stsResp stsTokenExchangeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stsResp); err != nil {
+		return "", err
+	}
+
+	return stsResp.AccessToken, nil
 }

--- a/pkg/gcpcredential/gcpcredential_test.go
+++ b/pkg/gcpcredential/gcpcredential_test.go
@@ -1,0 +1,232 @@
+package gcpcredential
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type mockTransport struct {
+	roundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}
+
+func TestProvide_WorkloadIdentity(t *testing.T) {
+	validToken := "dummyHeader.eyJpc3MiOiAiaHR0cHM6Ly9jb250YWluZXIuZ29vZ2xlYXBpcy5jb20vdjEvcHJvamVjdHMvbXktcHJvamVjdC9sb2NhdGlvbnMvdXMtY2VudHJhbDEvY2x1c3RlcnMvbXktY2x1c3RlciJ9.dummySignature"
+	tests := []struct {
+		name                      string
+		identityProvider          string
+		serviceAccountToken       string
+		serviceAccountAnnotations map[string]string
+		metadataResponses         map[string]string
+		stsResponse               string
+		wantAudience              string
+		expectedToken             string
+		projectID                 string
+	}{
+		{
+			name:                "Direct Access Mode (Success)",
+			identityProvider:    "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID:     "my-project",
+			stsResponse:   `{"access_token": "federated-token-xyz", "expires_in": 3600, "token_type": "Bearer"}`,
+			wantAudience:  "identitynamespace:my-project.svc.id.goog:https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			expectedToken: "federated-token-xyz",
+		},
+		{
+			name:                "Fallback to Node SA (Unannotated SA, bypass STS)",
+			serviceAccountToken: validToken,
+			metadataResponses: map[string]string{
+				"project/project-id":                      "my-project",
+				"instance/service-accounts/default/token": `{"access_token": "node-sa-token", "expires_in": 3600}`,
+				"instance/service-accounts/default/email": "node-sa@project.gserviceaccount.com",
+				"instance/service-accounts/":              "default/\n",
+			},
+			stsResponse:   `{"access_token": "should-not-be-called", "expires_in": 3600, "token_type": "Bearer"}`,
+			expectedToken: "node-sa-token",
+		},
+		{
+			name:                "Fail Fast - Annotated SA for WIF, STS Fails",
+			identityProvider:    "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID: "my-project",
+			metadataResponses: map[string]string{
+				"instance/service-accounts/default/token": `{"access_token": "node-sa-token", "expires_in": 3600}`,
+			},
+			stsResponse:   "error",
+			wantAudience:  "identitynamespace:my-project.svc.id.goog:https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			expectedToken: "",
+		},
+		{
+			name:                "Fail Fast - Annotated SA for WIF, Token is Empty",
+			identityProvider:    "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			serviceAccountToken: "",
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID: "my-project",
+			metadataResponses: map[string]string{
+				"instance/service-accounts/default/token": `{"access_token": "node-sa-token", "expires_in": 3600}`,
+			},
+			stsResponse:   `{"access_token": "should-not-be-called", "expires_in": 3600, "token_type": "Bearer"}`,
+			expectedToken: "",
+		},
+		{
+			name:                "Fallback to Node SA - Annotated but Feature Disabled",
+			identityProvider:    "",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			metadataResponses: map[string]string{
+				"project/project-id":                      "my-project",
+				"instance/service-accounts/default/token": `{"access_token": "node-sa-token", "expires_in": 3600}`,
+				"instance/service-accounts/default/email": "node-sa@project.gserviceaccount.com",
+				"instance/service-accounts/":              "default/\n",
+			},
+			stsResponse:   `{"access_token": "should-not-be-called", "expires_in": 3600, "token_type": "Bearer"}`,
+			expectedToken: "node-sa-token",
+		},
+		{
+			name:                "Direct Access Mode - Configured Identity Provider (Success)",
+			identityProvider:    "https://custom-provider.com",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID:     "my-project",
+			stsResponse:   `{"access_token": "federated-token-custom", "expires_in": 3600, "token_type": "Bearer"}`,
+			wantAudience:  "identitynamespace:my-project.svc.id.goog:https://custom-provider.com",
+			expectedToken: "federated-token-custom",
+		},
+		{
+			name:                "Direct Access Mode - With Pre-configured Project ID (Success)",
+			identityProvider:    "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID:     "pre-configured-project",
+			stsResponse:   `{"access_token": "federated-token-pre", "expires_in": 3600, "token_type": "Bearer"}`,
+			wantAudience:  "identitynamespace:pre-configured-project.svc.id.goog:https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			expectedToken: "federated-token-pre",
+		},
+		{
+			name:                "Fail Fast - Project ID is Empty",
+			identityProvider:    "https://container.googleapis.com/v1/projects/my-project/locations/us-central1/clusters/my-cluster",
+			serviceAccountToken: validToken,
+			serviceAccountAnnotations: map[string]string{
+				"iam.gke.io/enable-wi-image-pull": "true",
+			},
+			projectID:     "",
+			expectedToken: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mTransport := &mockTransport{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					// Handle Metadata Server requests
+					if req.URL.Host == "metadata.google.internal." {
+						path := strings.TrimPrefix(req.URL.Path, "/computeMetadata/v1/")
+						if resp, ok := tc.metadataResponses[path]; ok {
+							return &http.Response{
+								StatusCode: http.StatusOK,
+								Body:       io.NopCloser(bytes.NewBufferString(resp)),
+								Header:     make(http.Header),
+							}, nil
+						}
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(bytes.NewBufferString("")),
+						}, nil
+					}
+
+					// Handle STS Requests
+					if req.URL.Host == "sts.googleapis.com" && req.URL.Path == "/v1/token" {
+						if tc.stsResponse == "error" {
+							return &http.Response{
+								StatusCode: http.StatusBadRequest,
+								Body:       io.NopCloser(bytes.NewBufferString(`{"error": "invalid_grant"}`)),
+							}, nil
+						}
+
+						// Verify audience if specified
+						if tc.wantAudience != "" {
+							bodyBytes, err := io.ReadAll(req.Body)
+							if err != nil {
+								t.Errorf("failed to read STS request body: %v", err)
+							}
+							var stsReq stsTokenExchangeRequest
+							if err := json.Unmarshal(bodyBytes, &stsReq); err != nil {
+								t.Errorf("failed to unmarshal STS request body: %v", err)
+							}
+							if stsReq.Audience != tc.wantAudience {
+								t.Errorf("unexpected STS audience: got=%q, want=%q", stsReq.Audience, tc.wantAudience)
+							}
+						}
+
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewBufferString(tc.stsResponse)),
+						}, nil
+					}
+
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Body:       io.NopCloser(bytes.NewBufferString("")),
+					}, nil
+				},
+			}
+
+			httpClient := &http.Client{
+				Transport: mTransport,
+			}
+
+			provider := &ContainerRegistryProvider{
+				MetadataProvider: MetadataProvider{
+					Client: httpClient,
+				},
+				UseRegistryFromImage: true,
+			}
+			provider.KSAToken = tc.serviceAccountToken
+			provider.ServiceAccountAnnotations = tc.serviceAccountAnnotations
+			provider.IdentityProvider = tc.identityProvider
+			provider.ProjectID = tc.projectID
+
+			cfg := provider.Provide("us-central1-docker.pkg.dev/my-project/my-repo/my-image:latest")
+
+			if tc.expectedToken == "" {
+				for _, entry := range cfg {
+					if entry.Password != "" {
+						t.Errorf("expected no token, got: %s", entry.Password)
+					}
+				}
+			} else {
+				found := false
+				for _, entry := range cfg {
+					if entry.Password == tc.expectedToken {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected token %q not found in config: %+v", tc.expectedToken, cfg)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a manual cherry-pick of #1202 to the release-1.36 branch.

Manual Resolution Note: A minor conflict in pkg/gcpcredential/gcpcredential.go regarding imports was resolved manually. The master branch has deprecated io/ioutil, but it is still used in release-1.36, so both io and io/ioutil are kept here.

Cherry-pick of #1202