### PR TITLE
Use APPLICATION_DEFAULT_CREDENTIALS by default

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -425,8 +425,6 @@ func readConfig(reader io.Reader) (*ConfigFile, error) {
 
 func GenerateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err error) {
 	cloudConfig = &CloudConfig{}
-	// By default, fetch token from GCE metadata server
-	cloudConfig.TokenSource = google.ComputeTokenSource("")
 	cloudConfig.UseMetadataServer = true
 	cloudConfig.AlphaFeatureGate = NewAlphaFeatureGate([]string{})
 	if configFile != nil {
@@ -438,14 +436,8 @@ func GenerateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 			cloudConfig.ContainerAPIEndpoint = configFile.Global.ContainerAPIEndpoint
 		}
 
-		if configFile.Global.TokenURL != "" {
-			// if tokenURL is nil, set tokenSource to nil. This will force the OAuth client to fall
-			// back to use DefaultTokenSource. This allows running gceCloud remotely.
-			if configFile.Global.TokenURL == "nil" {
-				cloudConfig.TokenSource = nil
-			} else {
-				cloudConfig.TokenSource = NewAltTokenSource(configFile.Global.TokenURL, configFile.Global.TokenBody)
-			}
+		if configFile.Global.TokenURL != "" && configFile.Global.TokenURL != "nil" {
+			cloudConfig.TokenSource = NewAltTokenSource(configFile.Global.TokenURL, configFile.Global.TokenBody)
 		}
 
 		cloudConfig.NodeTags = configFile.Global.NodeTags

--- a/providers/gce/gce_test.go
+++ b/providers/gce/gce_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
 	cloudprovider "k8s.io/cloud-provider"
@@ -356,7 +355,6 @@ func TestGenerateCloudConfigs(t *testing.T) {
 		SubnetworkURL:      "",
 		SecondaryRangeName: "",
 		NodeTags:           []string{"node-tag"},
-		TokenSource:        google.ComputeTokenSource(""),
 		NodeInstancePrefix: "node-prefix",
 		UseMetadataServer:  true,
 		AlphaFeatureGate:   &AlphaFeatureGate{map[string]bool{}},
@@ -379,11 +377,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 				v.TokenURL = "nil"
 				return v
 			},
-			cloud: func() CloudConfig {
-				v := cloudBoilerplate
-				v.TokenSource = nil
-				return v
-			},
+			cloud: func() CloudConfig { return cloudBoilerplate },
 		},
 		{
 			name: "Network Project ID",


### PR DESCRIPTION
This pull request proposes that when `token_url` is not set in the cloud config, we should use Application Default Credentials (ADC), which would be expected by most GCP developers. Currently, if `token_url` is not set, `googleapis.com` is used, which retrieves credentials from the metadata server (a service account attached to the VM). This behavior is the same as the final case for ADC:

https://github.com/kubernetes/cloud-provider-gcp/blob/2f5f61176101310974bafa7750b7805a5b63c183/vendor/golang.org/x/oauth2/google/default.go#L214-L230

So the default behavior will remain the same, unless users have mounted credentials that satisfy cases 1 or 2, which seems more in line with what users would expect, without having to set the `token_url` in the cloud config to the magic string `nil`.

This PR depends on #1250. 93cfbf5f21539c2686fa0cec968bf8220e6756bd is the relevant commit for this PR. Once #1250 merges, I will rebase away the other two commits.

/hold