### PR TITLE
dependabot: ignore alpha, beta, and rc versions for golang docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,12 @@ updates:
   - "ok-to-test"
   - 'area/dependency'
   - 'release-note-none'
+  ignore:
+  - dependency-name: "golang"
+    versions:
+    - "*rc*"
+    - "*beta*"
+    - "*alpha*"
 - package-ecosystem: "github-actions"
   directory: "/"
   target-branch: "release-1.36"
@@ -87,6 +93,9 @@ updates:
   - "ok-to-test"
   - 'area/dependency'
   - 'release-note-none'
-
-
-
+  ignore:
+  - dependency-name: "golang"
+    versions:
+    - "*rc*"
+    - "*beta*"
+    - "*alpha*"


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Configures Dependabot to ignore alpha, beta, and rc versions (such as `1.27rc2`, `1.27beta1`) for the `golang` Docker dependency across default and `release-1.36` configurations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```