### PR TITLE
Fix omitted fields in gcloud firewall command generation

### DIFF
--- a/providers/gce/gce_util.go
+++ b/providers/gce/gce_util.go
@@ -186,22 +186,70 @@ func FirewallToGCloudDeleteCmd(fwName, projectID string) string {
 	return fmt.Sprintf("gcloud compute firewall-rules delete %v --project %v", fwName, projectID)
 }
 
+func formatFirewallRuleSpecs(protocol string, ports []string) []string {
+	if len(ports) == 0 {
+		return []string{protocol}
+	}
+	var specs []string
+	for _, p := range ports {
+		specs = append(specs, fmt.Sprintf("%v:%v", protocol, p))
+	}
+	return specs
+}
+
 func firewallToGcloudArgs(fw *compute.Firewall, projectID string) string {
-	var allPorts []string
-	for _, a := range fw.Allowed {
-		for _, p := range a.Ports {
-			allPorts = append(allPorts, fmt.Sprintf("%v:%v", a.IPProtocol, p))
+	var args []string
+
+	args = append(args, fmt.Sprintf("--description %q", fw.Description))
+
+	if len(fw.Allowed) > 0 {
+		var allowSpecs []string
+		for _, a := range fw.Allowed {
+			allowSpecs = append(allowSpecs, formatFirewallRuleSpecs(a.IPProtocol, a.Ports)...)
 		}
+		sort.Strings(allowSpecs)
+		args = append(args, fmt.Sprintf("--allow %v", strings.Join(allowSpecs, ",")))
 	}
 
-	// Sort all slices to prevent the event from being duped
-	sort.Strings(allPorts)
-	allow := strings.Join(allPorts, ",")
-	sort.Strings(fw.SourceRanges)
-	srcRngs := strings.Join(fw.SourceRanges, ",")
-	sort.Strings(fw.TargetTags)
-	targets := strings.Join(fw.TargetTags, ",")
-	return fmt.Sprintf("--description %q --allow %v --source-ranges %v --target-tags %v --project %v", fw.Description, allow, srcRngs, targets, projectID)
+	if len(fw.Denied) > 0 {
+		var denySpecs []string
+		for _, d := range fw.Denied {
+			denySpecs = append(denySpecs, formatFirewallRuleSpecs(d.IPProtocol, d.Ports)...)
+		}
+		sort.Strings(denySpecs)
+		args = append(args, fmt.Sprintf("--deny %v", strings.Join(denySpecs, ",")))
+	}
+
+	if len(fw.SourceRanges) > 0 {
+		sort.Strings(fw.SourceRanges)
+		args = append(args, fmt.Sprintf("--source-ranges %v", strings.Join(fw.SourceRanges, ",")))
+	}
+
+	if len(fw.DestinationRanges) > 0 {
+		sort.Strings(fw.DestinationRanges)
+		args = append(args, fmt.Sprintf("--destination-ranges %v", strings.Join(fw.DestinationRanges, ",")))
+	}
+
+	if len(fw.TargetTags) > 0 {
+		sort.Strings(fw.TargetTags)
+		args = append(args, fmt.Sprintf("--target-tags %v", strings.Join(fw.TargetTags, ",")))
+	}
+
+	if fw.Priority != 0 {
+		args = append(args, fmt.Sprintf("--priority %v", fw.Priority))
+	}
+
+	if fw.Direction != "" {
+		args = append(args, fmt.Sprintf("--direction %v", fw.Direction))
+	}
+
+	if fw.Disabled {
+		args = append(args, "--disabled")
+	}
+
+	args = append(args, fmt.Sprintf("--project %v", projectID))
+
+	return strings.Join(args, " ")
 }
 
 // Take a GCE instance 'hostname' and break it down to something that can be fed

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -22,6 +22,7 @@ package gce
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	compute "google.golang.org/api/compute/v1"
@@ -119,6 +120,484 @@ func TestFirewallToGcloudArgs(t *testing.T) {
 	var e = `--description "Last Line of Defense" --allow sctp:123,sctp:123-456,sctp:321,tcp:123,tcp:123-456,tcp:321,udp:123,udp:123-456,udp:321 --source-ranges 1.1.1.1/20,2.2.2.2/20,3.3.3.3/20 --target-tags band-nodes,jock-nodes --project my-project`
 	if got != e {
 		t.Errorf("%q does not equal %q", got, e)
+	}
+}
+
+func TestFirewallToGCloudCreateCmd(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		fw        *compute.Firewall
+		projectID string
+		wantArgs  []string
+	}{
+		{
+			desc: "pinhole rule with destination ranges",
+			fw: &compute.Firewall{
+				Name:              "k8s-fw-pinhole",
+				Network:           "projects/test-project/global/networks/default",
+				Description:       "pinhole rule",
+				SourceRanges:      []string{"10.0.0.0/8"},
+				DestinationRanges: []string{"192.168.1.2/32", "192.168.1.1/32"},
+				TargetTags:        []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-pinhole",
+				"--network default",
+				`--description "pinhole rule"`,
+				"--allow tcp:80",
+				"--source-ranges 10.0.0.0/8",
+				"--destination-ranges 192.168.1.1/32,192.168.1.2/32",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "standard rule without destination ranges",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-std",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "std rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-std",
+				"--network default",
+				`--description "std rule"`,
+				"--allow tcp:80",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "ipv6 pinhole rule",
+			fw: &compute.Firewall{
+				Name:              "k8s-fw-ipv6-pinhole",
+				Network:           "projects/test-project/global/networks/default",
+				Description:       "ipv6 pinhole rule",
+				SourceRanges:      []string{"2001:db8::/32"},
+				DestinationRanges: []string{"2001:db8::1/128"},
+				TargetTags:        []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-ipv6-pinhole",
+				"--network default",
+				`--description "ipv6 pinhole rule"`,
+				"--allow tcp:80",
+				"--source-ranges 2001:db8::/32",
+				"--destination-ranges 2001:db8::1/128",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "deny rule with priority, direction, and disabled",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-deny",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "deny rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Denied: []*compute.FirewallDenied{
+					{IPProtocol: "tcp", Ports: []string{"8080"}},
+				},
+				Priority:  500,
+				Direction: "INGRESS",
+				Disabled:  true,
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-deny",
+				"--network default",
+				`--description "deny rule"`,
+				"--deny tcp:8080",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--priority 500",
+				"--direction INGRESS",
+				"--disabled",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "rule with multiple protocols and multiple ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-multi-port",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "multi port rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+					{IPProtocol: "udp", Ports: []string{"53"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-multi-port",
+				"--network default",
+				`--description "multi port rule"`,
+				"--allow tcp:443,tcp:80,udp:53",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "deny all rule without ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-deny-all",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "deny all rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Denied: []*compute.FirewallDenied{
+					{IPProtocol: "all"},
+				},
+				Priority:  500,
+				Direction: "INGRESS",
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-deny-all",
+				"--network default",
+				`--description "deny all rule"`,
+				"--deny all",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--priority 500",
+				"--direction INGRESS",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "rule allowing ICMP without ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-icmp",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "icmp rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "icmp"},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-icmp",
+				"--network default",
+				`--description "icmp rule"`,
+				"--allow icmp",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "complex multi-protocol rule with tcp, udp, icmp, esp, and ah",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-complex",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "complex multi proto rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+					{IPProtocol: "udp", Ports: []string{"53"}},
+					{IPProtocol: "icmp"},
+					{IPProtocol: "esp"},
+					{IPProtocol: "ah"},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-complex",
+				"--network default",
+				`--description "complex multi proto rule"`,
+				"--allow ah,esp,icmp,tcp:443,tcp:80,udp:53",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := FirewallToGCloudCreateCmd(tc.fw, tc.projectID)
+			want := strings.Join(tc.wantArgs, " ")
+			if got != want {
+				t.Errorf("%s failed:\nGot:  %q\nWant: %q", tc.desc, got, want)
+			}
+		})
+	}
+}
+
+func TestFirewallToGCloudUpdateCmd(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		fw        *compute.Firewall
+		projectID string
+		wantArgs  []string
+	}{
+		{
+			desc: "pinhole rule with destination ranges",
+			fw: &compute.Firewall{
+				Name:              "k8s-fw-pinhole",
+				Network:           "projects/test-project/global/networks/default",
+				Description:       "pinhole rule",
+				SourceRanges:      []string{"10.0.0.0/8"},
+				DestinationRanges: []string{"192.168.1.2/32", "192.168.1.1/32"},
+				TargetTags:        []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-pinhole",
+				`--description "pinhole rule"`,
+				"--allow tcp:80",
+				"--source-ranges 10.0.0.0/8",
+				"--destination-ranges 192.168.1.1/32,192.168.1.2/32",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "standard rule without destination ranges",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-std",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "std rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-std",
+				`--description "std rule"`,
+				"--allow tcp:80",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "ipv6 pinhole rule",
+			fw: &compute.Firewall{
+				Name:              "k8s-fw-ipv6-pinhole",
+				Network:           "projects/test-project/global/networks/default",
+				Description:       "ipv6 pinhole rule",
+				SourceRanges:      []string{"2001:db8::/32"},
+				DestinationRanges: []string{"2001:db8::1/128"},
+				TargetTags:        []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-ipv6-pinhole",
+				`--description "ipv6 pinhole rule"`,
+				"--allow tcp:80",
+				"--source-ranges 2001:db8::/32",
+				"--destination-ranges 2001:db8::1/128",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "deny rule with priority, direction, and disabled",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-deny",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "deny rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Denied: []*compute.FirewallDenied{
+					{IPProtocol: "tcp", Ports: []string{"8080"}},
+				},
+				Priority:  500,
+				Direction: "INGRESS",
+				Disabled:  true,
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-deny",
+				`--description "deny rule"`,
+				"--deny tcp:8080",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--priority 500",
+				"--direction INGRESS",
+				"--disabled",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "rule with multiple protocols and multiple ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-multi-port",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "multi port rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+					{IPProtocol: "udp", Ports: []string{"53"}},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-multi-port",
+				`--description "multi port rule"`,
+				"--allow tcp:443,tcp:80,udp:53",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "deny all rule without ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-deny-all",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "deny all rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Denied: []*compute.FirewallDenied{
+					{IPProtocol: "all"},
+				},
+				Priority:  500,
+				Direction: "INGRESS",
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-deny-all",
+				`--description "deny all rule"`,
+				"--deny all",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--priority 500",
+				"--direction INGRESS",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "rule allowing ICMP without ports",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-icmp",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "icmp rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "icmp"},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-icmp",
+				`--description "icmp rule"`,
+				"--allow icmp",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+		{
+			desc: "complex multi-protocol rule with tcp, udp, icmp, esp, and ah",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-complex",
+				Network:      "projects/test-project/global/networks/default",
+				Description:  "complex multi proto rule",
+				SourceRanges: []string{"10.0.0.0/8"},
+				TargetTags:   []string{"node-tag"},
+				Allowed: []*compute.FirewallAllowed{
+					{IPProtocol: "tcp", Ports: []string{"80", "443"}},
+					{IPProtocol: "udp", Ports: []string{"53"}},
+					{IPProtocol: "icmp"},
+					{IPProtocol: "esp"},
+					{IPProtocol: "ah"},
+				},
+			},
+			projectID: "test-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules update k8s-fw-complex",
+				`--description "complex multi proto rule"`,
+				"--allow ah,esp,icmp,tcp:443,tcp:80,udp:53",
+				"--source-ranges 10.0.0.0/8",
+				"--target-tags node-tag",
+				"--project test-project",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := FirewallToGCloudUpdateCmd(tc.fw, tc.projectID)
+			want := strings.Join(tc.wantArgs, " ")
+			if got != want {
+				t.Errorf("%s failed:\nGot:  %q\nWant: %q", tc.desc, got, want)
+			}
+		})
+	}
+}
+
+func TestFirewallToGCloud_FieldExhaustiveness(t *testing.T) {
+	knownFields := map[string]bool{
+		"Allowed":               true,
+		"CreationTimestamp":     false,
+		"Denied":                true,
+		"Description":           true,
+		"DestinationRanges":     true,
+		"Direction":             true,
+		"Disabled":              true,
+		"Id":                    false,
+		"Kind":                  false,
+		"LogConfig":             false,
+		"Name":                  true,
+		"Network":               true,
+		"Params":                false,
+		"Priority":              true,
+		"SelfLink":              false,
+		"SourceRanges":          true,
+		"SourceServiceAccounts": false,
+		"SourceTags":            false,
+		"TargetServiceAccounts": false,
+		"TargetTags":            true,
+		"ServerResponse":        false,
+		"ForceSendFields":       false,
+		"NullFields":            false,
+	}
+
+	for field := range reflect.TypeOf(compute.Firewall{}).Fields() {
+		if _, evaluated := knownFields[field.Name]; !evaluated {
+			t.Fatalf(
+				"New field %q added to compute.Firewall!\n"+
+					"Evaluate whether it needs gcloud flag mapping in\n"+
+					"FirewallToGCloudCreateCmd / FirewallToGCloudUpdateCmd,\n"+
+					"then update knownFields in this test.",
+				field.Name,
+			)
+		}
 	}
 }
 

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -568,30 +568,43 @@ func TestFirewallToGCloudUpdateCmd(t *testing.T) {
 }
 
 func TestFirewallToGCloud_FieldExhaustiveness(t *testing.T) {
+	// knownFields maps every field in compute.Firewall to a boolean:
+	// true  = handled in FirewallToGCloudCreateCmd / FirewallToGCloudUpdateCmd
+	// false = intentionally unmapped (e.g. read-only server metadata,
+	//         internal SDK fields, or unused GCP features)
 	knownFields := map[string]bool{
-		"Allowed":               true,
-		"CreationTimestamp":     false,
-		"Denied":                true,
-		"Description":           true,
-		"DestinationRanges":     true,
-		"Direction":             true,
-		"Disabled":              true,
-		"Id":                    false,
-		"Kind":                  false,
+		// Handled fields in gcloud command generation
+		"Name":              true,
+		"Network":           true,
+		"Description":       true,
+		"Allowed":           true,
+		"Denied":            true,
+		"SourceRanges":      true,
+		"DestinationRanges": true,
+		"TargetTags":        true,
+		"Priority":          true,
+		"Direction":         true,
+		"Disabled":          true,
+
+		// Read-only server metadata (not CLI flags)
+		"CreationTimestamp": false,
+		"Id":                false,
+		"Kind":              false,
+		"SelfLink":          false,
+
+		// Unused GCP features in cloud provider
 		"LogConfig":             false,
-		"Name":                  true,
-		"Network":               true,
 		"Params":                false,
-		"Priority":              true,
-		"SelfLink":              false,
-		"SourceRanges":          true,
 		"SourceServiceAccounts": false,
 		"SourceTags":            false,
 		"TargetServiceAccounts": false,
-		"TargetTags":            true,
-		"ServerResponse":        false,
-		"ForceSendFields":       false,
-		"NullFields":            false,
+
+		// Internal Google API Go SDK helpers used for HTTP status tracking
+		// and JSON marshaling (ServerResponse stores HTTP headers/status,
+		// ForceSendFields/NullFields control JSON serialization).
+		"ServerResponse":  false,
+		"ForceSendFields": false,
+		"NullFields":      false,
 	}
 
 	for field := range reflect.TypeFor[compute.Firewall]().Fields() {

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -594,7 +594,7 @@ func TestFirewallToGCloud_FieldExhaustiveness(t *testing.T) {
 		"NullFields":            false,
 	}
 
-	for field := range reflect.TypeOf(compute.Firewall{}).Fields() {
+	for field := range reflect.TypeFor[compute.Firewall]().Fields() {
 		if _, evaluated := knownFields[field.Name]; !evaluated {
 			t.Fatalf(
 				"New field %q added to compute.Firewall!\n"+

--- a/providers/gce/gce_util_test.go
+++ b/providers/gce/gce_util_test.go
@@ -95,34 +95,6 @@ func TestSubnetsInCIDR(t *testing.T) {
 	}
 }
 
-func TestFirewallToGcloudArgs(t *testing.T) {
-	firewall := compute.Firewall{
-		Description:  "Last Line of Defense",
-		TargetTags:   []string{"jock-nodes", "band-nodes"},
-		SourceRanges: []string{"3.3.3.3/20", "1.1.1.1/20", "2.2.2.2/20"},
-		Allowed: []*compute.FirewallAllowed{
-			{
-				IPProtocol: "udp",
-				Ports:      []string{"321", "123-456", "123"},
-			},
-			{
-				IPProtocol: "tcp",
-				Ports:      []string{"321", "123-456", "123"},
-			},
-			{
-				IPProtocol: "sctp",
-				Ports:      []string{"321", "123-456", "123"},
-			},
-		},
-	}
-	got := firewallToGcloudArgs(&firewall, "my-project")
-
-	var e = `--description "Last Line of Defense" --allow sctp:123,sctp:123-456,sctp:321,tcp:123,tcp:123-456,tcp:321,udp:123,udp:123-456,udp:321 --source-ranges 1.1.1.1/20,2.2.2.2/20,3.3.3.3/20 --target-tags band-nodes,jock-nodes --project my-project`
-	if got != e {
-		t.Errorf("%q does not equal %q", got, e)
-	}
-}
-
 func TestFirewallToGCloudCreateCmd(t *testing.T) {
 	testCases := []struct {
 		desc      string
@@ -130,6 +102,40 @@ func TestFirewallToGCloudCreateCmd(t *testing.T) {
 		projectID string
 		wantArgs  []string
 	}{
+		{
+			desc: "rule with multiple protocols, port ranges, source ranges, and tags",
+			fw: &compute.Firewall{
+				Name:         "k8s-fw-last-line",
+				Network:      "projects/my-project/global/networks/default",
+				Description:  "Last Line of Defense",
+				TargetTags:   []string{"jock-nodes", "band-nodes"},
+				SourceRanges: []string{"3.3.3.3/20", "1.1.1.1/20", "2.2.2.2/20"},
+				Allowed: []*compute.FirewallAllowed{
+					{
+						IPProtocol: "udp",
+						Ports:      []string{"321", "123-456", "123"},
+					},
+					{
+						IPProtocol: "tcp",
+						Ports:      []string{"321", "123-456", "123"},
+					},
+					{
+						IPProtocol: "sctp",
+						Ports:      []string{"321", "123-456", "123"},
+					},
+				},
+			},
+			projectID: "my-project",
+			wantArgs: []string{
+				"gcloud compute firewall-rules create k8s-fw-last-line",
+				"--network default",
+				`--description "Last Line of Defense"`,
+				"--allow sctp:123,sctp:123-456,sctp:321,tcp:123,tcp:123-456,tcp:321,udp:123,udp:123-456,udp:321",
+				"--source-ranges 1.1.1.1/20,2.2.2.2/20,3.3.3.3/20",
+				"--target-tags band-nodes,jock-nodes",
+				"--project my-project",
+			},
+		},
 		{
 			desc: "pinhole rule with destination ranges",
 			fw: &compute.Firewall{


### PR DESCRIPTION
### What this PR does
In `FirewallToGCloudCreateCmd` and `FirewallToGCloudUpdateCmd`, several GCE firewall rule fields were omitted when generating `gcloud` command strings for events:
- `DestinationRanges` (essential for XPN / Shared VPC pinhole firewall rules)
- `Denied` rules
- `Priority`
- `Direction`
- `Disabled` state

Additionally, firewall rules with empty ports (such as `IPProtocol: "all"` or `IPProtocol: "icmp"`) failed to format properly because the formatting loop assumed non-empty `Ports`.

This change:
1. Includes `DestinationRanges`, `Denied`, `Priority`, `Direction`, and `Disabled` in `firewallToGcloudArgs`.
2. Extracts `formatFirewallRuleSpecs` helper to correctly handle portless protocols (`all`, `icmp`, `esp`, `ah`) as well as `protocol:port` specs.
3. Expands table-driven unit tests in `gce_util_test.go` and adds a reflection field exhaustiveness test (`TestFirewallToGCloud_FieldExhaustiveness`) to prevent future regressions if new fields are added to `compute.Firewall`.