### PR TITLE
Exempt default IPv6-only networks from IPv4 range validations

### DIFF
--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -183,7 +183,7 @@ func NewGKENetworkParamSetController(
 			c.clusterDefaultIPv4PodCIDR = clusterCIDR.String()
 		}
 	}
-	if c.clusterDefaultIPv4PodCIDR == "" {
+	if len(clusterCIDRs) == 0 {
 		klog.Fatal("Controller: Must specify --cluster-cidr for GKE VPC native cluster")
 	}
 

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -78,6 +78,7 @@ type Controller struct {
 	nodeLister                corelisters.NodeLister
 	nodeInformerSynced        cache.InformerSynced
 	clusterDefaultIPv4PodCIDR string
+	isIPv6OnlyCluster         bool
 }
 
 // NewGKENetworkParamSetController returns a new
@@ -183,6 +184,10 @@ func NewGKENetworkParamSetController(
 			c.clusterDefaultIPv4PodCIDR = clusterCIDR.String()
 		}
 	}
+
+	// cluster is IPv6-only if it doesn't have any IPv4 cluster CIDRs.
+	c.isIPv6OnlyCluster = c.clusterDefaultIPv4PodCIDR == ""
+
 	if len(clusterCIDRs) == 0 {
 		klog.Fatal("Controller: Must specify --cluster-cidr for GKE VPC native cluster")
 	}
@@ -365,14 +370,17 @@ func (c *Controller) populateDesiredDefaultParamSet(ctx context.Context, params 
 		return fmt.Errorf("failed to get vpcSubnet %q compute subnetwork: %v, err: %v", vpcSubnet, subnet, err)
 	}
 	defaultPodRange := ""
-	for _, r := range subnet.SecondaryIpRanges {
-		if r.IpCidrRange == c.clusterDefaultIPv4PodCIDR {
-			defaultPodRange = r.RangeName
-			break
+	// if cluster is ipv6 only, then defaultPodRange should be empty
+	if !c.isIPv6OnlyCluster {
+		for _, r := range subnet.SecondaryIpRanges {
+			if r.IpCidrRange == c.clusterDefaultIPv4PodCIDR {
+				defaultPodRange = r.RangeName
+				break
+			}
 		}
-	}
-	if defaultPodRange == "" {
-		return fmt.Errorf("failed to find range name for cluster default IPv4 Pod CIDR %q in compute subnet: %q", c.clusterDefaultIPv4PodCIDR, subnet.Name)
+		if defaultPodRange == "" {
+			return fmt.Errorf("failed to find range name for cluster default IPv4 Pod CIDR %q in compute subnet: %q", c.clusterDefaultIPv4PodCIDR, subnet.Name)
+		}
 	}
 
 	// ensure Annotations and Labels
@@ -390,9 +398,11 @@ func (c *Controller) populateDesiredDefaultParamSet(ctx context.Context, params 
 	params.Spec = networkv1.GKENetworkParamSetSpec{
 		VPC:       vpc,
 		VPCSubnet: vpcSubnet,
-		PodIPv4Ranges: &networkv1.SecondaryRanges{
+	}
+	if defaultPodRange != "" {
+		params.Spec.PodIPv4Ranges = &networkv1.SecondaryRanges{
 			RangeNames: []string{defaultPodRange},
-		},
+		}
 	}
 	return nil
 }
@@ -444,7 +454,7 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 
 	// update PodIPv4Ranges for the "default" paramset basing on all the nodes Pod ranges
 	// when the paramset is EnsureExists mode
-	if params.Name == networkv1.DefaultPodNetworkName {
+	if params.Name == networkv1.DefaultPodNetworkName && params.Spec.PodIPv4Ranges != nil {
 		if mode, ok := params.Labels[labelsAddonManagerMode]; ok && mode == ensureExistsMode {
 			if err = c.syncPodRanges(ctx, params); err != nil {
 				return err
@@ -499,7 +509,7 @@ func (c *Controller) syncNetworkWithGNP(ctx context.Context, network *networkv1.
 	newNetwork := network.DeepCopy()
 
 	// update the copy of old Network with new conditions to be new Network basing on the change of the GNP
-	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params)
+	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster)
 	meta.SetStatusCondition(&newNetwork.Status.Conditions, networkCrossValidation.toCondition())
 
 	if !reflect.DeepEqual(newNetwork.Status.Conditions, network.Status.Conditions) {

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -512,6 +512,7 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 		name              string
 		paramSet          *networkv1.GKENetworkParamSet
 		subnet            *compute.Subnetwork
+		isIPv6OnlyCluster bool
 		expectedCondition metav1.Condition
 	}{
 		{
@@ -855,6 +856,68 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 				Reason: "GNPConfigInvalid",
 			},
 		},
+		{
+			name: "IPv4/Dual-stack cluster rejects unset GNP.Spec.PodIPv4Ranges for Default Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: networkv1.DefaultPodNetworkName,
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       "test-vpc",
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: false,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "SecondaryRangeAndDeviceModeUnspecified",
+			},
+		},
+		{
+			name: "IPv6-only cluster allows unset GNP.Spec.PodIPv4Ranges for Default Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       defaultTestNetworkName,
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+				Reason: "GNPReady",
+			},
+		},
+		{
+			name: "IPv6-only cluster rejects unset GNP.Spec.PodIPv4Ranges for custom Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "custom-network",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       defaultTestNetworkName,
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "SecondaryRangeAndDeviceModeUnspecified",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -862,7 +925,12 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			// Create subnet
 			subnet := &compute.Subnetwork{
@@ -876,6 +944,15 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			}
 			subnetKey := meta.RegionalKey(subnet.Name, testVals.clusterValues.Region)
 			err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			defaultSubnet := &compute.Subnetwork{
+				Name: defaultTestSubnetworkName,
+			}
+			defaultSubnetKey := meta.RegionalKey(defaultSubnet.Name, testVals.clusterValues.Region)
+			err = testVals.cloud.Compute().Subnetworks().Insert(ctx, defaultSubnetKey, defaultSubnet)
 			if err != nil {
 				t.Error(err)
 			}
@@ -960,6 +1037,7 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 		name              string
 		network           *networkv1.Network
 		paramSet          *networkv1.GKENetworkParamSet
+		isIPv6OnlyCluster bool
 		expectedCondition metav1.Condition
 	}{
 		{
@@ -1172,13 +1250,75 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 				Reason: "GNPParamsReady",
 			},
 		},
+		{
+			name: "IPv6-only cluster allows L3NetworkType with unset GNP.Spec.PodIPv4Ranges for Default Network",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: networkv1.DefaultPodNetworkName,
+				},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: networkv1.DefaultPodNetworkName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       nonDefaultTestNetworkName,
+					VPCSubnet: subnetName,
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionTrue,
+				Reason: "GNPParamsReady",
+			},
+		},
+		{
+			name: "IPv6-only cluster rejects L3NetworkType with unset GNP.Spec.PodIPv4Ranges for custom Network",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: networkName},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: gkeNetworkParamSetName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        gkeNetworkParamSetName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:        nonDefaultTestNetworkName,
+					VPCSubnet:  subnetName,
+					DeviceMode: networkv1.NetDevice,
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionFalse,
+				Reason: "L3SecondaryMissing",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			subnetSecondaryCidr := "10.0.0.1/24"
 			subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -1191,8 +1331,16 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 					},
 				},
 			}
