### PR TITLE
e2e: Use framework propagation timeout for network tiers test

### DIFF
--- a/test/e2e/network_tiers.go
+++ b/test/e2e/network_tiers.go
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[cloud-provider-gcp-e2e] Network Tiers", func() {
 	})
 
 	f.It("should be able to create and tear down a standard-tier load balancer", f.WithSlow(), func(ctx context.Context) {
-		lagTimeout := e2eservice.LoadBalancerLagTimeoutDefault
+		lagTimeout := e2eservice.GetServiceLoadBalancerPropagationTimeout(ctx, cs)
 		createTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, cs)
 
 		svcName := "net-tiers-svc"


### PR DESCRIPTION
Use `e2eservice.GetServiceLoadBalancerPropagationTimeout` instead of `LoadBalancerLagTimeoutDefault` for network tiers E2E test. GCP load balancer propagation during tier changes (which involves IP reassignment) can occasionally take longer than the default 2 minutes, causing test flakiness. Using the framework's propagation timeout (default 10m) allows sufficient time for routing setup.