### PR TITLE
fix: clean up kops clusters after provisioning failures

### DIFF
--- a/e2e/scenarios/kops-simple
+++ b/e2e/scenarios/kops-simple
@@ -37,13 +37,12 @@ export KOPS_STATE_STORE="gs://kops-state-${GCP_PROJECT}"
 
 # 2. Cluster Lifecycle Management
 export KOPS_CLUSTER_NAME="${CLUSTER_NAME:-kops-simple.k8s.local}"
-make test-cluster-up
 
 # 3. Define cleanup function
 function cleanup {
   local exit_status=$?
   if [[ "${DELETE_CLUSTER:-true}" == "true" ]]; then
-    make test-cluster-down
+    make test-cluster-down || echo "Warning: test-cluster-down failed"
   fi
   if [[ -n "${BOSKOS_HEARTBEAT_PID:-}" ]]; then
     source test/boskos.sh
@@ -52,6 +51,8 @@ function cleanup {
   exit "${exit_status}"
 }
 trap cleanup EXIT
+
+make test-cluster-up
 
 # 4. Test Execution
 export K8S_VERSION=$(make --silent print-k8s-version)


### PR DESCRIPTION
Fixes #1288

`kops-simple` set its exit trap after `test-cluster-up`. When provisioning failed midway, cleanup never ran and GCP resources could be left around

This moves the trap before cluster creation. Cleanup errors also keep the original failure code.

Repro:

```bash
GCP_PROJECT=test bash -c '
make() {
  echo "make:$1"
  [[ "$1" != "test-cluster-up" ]]
}
export -f make
exec ./e2e/scenarios/kops-simple
'
```

Before: only `test-cluster-up` runs.
After: `test-cluster-up`, then `test-cluster-down`

Tests: `make test`, `make verify`