-
 			err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			defaultSubnet := &compute.Subnetwork{
+				Name: defaultTestSubnetworkName,
+			}
+			defaultSubnetKey := meta.RegionalKey(defaultSubnet.Name, testVals.clusterValues.Region)
+			err = testVals.cloud.Compute().Subnetworks().Insert(ctx, defaultSubnetKey, defaultSubnet)
 			if err != nil {
 				t.Error(err)
 			}
@@ -1401,10 +1549,13 @@ func (testVals *testGKENetworkParamSetController) doesGNPFinalizerExist(ctx cont
 func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 	desiredDefaultParamSet := newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, nil)
 
+	ipv6DesiredDefaultParamSet := newL3GNP(networkv1.DefaultPodNetworkName, nil, nil)
+
 	tests := []struct {
-		name            string
-		defaultParamSet *networkv1.GKENetworkParamSet
-		wantParamSet    *networkv1.GKENetworkParamSet
+		name              string
+		defaultParamSet   *networkv1.GKENetworkParamSet
+		wantParamSet      *networkv1.GKENetworkParamSet
+		isIPv6OnlyCluster bool
 	}{
 		{
 			name:            "not populate if addon is reconcile mode",
@@ -1436,6 +1587,12 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			defaultParamSet: newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, &gnpOptions{testAddonMode: ""}),
 			wantParamSet:    desiredDefaultParamSet,
 		},
+		{
+			name:              "ipv6-only cluster ignores and clears PodIPv4Ranges",
+			defaultParamSet:   newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, nil),
+			wantParamSet:      ipv6DesiredDefaultParamSet,
+			isIPv6OnlyCluster: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -1443,7 +1600,12 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -48,11 +48,12 @@ const (
 	newPodRange1              = "new-pod-range1"
 	newPodRange2              = "new-pod-range2"
 	defaultPodCIDR            = "10.100.0.0/16"
+	defaultPodIPv6CIDR        = "2600:1900:4000:fd1::/64"
 	newPodCIDR1               = "10.101.0.0/16"
 	newPodCIDR2               = "10.102.0.0/16"
 )
 
