### PR TITLE
Pin protoc-gen-go and protoc-gen-go-grpc versions in update-proto.sh

### DIFF
--- a/tools/update-proto.sh
+++ b/tools/update-proto.sh
@@ -67,11 +67,14 @@ if $need_install; then
   rm -rf "${TMP_PROTOC_DIR}"
 fi
 
+  PROTOC_GEN_GO_VERSION="v1.36.12"
+  PROTOC_GEN_GO_GRPC_VERSION="v1.6.2"
+
   echo "Installing protoc-gen-go/grpc..."
   export GOBIN="${TOOLS_BIN}"
   
-  go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+  go install "google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}"
+  go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}"
 
 # Find all proto files outside of vendor and temporary/artifact directories
 proto_files=$(find . -name "*.proto" -not -path "./vendor/*" -not -path "./_*" )


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Pins `protoc-gen-go` (`v1.36.12`) and `protoc-gen-go-grpc` (`v1.6.2`) compiler plugins in `tools/update-proto.sh` instead of installing with `@latest`.

Using `@latest` causes non-deterministic code generation across environments and suddenly breaks `verify-up-to-date` CI jobs across branches whenever upstream tools publish minor/patch releases (such as `protoc-gen-go` `v1.36.12`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```