### PR TITLE
Foundational changes for IPv6-only multinetworking clusters

### DIFF
--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -448,7 +448,7 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 			return nil
 		}
 
-		return c.getAndSyncNetworkForGNP(ctx, params)
+		return c.getAndSyncNetworkForGNP(ctx, params, nil)
 	}
 
 	// Validate params with (VPC + VPCSubnet).
@@ -482,13 +482,13 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 		CIDRBlocks: cidrs,
 	}
 
-	return c.getAndSyncNetworkForGNP(ctx, params)
+	return c.getAndSyncNetworkForGNP(ctx, params, subnet)
 }
 
 // getAndSyncNetworkForGNP gets the network that refers to this GNP object, and
 // then does the cross sync of Network with GNP. GNP is guaranteed to have
 // minimum fields set (either NetworkAttachment or [VPC + VPCSubnet]).
-func (c *Controller) getAndSyncNetworkForGNP(ctx context.Context, params *networkv1.GKENetworkParamSet) error {
+func (c *Controller) getAndSyncNetworkForGNP(ctx context.Context, params *networkv1.GKENetworkParamSet, subnet *compute.Subnetwork) error {
 	network, err := c.getNetworkReferringToGNP(params.Name)
 	if err != nil {
 		return err
@@ -497,7 +497,7 @@ func (c *Controller) getAndSyncNetworkForGNP(ctx context.Context, params *networ
 		return nil
 	}
 
-	if err = c.syncNetworkWithGNP(ctx, network, params); err != nil {
+	if err = c.syncNetworkWithGNP(ctx, network, params, subnet); err != nil {
 		return err
 	}
 	return nil
@@ -520,11 +520,11 @@ func (c *Controller) getNetworkReferringToGNP(gnpName string) (*networkv1.Networ
 
 // syncNetworkWithGNP does the cross sync of Network with GNP.
 // GNP can be mutated, while a copy of Network is both transformed AND updated in the cluster
-func (c *Controller) syncNetworkWithGNP(ctx context.Context, network *networkv1.Network, params *networkv1.GKENetworkParamSet) error {
+func (c *Controller) syncNetworkWithGNP(ctx context.Context, network *networkv1.Network, params *networkv1.GKENetworkParamSet, subnet *compute.Subnetwork) error {
 	newNetwork := network.DeepCopy()
 
 	// update the copy of old Network with new conditions to be new Network basing on the change of the GNP
-	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster)
+	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster, subnet)
 	meta.SetStatusCondition(&newNetwork.Status.Conditions, networkCrossValidation.toCondition())
 
 	if !reflect.DeepEqual(newNetwork.Status.Conditions, network.Status.Conditions) {

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -477,7 +477,7 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 		}
 	}
 
-	cidrs := extractRelevantCidrs(subnet, params)
+	cidrs := extractRelevantCidrs(subnet, params, c.isIPv6OnlyCluster)
 	params.Status.PodCIDRs = &networkv1.NetworkRanges{
 		CIDRBlocks: cidrs,
 	}
@@ -594,24 +594,38 @@ func (c *Controller) cleanupGNPDeletion(ctx context.Context, gnpName string) err
 	return nil
 }
 
-// extractRelevantCidrs returns the CIDRS of the named ranges in paramset
-func extractRelevantCidrs(subnet *compute.Subnetwork, paramset *networkv1.GKENetworkParamSet) []string {
+// extractRelevantCidrs returns the appropriate IPv4 and IPv6 CIDR blocks from the subnet based on the paramset configuration (including primary, secondary, and IPv6 prefixes)
+func extractRelevantCidrs(subnet *compute.Subnetwork, paramset *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool) []string {
 	cidrs := []string{}
 
-	// use the subnet cidr if there are no secondary ranges specified by user in params, this can only happen if the GNP is using deviceMode
-	if !hasRangeNames(paramset) {
-		cidrs = append(cidrs, subnet.IpCidrRange)
-		return cidrs
-	}
-
-	// get secondary ranges' corresponding cidrs
-	for _, sr := range subnet.SecondaryIpRanges {
-		if !paramSetIncludesRange(paramset, sr.RangeName) {
-			continue
+	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && paramset.Name == networkv1.DefaultPodNetworkName
+	if !canHaveIpv6OnlyNetworksOnly {
+		if hasRangeNames(paramset) {
+			// get secondary ranges' corresponding cidrs
+			for _, sr := range subnet.SecondaryIpRanges {
+				if paramSetIncludesRange(paramset, sr.RangeName) {
+					cidrs = append(cidrs, sr.IpCidrRange)
+				}
+			}
+		} else {
+			// use the subnet cidr if there are no secondary ranges specified by user in params,
+			// this can only happen if the GNP is using deviceMode.
+			if subnet.IpCidrRange != "" {
+				cidrs = append(cidrs, subnet.IpCidrRange)
+			}
 		}
-
-		cidrs = append(cidrs, sr.IpCidrRange)
 	}
+
+	// add IPv6 ranges if present
+	if subnet.InternalIpv6Prefix != "" {
+		cidrs = append(cidrs, subnet.InternalIpv6Prefix)
+	} else if subnet.ExternalIpv6Prefix != "" {
+		cidrs = append(cidrs, subnet.ExternalIpv6Prefix)
+	} else if subnet.Ipv6CidrRange != "" {
+		// legacy subnet case
+		cidrs = append(cidrs, subnet.Ipv6CidrRange)
+	}
+
 	return cidrs
 }
 

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -192,7 +192,7 @@ func NewGKENetworkParamSetController(
 			c.clusterDefaultIPv4PodCIDR = clusterCIDR.String()
 		}
 	}
-	if c.clusterDefaultIPv4PodCIDR == "" {
+	if len(clusterCIDRs) == 0 {
 		klog.Fatal("Controller: Must specify --cluster-cidr for GKE VPC native cluster")
 	}
 

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -81,6 +81,7 @@ type Controller struct {
 	nodeInformerSynced        cache.InformerSynced
 	clusterDefaultIPv4PodCIDR string
 	defaultGNPName            string
+	isIPv6OnlyCluster         bool
 }
 
 // NewGKENetworkParamSetController returns a new
@@ -192,6 +193,10 @@ func NewGKENetworkParamSetController(
 			c.clusterDefaultIPv4PodCIDR = clusterCIDR.String()
 		}
 	}
+
+	// cluster is IPv6-only if it doesn't have any IPv4 cluster CIDRs.
+	c.isIPv6OnlyCluster = c.clusterDefaultIPv4PodCIDR == ""
+
 	if len(clusterCIDRs) == 0 {
 		klog.Fatal("Controller: Must specify --cluster-cidr for GKE VPC native cluster")
 	}
@@ -374,14 +379,17 @@ func (c *Controller) populateDesiredDefaultParamSet(ctx context.Context, params 
 		return fmt.Errorf("failed to get vpcSubnet %q compute subnetwork: %v, err: %v", vpcSubnet, subnet, err)
 	}
 	defaultPodRange := ""
-	for _, r := range subnet.SecondaryIpRanges {
-		if r.IpCidrRange == c.clusterDefaultIPv4PodCIDR {
-			defaultPodRange = r.RangeName
-			break
+	// if cluster is ipv6 only, then defaultPodRange should be empty
+	if !c.isIPv6OnlyCluster {
+		for _, r := range subnet.SecondaryIpRanges {
+			if r.IpCidrRange == c.clusterDefaultIPv4PodCIDR {
+				defaultPodRange = r.RangeName
+				break
+			}
 		}
-	}
-	if defaultPodRange == "" {
-		return fmt.Errorf("failed to find range name for cluster default IPv4 Pod CIDR %q in compute subnet: %q", c.clusterDefaultIPv4PodCIDR, subnet.Name)
+		if defaultPodRange == "" {
+			return fmt.Errorf("failed to find range name for cluster default IPv4 Pod CIDR %q in compute subnet: %q", c.clusterDefaultIPv4PodCIDR, subnet.Name)
+		}
 	}
 
 	// ensure Annotations and Labels
@@ -405,9 +413,11 @@ func (c *Controller) populateDesiredDefaultParamSet(ctx context.Context, params 
 	params.Spec = networkv1.GKENetworkParamSetSpec{
 		VPC:       vpc,
 		VPCSubnet: vpcSubnet,
-		PodIPv4Ranges: &networkv1.SecondaryRanges{
+	}
+	if defaultPodRange != "" {
+		params.Spec.PodIPv4Ranges = &networkv1.SecondaryRanges{
 			RangeNames: []string{defaultPodRange},
-		},
+		}
 	}
 	return nil
 }
@@ -459,7 +469,7 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 
 	// update PodIPv4Ranges for the "default" paramset basing on all the nodes Pod ranges
 	// when the paramset is EnsureExists mode
-	if params.Name == c.defaultGNPName {
+	if params.Name == c.defaultGNPName && params.Spec.PodIPv4Ranges != nil {
 		if mode, ok := params.Labels[labelsAddonManagerMode]; ok && mode == ensureExistsMode {
 			if err = c.syncPodRanges(ctx, params); err != nil {
 				return err
@@ -514,7 +524,7 @@ func (c *Controller) syncNetworkWithGNP(ctx context.Context, network *networkv1.
 	newNetwork := network.DeepCopy()
 
 	// update the copy of old Network with new conditions to be new Network basing on the change of the GNP
-	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params)
+	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster)
 	meta.SetStatusCondition(&newNetwork.Status.Conditions, networkCrossValidation.toCondition())
 
 	if !reflect.DeepEqual(newNetwork.Status.Conditions, network.Status.Conditions) {

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -477,7 +477,7 @@ func (c *Controller) syncGNP(ctx context.Context, params *networkv1.GKENetworkPa
 		}
 	}
 
-	cidrs := extractRelevantCidrs(subnet, params, c.isIPv6OnlyCluster)
+	cidrs := extractRelevantCidrs(subnet, params, c.isIPv6OnlyCluster, c.defaultGNPName)
 	params.Status.PodCIDRs = &networkv1.NetworkRanges{
 		CIDRBlocks: cidrs,
 	}
@@ -524,7 +524,7 @@ func (c *Controller) syncNetworkWithGNP(ctx context.Context, network *networkv1.
 	newNetwork := network.DeepCopy()
 
 	// update the copy of old Network with new conditions to be new Network basing on the change of the GNP
-	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster, subnet)
+	networkCrossValidation := crossValidateNetworkAndGnp(newNetwork, params, c.isIPv6OnlyCluster, c.defaultGNPName, subnet)
 	meta.SetStatusCondition(&newNetwork.Status.Conditions, networkCrossValidation.toCondition())
 
 	if !reflect.DeepEqual(newNetwork.Status.Conditions, network.Status.Conditions) {
@@ -595,10 +595,11 @@ func (c *Controller) cleanupGNPDeletion(ctx context.Context, gnpName string) err
 }
 
 // extractRelevantCidrs returns the appropriate IPv4 and IPv6 CIDR blocks from the subnet based on the paramset configuration (including primary, secondary, and IPv6 prefixes)
-func extractRelevantCidrs(subnet *compute.Subnetwork, paramset *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool) []string {
+func extractRelevantCidrs(subnet *compute.Subnetwork, paramset *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool, defaultGNPName string) []string {
 	cidrs := []string{}
 
-	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && paramset.Name == networkv1.DefaultPodNetworkName
+	isDefaultGNP := paramset.Name == defaultGNPName
+	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && isDefaultGNP
 	if !canHaveIpv6OnlyNetworksOnly {
 		if hasRangeNames(paramset) {
 			// get secondary ranges' corresponding cidrs

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -445,6 +445,156 @@ func TestValidParamSetSubnetRange(t *testing.T) {
 
 }
 
+func TestValidParamSetSubnetInternalIpv6Prefix(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodIPv6CIDR)
+
+	subnetName := "ipv6-subnet"
+	subnetIpv6Cidr := "2001:db8::/32"
+	subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
+
+	subnet := &compute.Subnetwork{
+		Name:               subnetName,
+		InternalIpv6Prefix: subnetIpv6Cidr,
+	}
+
+	err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+	if err != nil {
+		t.Error(err)
+	}
+	testVals.runGKENetworkParamSetController(ctx)
+
+	gkeNetworkParamSetName := "test-paramset-ipv6"
+	paramSet := &networkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gkeNetworkParamSetName,
+		},
+		Spec: networkv1.GKENetworkParamSetSpec{
+			VPC:        nonDefaultTestNetworkName,
+			VPCSubnet:  subnetName,
+			DeviceMode: networkv1.NetDevice,
+		},
+	}
+
+	_, err = testVals.networkClient.NetworkingV1().GKENetworkParamSets().Create(ctx, paramSet, metav1.CreateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	g.Eventually(func() (bool, error) {
+		paramSet, err := testVals.networkClient.NetworkingV1().GKENetworkParamSets().Get(ctx, gkeNetworkParamSetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		cidrExists := paramSet.Status.PodCIDRs != nil && len(paramSet.Status.PodCIDRs.CIDRBlocks) > 0
+		if cidrExists {
+			g.Ω(paramSet.Status.PodCIDRs.CIDRBlocks).Should(gomega.ConsistOf(subnetIpv6Cidr))
+			return true, nil
+		}
+
+		return false, nil
+	}).Should(gomega.BeTrue(), "GKENetworkParamSet Status should be updated ONLY with subnet internal ipv6 prefix.")
+}
+
+func TestValidParamSetSubnetExternalIpv6Prefix(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodIPv6CIDR)
+	subnetName := "ipv6-subnet"
+	subnetIpv6Cidr := "2001:db8::/32"
+	subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
+
+	subnet := &compute.Subnetwork{
+		Name:               subnetName,
+		ExternalIpv6Prefix: subnetIpv6Cidr,
+	}
+	err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+	if err != nil {
+		t.Error(err)
+	}
+	testVals.runGKENetworkParamSetController(ctx)
+	gkeNetworkParamSetName := "test-paramset-ipv6"
+	paramSet := &networkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{Name: gkeNetworkParamSetName},
+		Spec: networkv1.GKENetworkParamSetSpec{
+			VPC:        nonDefaultTestNetworkName,
+			VPCSubnet:  subnetName,
+			DeviceMode: networkv1.NetDevice,
+		},
+	}
+
+	_, err = testVals.networkClient.NetworkingV1().GKENetworkParamSets().Create(ctx, paramSet, metav1.CreateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	g.Eventually(func() (bool, error) {
+		paramSet, err := testVals.networkClient.NetworkingV1().GKENetworkParamSets().Get(ctx, gkeNetworkParamSetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		cidrExists := paramSet.Status.PodCIDRs != nil && len(paramSet.Status.PodCIDRs.CIDRBlocks) > 0
+		if cidrExists {
+			g.Ω(paramSet.Status.PodCIDRs.CIDRBlocks).Should(gomega.ConsistOf(subnetIpv6Cidr))
+			return true, nil
+		}
+		return false, nil
+	}).Should(gomega.BeTrue(), "GKENetworkParamSet Status should be updated with subnet cidr.")
+}
+
+func TestValidParamSetSubnetIpv6CidrRange(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodIPv6CIDR)
+
+	subnetName := "ipv6-subnet"
+	subnetIpv6Cidr := "2001:db8::/32"
+	subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
+
+	subnet := &compute.Subnetwork{
+		Name:          subnetName,
+		Ipv6CidrRange: subnetIpv6Cidr,
+	}
+
+	err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+	if err != nil {
+		t.Error(err)
+	}
+	testVals.runGKENetworkParamSetController(ctx)
+
+	gkeNetworkParamSetName := "test-paramset-ipv6"
+	paramSet := &networkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{Name: gkeNetworkParamSetName},
+		Spec: networkv1.GKENetworkParamSetSpec{
+			VPC:        nonDefaultTestNetworkName,
+			VPCSubnet:  subnetName,
+			DeviceMode: networkv1.NetDevice,
+		},
+	}
+
+	_, err = testVals.networkClient.NetworkingV1().GKENetworkParamSets().Create(ctx, paramSet, metav1.CreateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	g.Eventually(func() (bool, error) {
+		paramSet, err := testVals.networkClient.NetworkingV1().GKENetworkParamSets().Get(ctx, gkeNetworkParamSetName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		cidrExists := paramSet.Status.PodCIDRs != nil && len(paramSet.Status.PodCIDRs.CIDRBlocks) > 0
+		if cidrExists {
+			g.Ω(paramSet.Status.PodCIDRs.CIDRBlocks).Should(gomega.ConsistOf(subnetIpv6Cidr))
+			return true, nil
+		}
+		return false, nil
+	}).Should(gomega.BeTrue(), "GKENetworkParamSet Status should be updated with subnet cidr.")
+}
+
 func TestAddAndRemoveFinalizerToGKENetworkParamSet_NoNetworkName(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -526,6 +526,7 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 		name              string
 		paramSet          *networkv1.GKENetworkParamSet
 		subnet            *compute.Subnetwork
+		isIPv6OnlyCluster bool
 		expectedCondition metav1.Condition
 	}{
 		{
@@ -869,6 +870,68 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 				Reason: "GNPConfigInvalid",
 			},
 		},
+		{
+			name: "IPv4/Dual-stack cluster rejects unset GNP.Spec.PodIPv4Ranges for Default Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: networkv1.DefaultPodNetworkName,
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       "test-vpc",
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: false,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "SecondaryRangeAndDeviceModeUnspecified",
+			},
+		},
+		{
+			name: "IPv6-only cluster allows unset GNP.Spec.PodIPv4Ranges for Default Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       defaultTestNetworkName,
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionTrue,
+				Reason: "GNPReady",
+			},
+		},
+		{
+			name: "IPv6-only cluster rejects unset GNP.Spec.PodIPv4Ranges for custom Network",
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "custom-network",
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       defaultTestNetworkName,
+					VPCSubnet: "test-subnet",
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "Ready",
+				Status: metav1.ConditionFalse,
+				Reason: "SecondaryRangeAndDeviceModeUnspecified",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -876,7 +939,12 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			// Create subnet
 			subnet := &compute.Subnetwork{
@@ -890,6 +958,15 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			}
 			subnetKey := meta.RegionalKey(subnet.Name, testVals.clusterValues.Region)
 			err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			defaultSubnet := &compute.Subnetwork{
+				Name: defaultTestSubnetworkName,
+			}
+			defaultSubnetKey := meta.RegionalKey(defaultSubnet.Name, testVals.clusterValues.Region)
+			err = testVals.cloud.Compute().Subnetworks().Insert(ctx, defaultSubnetKey, defaultSubnet)
 			if err != nil {
 				t.Error(err)
 			}
@@ -974,6 +1051,7 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 		name              string
 		network           *networkv1.Network
 		paramSet          *networkv1.GKENetworkParamSet
+		isIPv6OnlyCluster bool
 		expectedCondition metav1.Condition
 	}{
 		{
@@ -1186,13 +1264,75 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 				Reason: "GNPParamsReady",
 			},
 		},
+		{
+			name: "IPv6-only cluster allows L3NetworkType with unset GNP.Spec.PodIPv4Ranges for Default Network",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: networkv1.DefaultPodNetworkName,
+				},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: networkv1.DefaultPodNetworkName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:       nonDefaultTestNetworkName,
+					VPCSubnet: subnetName,
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionTrue,
+				Reason: "GNPParamsReady",
+			},
+		},
+		{
+			name: "IPv6-only cluster rejects L3NetworkType with unset GNP.Spec.PodIPv4Ranges for custom Network",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: networkName},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: gkeNetworkParamSetName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        gkeNetworkParamSetName,
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:        nonDefaultTestNetworkName,
+					VPCSubnet:  subnetName,
+					DeviceMode: networkv1.NetDevice,
+				},
+			},
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionFalse,
+				Reason: "L3SecondaryMissing",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			subnetSecondaryCidr := "10.0.0.1/24"
 			subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -1205,8 +1345,16 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 					},
 				},
 			}
-
 			err := testVals.cloud.Compute().Subnetworks().Insert(ctx, subnetKey, subnet)
+			if err != nil {
+				t.Error(err)
+			}
+
+			defaultSubnet := &compute.Subnetwork{
+				Name: defaultTestSubnetworkName,
+			}
+			defaultSubnetKey := meta.RegionalKey(defaultSubnet.Name, testVals.clusterValues.Region)
+			err = testVals.cloud.Compute().Subnetworks().Insert(ctx, defaultSubnetKey, defaultSubnet)
 			if err != nil {
 				t.Error(err)
 			}
@@ -1415,10 +1563,13 @@ func (testVals *testGKENetworkParamSetController) doesGNPFinalizerExist(ctx cont
 func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 	desiredDefaultParamSet := newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, nil)
 
+	ipv6DesiredDefaultParamSet := newL3GNP(networkv1.DefaultPodNetworkName, nil, nil)
+
 	tests := []struct {
-		name            string
-		defaultParamSet *networkv1.GKENetworkParamSet
-		wantParamSet    *networkv1.GKENetworkParamSet
+		name              string
+		defaultParamSet   *networkv1.GKENetworkParamSet
+		wantParamSet      *networkv1.GKENetworkParamSet
+		isIPv6OnlyCluster bool
 	}{
 		{
 			name:            "not populate if addon is reconcile mode",
@@ -1450,6 +1601,12 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			defaultParamSet: newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, &gnpOptions{testAddonMode: ""}),
 			wantParamSet:    desiredDefaultParamSet,
 		},
+		{
+			name:              "ipv6-only cluster ignores and clears PodIPv4Ranges",
+			defaultParamSet:   newL3GNP(networkv1.DefaultPodNetworkName, []string{defaultPodRange}, nil),
+			wantParamSet:      ipv6DesiredDefaultParamSet,
+			isIPv6OnlyCluster: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -1457,7 +1614,12 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+
+			cidrForEnv := defaultPodCIDR
+			if test.isIPv6OnlyCluster {
+				cidrForEnv = defaultPodIPv6CIDR
+			}
+			testVals := setupGKENetworkParamSetController(ctx, cidrForEnv)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -1114,6 +1114,12 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 
 			defaultSubnet := &compute.Subnetwork{
 				Name: defaultTestSubnetworkName,
+				SecondaryIpRanges: []*compute.SubnetworkSecondaryRange{
+					{
+						IpCidrRange: "10.100.0.0/16",
+						RangeName:   "default-pod-range",
+					},
+				},
 			}
 			defaultSubnetKey := meta.RegionalKey(defaultSubnet.Name, testVals.clusterValues.Region)
 			err = testVals.cloud.Compute().Subnetworks().Insert(ctx, defaultSubnetKey, defaultSubnet)
@@ -1201,6 +1207,7 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 		name              string
 		network           *networkv1.Network
 		paramSet          *networkv1.GKENetworkParamSet
+		subnetStackType   string
 		isIPv6OnlyCluster bool
 		expectedCondition metav1.Condition
 	}{
@@ -1229,6 +1236,96 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 				Type:   "ParamsReady",
 				Status: metav1.ConditionFalse,
 				Reason: "L3SecondaryMissing",
+			},
+		},
+		{
+			name: "L3NetworkType with IPV6_ONLY subnet",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: networkName,
+				},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: gkeNetworkParamSetName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: gkeNetworkParamSetName,
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:           nonDefaultTestNetworkName,
+					VPCSubnet:     subnetName,
+					PodIPv4Ranges: &networkv1.SecondaryRanges{RangeNames: []string{subnetSecondaryRangeName}},
+				},
+			},
+			subnetStackType: "IPV6_ONLY",
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionFalse,
+				Reason: "SubnetStackTypeIncompatible",
+			},
+		},
+		{
+			name: "L3NetworkType Default network with IPV6_ONLY subnet on IPv6Only Cluster",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: networkv1.DefaultPodNetworkName},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: networkv1.DefaultPodNetworkName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:           nonDefaultTestNetworkName,
+					VPCSubnet:     subnetName,
+					PodIPv4Ranges: &networkv1.SecondaryRanges{RangeNames: []string{subnetSecondaryRangeName}},
+				},
+			},
+			subnetStackType:   "IPV6_ONLY",
+			isIPv6OnlyCluster: true,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionTrue,
+				Reason: "GNPParamsReady",
+			},
+		},
+		{
+			name: "L3NetworkType Default network with IPV6_ONLY subnet on DualStack/IPv4 Cluster",
+			network: &networkv1.Network{
+				ObjectMeta: metav1.ObjectMeta{Name: networkv1.DefaultPodNetworkName},
+				Spec: networkv1.NetworkSpec{
+					Type:          networkv1.L3NetworkType,
+					ParametersRef: &networkv1.NetworkParametersReference{Name: networkv1.DefaultPodNetworkName, Kind: gnpKind},
+				},
+			},
+			paramSet: &networkv1.GKENetworkParamSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        networkv1.DefaultPodNetworkName,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
+				},
+				Spec: networkv1.GKENetworkParamSetSpec{
+					VPC:           nonDefaultTestNetworkName,
+					VPCSubnet:     subnetName,
+					PodIPv4Ranges: &networkv1.SecondaryRanges{RangeNames: []string{subnetSecondaryRangeName}},
+				},
+			},
+			subnetStackType:   "IPV6_ONLY",
+			isIPv6OnlyCluster: false,
+			expectedCondition: metav1.Condition{
+				Type:   "ParamsReady",
+				Status: metav1.ConditionFalse,
+				Reason: "SubnetStackTypeIncompatible",
 			},
 		},
 		{
@@ -1427,8 +1524,10 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 			},
 			paramSet: &networkv1.GKENetworkParamSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        networkv1.DefaultPodNetworkName,