-func setupGKENetworkParamSetController(ctx context.Context) *testGKENetworkParamSetController {
+func setupGKENetworkParamSetController(ctx context.Context, clusterCIDR string) *testGKENetworkParamSetController {
 	fakeNetworking := networkfake.NewSimpleClientset()
 	nwInfFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
 	nwInformer := nwInfFactory.Networking().V1().Networks()
@@ -65,7 +66,7 @@ func setupGKENetworkParamSetController(ctx context.Context) *testGKENetworkParam
 	fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
 	fakeNodeInformer := fakeInformerFactory.Core().V1().Nodes()
 
-	_, ipnet, _ := net.ParseCIDR(defaultPodCIDR)
+	_, ipnet, _ := net.ParseCIDR(clusterCIDR)
 
 	controller := NewGKENetworkParamSetController(
 		fakeNodeInformer,
@@ -111,7 +112,14 @@ func (testVals *testGKENetworkParamSetController) runGKENetworkParamSetControlle
 func TestControllerRuns(t *testing.T) {
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+	testVals.runGKENetworkParamSetController(ctx)
+}
+
+func TestControllerRunsIPv6Only(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodIPv6CIDR)
 	testVals.runGKENetworkParamSetController(ctx)
 }
 
@@ -119,7 +127,7 @@ func TestAddValidParamSetSingleSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName := "test-secondary-range"
@@ -183,7 +191,7 @@ func TestAddValidParamSetMultipleSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName1 := "test-secondary-range-1"
@@ -254,7 +262,7 @@ func TestAddInvalidParamSetNoMatchingSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -310,7 +318,7 @@ func TestParamSetPartialSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName1 := "test-secondary-range-1"
@@ -374,7 +382,7 @@ func TestValidParamSetSubnetRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetCidr := "10.0.0.0/24"
@@ -427,7 +435,7 @@ func TestAddAndRemoveFinalizerToGKENetworkParamSet_NoNetworkName(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	testVals.runGKENetworkParamSetController(ctx)
 
@@ -854,7 +862,7 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			// Create subnet
 			subnet := &compute.Subnetwork{
@@ -1170,7 +1178,7 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetSecondaryCidr := "10.0.0.1/24"
 			subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -1255,7 +1263,7 @@ func TestHandleGKENetworkParamSetDelete_NetworkPresent(t *testing.T) {
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
 
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetName := "test-subnet"
 			subnet := &compute.Subnetwork{
@@ -1435,7 +1443,7 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{
@@ -1570,7 +1578,7 @@ func TestSyncDefaultPodRanges(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{

--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -93,8 +93,12 @@ func (c *Controller) validateFieldCombinations(ctx context.Context, params *netw
 	}
 
 	// Network attachment is not specified.
-	// Check if both deviceMode and secondary ranges are unspecified.
-	if !hasSecondaryRanges && !hasDeviceMode {
+	// check if deviceMode and secondary ranges are unspecified
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+
+	// we skip this check for IPv6-only clusters because their default network inherently does not have IPv4 secondary ranges
+	if !canHaveIpv6OnlyNetworksOnly && !hasSecondaryRanges && !hasDeviceMode {
 		return &gnpValidation{
 			IsValid:      false,
 			ErrorReason:  networkv1.SecondaryRangeAndDeviceModeUnspecified,
@@ -173,10 +177,13 @@ func (c *Controller) validateGKENetworkParamSet(ctx context.Context, params *net
 		}
 	}
 
-	// check if both deviceMode and secondary ranges are unspecified
+	// check if both deviceMode and secondary ranges are unspecified.
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isDeviceModeSpecified := params.Spec.DeviceMode != ""
-	if !isSecondaryRangeSpecified && !isDeviceModeSpecified {
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+
+	if !canHaveIpv6OnlyNetworksOnly && !isSecondaryRangeSpecified && !isDeviceModeSpecified {
 		return &gnpValidation{
 			IsValid:      false,
 			ErrorReason:  networkv1.SecondaryRangeAndDeviceModeUnspecified,
@@ -276,14 +283,16 @@ func (val *gnpNetworkCrossValidation) toCondition() metav1.Condition {
 }
 
 // crossValidateNetworkAndGnp validates a given network and GNP object are compatible
-func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet) *gnpNetworkCrossValidation {
+func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool) *gnpNetworkCrossValidation {
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isVPCSpecified := params.Spec.VPC != ""
 	isVPCSubnetSpecified := params.Spec.VPCSubnet != ""
 	isNetworkAttachmentSpecified := params.Spec.NetworkAttachment != ""
 
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
+	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
 	if network.Spec.Type == networkv1.L3NetworkType {
-		if isVPCSpecified && isVPCSubnetSpecified && !isSecondaryRangeSpecified {
+		if !canHaveIpv6OnlyNetworksOnly && isVPCSpecified && isVPCSubnetSpecified && !isSecondaryRangeSpecified {
 			return &gnpNetworkCrossValidation{
 				IsValid:      false,
 				ErrorReason:  networkv1.L3SecondaryMissing,


### PR DESCRIPTION
This PR adds support for the default network on strictly IPv6-only clusters by entirely omitting the PodIPv4Ranges property and exempting the parameter set from strict multi-network validation rules.

Depends on: PR #1301
