### PR TITLE
Allow empty pod ranges in MT ProviderConfig

### DIFF
--- a/cmd/cloud-controller-manager/gketenantcontrollermanager.go
+++ b/cmd/cloud-controller-manager/gketenantcontrollermanager.go
@@ -26,6 +26,7 @@ import (
 	controllermanagerapp "k8s.io/controller-manager/app"
 	"k8s.io/controller-manager/controller"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 
 	"k8s.io/cloud-provider-gcp/pkg/controller/nodeipam"
 	"k8s.io/cloud-provider-gcp/pkg/controller/nodeipam/ipam"
@@ -126,7 +127,14 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 		},
 		"node-ipam-controller": func(cfg *gketenantcontrollers.ControllerConfig) error {
 			klog.Infof("Starting Node IPAM Controller for %s...", cfg.ProviderConfig.Name)
-			cidrs := getCIDRsFromProviderConfig(cfg.ProviderConfig)
+			var cidrs string
+			if isIPV6OnlyCluster(mgrCfg.nodeIPAMConfig) {
+				// MT always uses Cloud allocator, CIDRs are only needed to pass validation.
+				// IPv6-only clusters don't use pod ranges, backfill with discard prefix (RFC 6666).
+				cidrs = "100::/64"
+			} else {
+				cidrs = getCIDRsFromProviderConfig(cfg.ProviderConfig)
+			}
 
 			// Disable MultiSubnetCluster for tenant controllers to prevent them from
 			// overwriting the global "default" NodeTopology CR with tenant-specific subnets.
@@ -229,6 +237,11 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 	go mgr.Run()
 
 	return nil, starter, true, nil
+}
+
+// isIPV6OnlyCluster returns true if cluster is IPv6 single-stack (and false otherwise).
+func isIPV6OnlyCluster(ipamCfg nodeipamconfig.NodeIPAMControllerConfiguration) bool {
+	return netutils.IPFamilyOfCIDRString(ipamCfg.ServiceCIDR) == netutils.IPv6 && ipamCfg.SecondaryServiceCIDR == ""
 }
 
 // getCIDRsFromProviderConfig returns a comma-separated list of CIDRs from the given ProviderConfig.


### PR DESCRIPTION
IPv6 discard prefix (blackhole) is provided to satisfy validation, this value is guaranteed to never be used