-					Labels:      map[string]string{},
+					Name: networkv1.DefaultPodNetworkName,
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
 					Annotations: map[string]string{},
 				},
 				Spec: networkv1.GKENetworkParamSetSpec{
@@ -1454,8 +1553,10 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 			},
 			paramSet: &networkv1.GKENetworkParamSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        gkeNetworkParamSetName,
-					Labels:      map[string]string{},
+					Name: gkeNetworkParamSetName,
+					Labels: map[string]string{
+						"addonmanager.kubernetes.io/mode": "Reconcile",
+					},
 					Annotations: map[string]string{},
 				},
 				Spec: networkv1.GKENetworkParamSetSpec{
@@ -1487,7 +1588,8 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 			subnetSecondaryCidr := "10.0.0.1/24"
 			subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{
-				Name: subnetName,
+				Name:      subnetName,
+				StackType: test.subnetStackType,
 				SecondaryIpRanges: []*compute.SubnetworkSecondaryRange{
 					{
 						IpCidrRange: subnetSecondaryCidr,

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -51,19 +51,20 @@ const (
 	newPodRange1              = "new-pod-range1"
 	newPodRange2              = "new-pod-range2"
 	defaultPodCIDR            = "10.100.0.0/16"
+	defaultPodIPv6CIDR        = "2600:1900:4000:fd1::/64"
 	newPodCIDR1               = "10.101.0.0/16"
 	newPodCIDR2               = "10.102.0.0/16"
 )
 
-func setupGKENetworkParamSetController(ctx context.Context) *testGKENetworkParamSetController {
-	return setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, "", fake.NewSimpleClientset())
+func setupGKENetworkParamSetController(ctx context.Context, clusterCIDR string) *testGKENetworkParamSetController {
+	return setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, clusterCIDR, "", fake.NewSimpleClientset())
 }
 
-func setupGKENetworkParamSetControllerWithCustomDefaultGNP(ctx context.Context, customDefaultGNPName string) *testGKENetworkParamSetController {
-	return setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, customDefaultGNPName, fake.NewSimpleClientset())
+func setupGKENetworkParamSetControllerWithCustomDefaultGNP(ctx context.Context, clusterCIDR string, customDefaultGNPName string) *testGKENetworkParamSetController {
+	return setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, clusterCIDR, customDefaultGNPName, fake.NewSimpleClientset())
 }
 
-func setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx context.Context, customDefaultGNPName string, nodeClient *fake.Clientset) *testGKENetworkParamSetController {
+func setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx context.Context, clusterCIDR string, customDefaultGNPName string, nodeClient *fake.Clientset) *testGKENetworkParamSetController {
 	fakeNetworking := networkfake.NewSimpleClientset()
 	nwInfFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
 	nwInformer := nwInfFactory.Networking().V1().Networks()
@@ -76,7 +77,7 @@ func setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx cont
 	fakeInformerFactory := informers.NewSharedInformerFactory(nodeClient, 0*time.Second)
 	fakeNodeInformer := fakeInformerFactory.Core().V1().Nodes()
 
-	_, ipnet, _ := net.ParseCIDR(defaultPodCIDR)
+	_, ipnet, _ := net.ParseCIDR(clusterCIDR)
 
 	controller := NewGKENetworkParamSetController(
 		fakeNodeInformer,
@@ -125,7 +126,14 @@ func (testVals *testGKENetworkParamSetController) runGKENetworkParamSetControlle
 func TestControllerRuns(t *testing.T) {
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
+	testVals.runGKENetworkParamSetController(ctx)
+}
+
+func TestControllerRunsIPv6Only(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	defer stop()
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodIPv6CIDR)
 	testVals.runGKENetworkParamSetController(ctx)
 }
 
@@ -133,7 +141,7 @@ func TestAddValidParamSetSingleSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName := "test-secondary-range"
@@ -197,7 +205,7 @@ func TestAddValidParamSetMultipleSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName1 := "test-secondary-range-1"
@@ -268,7 +276,7 @@ func TestAddInvalidParamSetNoMatchingSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -324,7 +332,7 @@ func TestParamSetPartialSecondaryRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetSecondaryRangeName1 := "test-secondary-range-1"
@@ -388,7 +396,7 @@ func TestValidParamSetSubnetRange(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	subnetName := "test-subnet"
 	subnetCidr := "10.0.0.0/24"
@@ -441,7 +449,7 @@ func TestAddAndRemoveFinalizerToGKENetworkParamSet_NoNetworkName(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	ctx, stop := context.WithCancel(context.Background())
 	defer stop()
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	testVals.runGKENetworkParamSetController(ctx)
 
@@ -868,7 +876,7 @@ func TestGKENetworkParamSetValidations(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			// Create subnet
 			subnet := &compute.Subnetwork{
@@ -1184,7 +1192,7 @@ func TestCrossValidateNetworkAndGnp(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetSecondaryCidr := "10.0.0.1/24"
 			subnetKey := meta.RegionalKey(subnetName, testVals.clusterValues.Region)
@@ -1269,7 +1277,7 @@ func TestHandleGKENetworkParamSetDelete_NetworkPresent(t *testing.T) {
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
 
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetName := "test-subnet"
 			subnet := &compute.Subnetwork{
@@ -1449,7 +1457,7 @@ func TestPopulateDesiredDefaultParamSet(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{
@@ -1584,7 +1592,7 @@ func TestSyncDefaultPodRanges(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
 			ctx, stop := context.WithCancel(context.Background())
 			defer stop()
-			testVals := setupGKENetworkParamSetController(ctx)
+			testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 			subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 			subnet := &compute.Subnetwork{
@@ -1782,7 +1790,7 @@ func TestSyncDefaultPodRangesWithCustomDefaultGNPName(t *testing.T) {
 
 	customDefaultName := "t365985285473-tenantuno-default"
 
-	testVals := setupGKENetworkParamSetControllerWithCustomDefaultGNP(ctx, customDefaultName)
+	testVals := setupGKENetworkParamSetControllerWithCustomDefaultGNP(ctx, defaultPodCIDR, customDefaultName)
 
 	subnetKey := meta.RegionalKey(defaultTestSubnetworkName, testVals.clusterValues.Region)
 	subnet := &compute.Subnetwork{
@@ -1854,7 +1862,7 @@ func TestNodeUpdateTriggersCustomDefaultGNPQueue(t *testing.T) {
 
 	customDefaultName := "t365985285473-tenantuno-default"
 	nodeClient := fake.NewSimpleClientset()
-	testVals := setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, customDefaultName, nodeClient)
+	testVals := setupGKENetworkParamSetControllerWithCustomDefaultGNPAndNodeClient(ctx, defaultPodCIDR, customDefaultName, nodeClient)
 
 	// Start both informer factories
 	testVals.informerFactory.Start(ctx.Done())
@@ -1907,7 +1915,7 @@ func TestRemoveTenantParamSetFinalizers(t *testing.T) {
 	tenantName := "t12345-tenantuno"
 	otherTenantName := "t99999-tenantdos"
 
-	testVals := setupGKENetworkParamSetController(ctx)
+	testVals := setupGKENetworkParamSetController(ctx, defaultPodCIDR)
 
 	// Create GNPs for tenant-1 (one with finalizer, one without)
 	gnp1 := newL3GNP("tenant1-default", []string{defaultPodRange}, nil)

--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -93,8 +93,12 @@ func (c *Controller) validateFieldCombinations(ctx context.Context, params *netw
 	}
 
 	// Network attachment is not specified.
-	// Check if both deviceMode and secondary ranges are unspecified.
-	if !hasSecondaryRanges && !hasDeviceMode {
+	// check if deviceMode and secondary ranges are unspecified
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+
+	// we skip this check for IPv6-only clusters because their default network inherently does not have IPv4 secondary ranges
+	if !canHaveIpv6OnlyNetworksOnly && !hasSecondaryRanges && !hasDeviceMode {
 		return &gnpValidation{
 			IsValid:      false,
 			ErrorReason:  networkv1.SecondaryRangeAndDeviceModeUnspecified,
@@ -173,10 +177,13 @@ func (c *Controller) validateGKENetworkParamSet(ctx context.Context, params *net
 		}
 	}
 
-	// check if both deviceMode and secondary ranges are unspecified
+	// check if both deviceMode and secondary ranges are unspecified.
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isDeviceModeSpecified := params.Spec.DeviceMode != ""
-	if !isSecondaryRangeSpecified && !isDeviceModeSpecified {
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+
+	if !canHaveIpv6OnlyNetworksOnly && !isSecondaryRangeSpecified && !isDeviceModeSpecified {
 		return &gnpValidation{
 			IsValid:      false,
 			ErrorReason:  networkv1.SecondaryRangeAndDeviceModeUnspecified,
@@ -276,14 +283,16 @@ func (val *gnpNetworkCrossValidation) toCondition() metav1.Condition {
 }
 
 // crossValidateNetworkAndGnp validates a given network and GNP object are compatible
-func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet) *gnpNetworkCrossValidation {
+func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool) *gnpNetworkCrossValidation {
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isVPCSpecified := params.Spec.VPC != ""
 	isVPCSubnetSpecified := params.Spec.VPCSubnet != ""
 	isNetworkAttachmentSpecified := params.Spec.NetworkAttachment != ""
 
+	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
+	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
 	if network.Spec.Type == networkv1.L3NetworkType {
-		if isVPCSpecified && isVPCSubnetSpecified && !isSecondaryRangeSpecified {
+		if !canHaveIpv6OnlyNetworksOnly && isVPCSpecified && isVPCSubnetSpecified && !isSecondaryRangeSpecified {
 			return &gnpNetworkCrossValidation{
 				IsValid:      false,
 				ErrorReason:  networkv1.L3SecondaryMissing,

--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -95,7 +95,8 @@ func (c *Controller) validateFieldCombinations(ctx context.Context, params *netw
 	// Network attachment is not specified.
 	// check if deviceMode and secondary ranges are unspecified
 	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
-	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+	isDefaultGNP := params.Name == c.defaultGNPName
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && isDefaultGNP
 
 	// we skip this check for IPv6-only clusters because their default network inherently does not have IPv4 secondary ranges
 	if !canHaveIpv6OnlyNetworksOnly && !hasSecondaryRanges && !hasDeviceMode {
@@ -181,7 +182,8 @@ func (c *Controller) validateGKENetworkParamSet(ctx context.Context, params *net
 	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isDeviceModeSpecified := params.Spec.DeviceMode != ""
-	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+	isDefaultGNP := params.Name == c.defaultGNPName
+	canHaveIpv6OnlyNetworksOnly := c.isIPv6OnlyCluster && isDefaultGNP
 
 	if !canHaveIpv6OnlyNetworksOnly && !isSecondaryRangeSpecified && !isDeviceModeSpecified {
 		return &gnpValidation{
@@ -283,14 +285,15 @@ func (val *gnpNetworkCrossValidation) toCondition() metav1.Condition {
 }
 
 // crossValidateNetworkAndGnp validates a given network and GNP object are compatible
-func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool, subnet *compute.Subnetwork) *gnpNetworkCrossValidation {
+func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool, defaultGNPName string, subnet *compute.Subnetwork) *gnpNetworkCrossValidation {
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isVPCSpecified := params.Spec.VPC != ""
 	isVPCSubnetSpecified := params.Spec.VPCSubnet != ""
 	isNetworkAttachmentSpecified := params.Spec.NetworkAttachment != ""
 
 	// The associated Network CRs are implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
-	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && params.Name == networkv1.DefaultPodNetworkName
+	isDefaultGNP := params.Name == defaultGNPName
+	canHaveIpv6OnlyNetworksOnly := isIPv6OnlyCluster && isDefaultGNP
 	if network.Spec.Type == networkv1.L3NetworkType {
 		if !canHaveIpv6OnlyNetworksOnly && isVPCSpecified && isVPCSubnetSpecified && !isSecondaryRangeSpecified {
 			return &gnpNetworkCrossValidation{
@@ -319,8 +322,7 @@ func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GK
 
 	// Network CR is implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
 	if subnet != nil && subnet.StackType == "IPV6_ONLY" {
-		isDefaultNetwork := params.Name == networkv1.DefaultPodNetworkName
-		isAllowedContext := isDefaultNetwork && isIPv6OnlyCluster
+		isAllowedContext := isDefaultGNP && isIPv6OnlyCluster
 
 		if !isAllowedContext {
 			return &gnpNetworkCrossValidation{

--- a/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
+++ b/pkg/controller/gkenetworkparamset/gnpcontroller_validations.go
@@ -283,7 +283,7 @@ func (val *gnpNetworkCrossValidation) toCondition() metav1.Condition {
 }
 
 // crossValidateNetworkAndGnp validates a given network and GNP object are compatible
-func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool) *gnpNetworkCrossValidation {
+func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GKENetworkParamSet, isIPv6OnlyCluster bool, subnet *compute.Subnetwork) *gnpNetworkCrossValidation {
 	isSecondaryRangeSpecified := hasRangeNames(params)
 	isVPCSpecified := params.Spec.VPC != ""
 	isVPCSubnetSpecified := params.Spec.VPCSubnet != ""
@@ -313,6 +313,20 @@ func crossValidateNetworkAndGnp(network *networkv1.Network, params *networkv1.GK
 				IsValid:      false,
 				ErrorReason:  networkv1.DeviceModeMissing,
 				ErrorMessage: "Device type network requires device mode to be specified in params",
+			}
+		}
+	}
+
+	// Network CR is implicitly IPv4-only, apart from the default network on an IPv6-only cluster.
+	if subnet != nil && subnet.StackType == "IPV6_ONLY" {
+		isDefaultNetwork := params.Name == networkv1.DefaultPodNetworkName
+		isAllowedContext := isDefaultNetwork && isIPv6OnlyCluster
+
+		if !isAllowedContext {
+			return &gnpNetworkCrossValidation{
+				IsValid:      false,
+				ErrorReason:  networkv1.GNPNetworkParamsReadyConditionReason("SubnetStackTypeIncompatible"),
+				ErrorMessage: "Network CR is not compatible with the subnet's StackType",
 			}
 		}
 	}

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -129,10 +129,6 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 				// otherwise get the CIDR with labels
 				if networkv1.IsDefaultNetwork(network.Name) && !hasNodeLabels {
 					defaultNwCIDRs = append(defaultNwCIDRs, ipRange.IpCidrRange)
-					ipv6Addr := ca.cloud.GetIPV6Address(inf)
-					if ipv6Addr != nil {
-						defaultNwCIDRs = append(defaultNwCIDRs, ipv6Addr.String())
-					}
 				}
 				if !networkv1.IsDefaultNetwork(network.Name) {
 					northInterfaces = append(northInterfaces, networkv1.NorthInterface{Network: network.Name, IpAddress: inf.NetworkIP})
@@ -143,6 +139,13 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 					}
 				}
 				break
+			}
+			if networkv1.IsDefaultNetwork(network.Name) && !hasNodeLabels {
+				ipv6Addr := ca.cloud.GetIPV6Address(inf)
+				if ipv6Addr != nil {
+					defaultNwCIDRs = append(defaultNwCIDRs, ipv6Addr.String())
+					processedNetworks[network.Name] = struct{}{}
+				}
 			}
 		}
 	}

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
@@ -5,9 +5,14 @@ import (
 	"testing"
 
 	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
+	clSetFake "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned/fake"
+	networkinformers "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions"
+	ntfakeclient "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned/fake"
 	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/cloud-provider-gcp/pkg/controller/testutil"
@@ -441,5 +446,304 @@ func TestExtractDefaultNwCIDRs(t *testing.T) {
 	res := ca.extractDefaultNwCIDRs(interfaces, "default", "RangeA")
 	if len(res) != 1 || res[0] != "10.0.0.0/24" {
 		t.Errorf("Expected [10.0.0.0/24], got %v", res)
+	}
+}
+
+func TestDefaultNetworkCIDRs_IPv4Only(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	clientSet := clSetFake.NewSimpleClientset()
+	nwInfFactory := networkinformers.NewSharedInformerFactory(clientSet, 0).Networking()
+
+	// Default Network
+	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	// Additional non-default network with same VPC but different subnet
+	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "different-subnet", []string{})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
+
+	// Additional non-default network with different VPC
+	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "", []string{})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
+
+	kubeClient := fake.NewSimpleClientset()
+	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
+
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, false, nodeInformer, CIDRAllocatorParams{})
+	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ipv4-node",
+			Annotations: map[string]string{
+				// Mark default and additional networks as ready
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}, {"name":"secondary1"}, {"name":"secondary2"}]`,
+			},
+		},
+	}
+
+	interfaces := []*compute.NetworkInterface{
+		{
+			Name:      "nic0",
+			Network:   "projects/testProject/global/networks/default",
+			NetworkIP: "10.0.0.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.1.0/24",
+					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+		{
+			Name:      "nic1",
+			Network:   "projects/testProject/global/networks/default",
+			NetworkIP: "10.0.1.1",
+		},
+		{
+			Name:      "nic2",
+			Network:   "projects/testProject/global/networks/other-vpc",
+			NetworkIP: "10.0.2.1",
+		},
+	}
+
+	cidrs, err := cloudAllocator.performMultiNetworkCIDRAllocation(node, interfaces, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cidrs) != 1 || cidrs[0] != "10.0.1.0/24" {
+		t.Errorf("Expected exact 1 CIDR block string for IPv4 podCIDR [10.0.1.0/24], got: %v", cidrs)
+	}
+}
+
+func TestDefaultNetworkCIDRs_DualStack_NoLabels(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	clientSet := clSetFake.NewSimpleClientset()
+	nwInfFactory := networkinformers.NewSharedInformerFactory(clientSet, 0).Networking()
+
+	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
+
+	// Initialize mock for default network - with IPv4 parameters
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	kubeClient := fake.NewSimpleClientset()
+	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
+
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dual-stack-node",
+			Annotations: map[string]string{
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}]`,
+			},
+		},
+	}
+
+	// Simulate node using v4/v6 stack on default network
+	interfaces := []*compute.NetworkInterface{
+		{
+			Name:        "nic0",
+			Network:     "projects/testProject/global/networks/default",
+			NetworkIP:   "10.0.0.1",
+			Ipv6Address: "2600:1900:4000:fd1::110",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.1.0/24",
+					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+	}
+
+	// Test case without node labels (hasNodeLabels = false)
+	cidrs, err := cloudAllocator.performMultiNetworkCIDRAllocation(node, interfaces, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Without labels, the function should extract both IPv4 and IPv6 CIDRs
+	if len(cidrs) != 2 || cidrs[0] != "10.0.1.0/24" || cidrs[1] != "2600:1900:4000:fd1::/112" {
+		t.Errorf("Expected exactly IPv4 and IPv6 CIDR blocks from dual-stack, got: %v", cidrs)
+	}
+}
+
+func TestDefaultNetworkCIDRs_DualStack_WithLabels(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	clientSet := clSetFake.NewSimpleClientset()
+	nwInfFactory := networkinformers.NewSharedInformerFactory(clientSet, 0).Networking()
+
+	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
+
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	kubeClient := fake.NewSimpleClientset()
+	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
+
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dual-stack-node-labeled",
+			Annotations: map[string]string{
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}]`,
+			},
+		},
+	}
+
+	interfaces := []*compute.NetworkInterface{
+		{
+			Name:        "nic0",
+			Network:     "projects/testProject/global/networks/default",
+			NetworkIP:   "10.0.0.1",
+			Ipv6Address: "2600:1900:4000:fd1::110",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.1.0/24",
+					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+	}
+
+	// Test case WITH known node labels (hasNodeLabels = true)
+	cidrs, err := cloudAllocator.performMultiNetworkCIDRAllocation(node, interfaces, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// With hasNodeLabels==true, the function drops default network allocation, leaving an empty slice
+	if len(cidrs) != 0 {
+		t.Errorf("Expected empty CIDR blocks because node has labels, got: %v", cidrs)
+	}
+}
+
+func TestDefaultNetworkCIDRs_IPv6Only(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	clientSet := clSetFake.NewSimpleClientset()
+	nwInfFactory := networkinformers.NewSharedInformerFactory(clientSet, 0).Networking()
+
+	// Default Network
+	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	// Additional non-default network with same VPC but different subnet
+	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "different-subnet", []string{})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
+
+	// Additional non-default network with different VPC
+	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "", []string{})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
+
+	kubeClient := fake.NewSimpleClientset()
+	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
+
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ipv6-node",
+			Annotations: map[string]string{
+				// Mark default and additional networks as ready
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}, {"name":"secondary1"}, {"name":"secondary2"}]`,
+			},
+		},
+	}
+
+	interfaces := []*compute.NetworkInterface{
+		{
+			Name:        "nic0",
+			Network:     "projects/testProject/global/networks/default",
+			Ipv6Address: "2600:1900:4000:fd1::110",
+		},
+		{
+			Name:        "nic1",
+			Network:     "projects/testProject/global/networks/default",
+			Ipv6Address: "2001:db9:1::110",
+		},
+		{
+			Name:        "nic2",
+			Network:     "projects/testProject/global/networks/other-vpc",
+			Ipv6Address: "2001:db9:2::110",
+		},
+	}
+
+	cidrs, err := cloudAllocator.performMultiNetworkCIDRAllocation(node, interfaces, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(cidrs) != 1 || cidrs[0] != "2600:1900:4000:fd1::/112" {
+		t.Errorf("Expected exactly 1 CIDR block string for IPv6 podCIDR [2600:1900:4000:fd1::/112], got: %v", cidrs)
+	}
+}
+
+func TestDefaultNetworkCIDRs_DefaultNetworkNotUp(t *testing.T) {
+	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
+	clientSet := clSetFake.NewSimpleClientset()
+	// Empty informer - no default network added
+	nwInfFactory := networkinformers.NewSharedInformerFactory(clientSet, 0).Networking()
+
+	kubeClient := fake.NewSimpleClientset()
+	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
+
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "missing-network-node",
+			Annotations: map[string]string{
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}]`,
+			},
+		},
+	}
+
+	interfaces := []*compute.NetworkInterface{
+		{
+			Name:      "nic0",
+			Network:   "projects/testProject/global/networks/default",
+			NetworkIP: "10.0.0.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.1.0/24",
+					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+	}
+
+	cidrs, err := cloudAllocator.performMultiNetworkCIDRAllocation(node, interfaces, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that missing default Network CR returns an empty slice safely instead of throwing a panic
+	if len(cidrs) != 0 {
+		t.Errorf("Expected empty CIDR blocks because default network was not in Informer (not up/ready), got: %v", cidrs)
 	}
 }

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
@@ -457,26 +457,26 @@ func TestDefaultNetworkCIDRs_IPv4Only(t *testing.T) {
 	// Default Network
 	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
-	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/default", []string{"test-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
 
 	// Additional non-default network with same VPC but different subnet
 	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
-	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "different-subnet", []string{})
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/secondary-subnet", []string{"sec1-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
 
 	// Additional non-default network with different VPC
 	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
-	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "", []string{})
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet", []string{"sec2-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
 
 	kubeClient := fake.NewSimpleClientset()
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, false, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -491,9 +491,10 @@ func TestDefaultNetworkCIDRs_IPv4Only(t *testing.T) {
 
 	interfaces := []*compute.NetworkInterface{
 		{
-			Name:      "nic0",
-			Network:   "projects/testProject/global/networks/default",
-			NetworkIP: "10.0.0.1",
+			Name:       "nic0",
+			Network:    "projects/testProject/global/networks/default",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/default",
+			NetworkIP:  "10.0.0.1",
 			AliasIpRanges: []*compute.AliasIpRange{
 				{
 					IpCidrRange:         "10.0.1.0/24",
@@ -502,14 +503,28 @@ func TestDefaultNetworkCIDRs_IPv4Only(t *testing.T) {
 			},
 		},
 		{
-			Name:      "nic1",
-			Network:   "projects/testProject/global/networks/default",
-			NetworkIP: "10.0.1.1",
+			Name:       "nic1",
+			Network:    "projects/testProject/global/networks/default",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/secondary-subnet",
+			NetworkIP:  "10.0.2.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.5.0/24",
+					SubnetworkRangeName: "sec1-pod-range",
+				},
+			},
 		},
 		{
-			Name:      "nic2",
-			Network:   "projects/testProject/global/networks/other-vpc",
-			NetworkIP: "10.0.2.1",
+			Name:       "nic2",
+			Network:    "projects/testProject/global/networks/other-vpc",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet",
+			NetworkIP:  "10.0.3.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.4.0/24",
+					SubnetworkRangeName: "sec2-pod-range",
+				},
+			},
 		},
 	}
 
@@ -532,21 +547,32 @@ func TestDefaultNetworkCIDRs_DualStack_NoLabels(t *testing.T) {
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
 
 	// Initialize mock for default network - with IPv4 parameters
-	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/default", []string{"test-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	// Additional networks
+	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/secondary-subnet", []string{"sec1-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
+
+	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet", []string{"sec2-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
 
 	kubeClient := fake.NewSimpleClientset()
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dual-stack-node",
 			Annotations: map[string]string{
-				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}]`,
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}, {"name":"secondary1"}, {"name":"secondary2"}]`,
 			},
 		},
 	}
@@ -556,12 +582,38 @@ func TestDefaultNetworkCIDRs_DualStack_NoLabels(t *testing.T) {
 		{
 			Name:        "nic0",
 			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/default",
 			NetworkIP:   "10.0.0.1",
 			Ipv6Address: "2600:1900:4000:fd1::110",
 			AliasIpRanges: []*compute.AliasIpRange{
 				{
 					IpCidrRange:         "10.0.1.0/24",
 					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+		{
+			Name:        "nic1",
+			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/secondary-subnet",
+			NetworkIP:   "10.0.2.1",
+			Ipv6Address: "2001:db9:1::110",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.5.0/24",
+					SubnetworkRangeName: "sec1-pod-range",
+				},
+			},
+		},
+		{
+			Name:       "nic2",
+			Network:    "projects/testProject/global/networks/other-vpc",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet",
+			NetworkIP:  "10.0.3.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.4.0/24",
+					SubnetworkRangeName: "sec2-pod-range",
 				},
 			},
 		},
@@ -587,21 +639,31 @@ func TestDefaultNetworkCIDRs_DualStack_WithLabels(t *testing.T) {
 	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
 
-	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{"test-pod-range"})
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/default", []string{"test-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
+
+	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/secondary-subnet", []string{"sec1-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
+
+	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
+	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet", []string{"sec2-pod-range"})
+	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
 
 	kubeClient := fake.NewSimpleClientset()
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dual-stack-node-labeled",
 			Annotations: map[string]string{
-				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}]`,
+				networkv1.NodeNetworkAnnotationKey: `[{"name":"default"}, {"name":"secondary1"}, {"name":"secondary2"}]`,
 			},
 		},
 	}
@@ -610,12 +672,38 @@ func TestDefaultNetworkCIDRs_DualStack_WithLabels(t *testing.T) {
 		{
 			Name:        "nic0",
 			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/default",
 			NetworkIP:   "10.0.0.1",
 			Ipv6Address: "2600:1900:4000:fd1::110",
 			AliasIpRanges: []*compute.AliasIpRange{
 				{
 					IpCidrRange:         "10.0.1.0/24",
 					SubnetworkRangeName: "test-pod-range",
+				},
+			},
+		},
+		{
+			Name:        "nic1",
+			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/secondary-subnet",
+			NetworkIP:   "10.0.2.1",
+			Ipv6Address: "2001:db9:1::110",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.5.0/24",
+					SubnetworkRangeName: "sec1-pod-range",
+				},
+			},
+		},
+		{
+			Name:       "nic2",
+			Network:    "projects/testProject/global/networks/other-vpc",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet",
+			NetworkIP:  "10.0.3.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.4.0/24",
+					SubnetworkRangeName: "sec2-pod-range",
 				},
 			},
 		},
@@ -641,26 +729,26 @@ func TestDefaultNetworkCIDRs_IPv6Only(t *testing.T) {
 	// Default Network
 	defaultNetwork := networkAll("default", "default", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(defaultNetwork)
-	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "", []string{})
+	defaultGNP := gkeNetworkParams("default", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/default", []string{})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(defaultGNP)
 
 	// Additional non-default network with same VPC but different subnet
 	secondary1 := networkAll("secondary1", "secondary1-params", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary1)
-	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "different-subnet", []string{})
+	sec1GNP := gkeNetworkParams("secondary1-params", "projects/testProject/global/networks/default", "projects/testProject/regions/us-central1/subnetworks/secondary-subnet", []string{"sec1-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec1GNP)
 
 	// Additional non-default network with different VPC
 	secondary2 := networkAll("secondary2", "secondary2-params", networkv1.L3NetworkType, true)
 	nwInfFactory.V1().Networks().Informer().GetIndexer().Add(secondary2)
-	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "", []string{})
+	sec2GNP := gkeNetworkParams("secondary2-params", "projects/testProject/global/networks/other-vpc", "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet", []string{"sec2-pod-range"})
 	nwInfFactory.V1().GKENetworkParamSets().Informer().GetIndexer().Add(sec2GNP)
 
 	kubeClient := fake.NewSimpleClientset()
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -677,17 +765,33 @@ func TestDefaultNetworkCIDRs_IPv6Only(t *testing.T) {
 		{
 			Name:        "nic0",
 			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/default",
 			Ipv6Address: "2600:1900:4000:fd1::110",
 		},
 		{
 			Name:        "nic1",
 			Network:     "projects/testProject/global/networks/default",
+			Subnetwork:  "projects/testProject/regions/us-central1/subnetworks/secondary-subnet",
+			NetworkIP:   "10.0.1.1",
 			Ipv6Address: "2001:db9:1::110",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.5.0/24",
+					SubnetworkRangeName: "sec1-pod-range",
+				},
+			},
 		},
 		{
-			Name:        "nic2",
-			Network:     "projects/testProject/global/networks/other-vpc",
-			Ipv6Address: "2001:db9:2::110",
+			Name:       "nic2",
+			Network:    "projects/testProject/global/networks/other-vpc",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/other-vpc-subnet",
+			NetworkIP:  "10.0.3.1",
+			AliasIpRanges: []*compute.AliasIpRange{
+				{
+					IpCidrRange:         "10.0.4.0/24",
+					SubnetworkRangeName: "sec2-pod-range",
+				},
+			},
 		},
 	}
 
@@ -711,7 +815,7 @@ func TestDefaultNetworkCIDRs_DefaultNetworkNotUp(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), true, false, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -725,9 +829,10 @@ func TestDefaultNetworkCIDRs_DefaultNetworkNotUp(t *testing.T) {
 
 	interfaces := []*compute.NetworkInterface{
 		{
-			Name:      "nic0",
-			Network:   "projects/testProject/global/networks/default",
-			NetworkIP: "10.0.0.1",
+			Name:       "nic0",
+			Network:    "projects/testProject/global/networks/default",
+			Subnetwork: "projects/testProject/regions/us-central1/subnetworks/default",
+			NetworkIP:  "10.0.0.1",
 			AliasIpRanges: []*compute.AliasIpRange{
 				{
 					IpCidrRange:         "10.0.1.0/24",


### PR DESCRIPTION
Aggregated Changes:
1. ccm: Check for default IPv4 Pod CIDR - this commit updates the `GKENetworkParamSet` controller to check `len(clusterCIDRs) == 0` instead of strictly requiring an IPv4 Pod CIDR. This prevents fatal initialization crashes on IPv6-only clusters

2. ccm: ignore ranges in `populateDesiredDefaultParamSet` - this commit adds support for the default network on strictly IPv6-only clusters by entirely omitting the `PodIPv4Ranges` property 

3. ccm: populate IPv6 ranges in `GKENetworkParamSet.Status.PodCIDRs` - this commit updates the controller to extract and append IPv6 subnet prefixes (`InternalIpv6Prefix`, `ExternalIpv6Prefix`, or legacy `Ipv6CidrRange`) when populating `.Status.PodCIDRs` 

4. ccm: populate `Node.Spec.PodCIDRs` with node IPv6 CIDRs - this commit fixes IPv6 allocation on the default network by extracting the IPv6 address independently of the IPv4 `AliasIpRanges` iteration. This enables `.Spec.PodCIDRs` population on IPv6-only nodes

5. ccm: reject `IPV6_ONLY` subnets for implicitly IPv4 Network CR - this commit updates the network cross-validation logic to explicitly reject secondary network parameters bound to `IPV6_ONLY` subnets