### PR TITLE
[MT-MN] Introduce FilteredNetworkInformer utility for multi-tenancy

### DIFF
--- a/pkg/controller/gketenantcontrollers/utils/filtered_network_informer.go
+++ b/pkg/controller/gketenantcontrollers/utils/filtered_network_informer.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/filtered"
+	networkinformers "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions"
+	network "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network"
+	networkv1 "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
+	networklisters "github.com/GoogleCloudPlatform/gke-networking-api/client/network/listers/network/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// FilteredNetworkSharedInformerFactory wraps the standard network informer factory
+// and applies tenant-specific filtering to Network and GKENetworkParamSet resources.
+type FilteredNetworkSharedInformerFactory struct {
+	networkinformers.SharedInformerFactory
+	filterKey    string
+	filterValue  string
+	allowMissing bool
+
+	mu        sync.Mutex
+	informers map[string]*localFilteredInformer
+}
+
+// NewFilteredNetworkSharedInformerFactory creates a new FilteredNetworkSharedInformerFactory.
+func NewFilteredNetworkSharedInformerFactory(parent networkinformers.SharedInformerFactory, key, value string, allowMissing bool) *FilteredNetworkSharedInformerFactory {
+	return &FilteredNetworkSharedInformerFactory{
+		SharedInformerFactory: parent,
+		filterKey:             key,
+		filterValue:           value,
+		allowMissing:          allowMissing,
+		informers:             make(map[string]*localFilteredInformer),
+	}
+}
+
+// getOrCreateInformer safely fetches a cached informer, or creates it if missing.
+func (f *FilteredNetworkSharedInformerFactory) getOrCreateInformer(informerType string, parent cache.SharedIndexInformer) cache.SharedIndexInformer {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Return the cached informer if it already exists
+	if inf, exists := f.informers[informerType]; exists {
+		return inf
+	}
+
+	// Otherwise create, cache, and return it
+	inf := newLocalFilteredInformer(parent, f.filterKey, f.filterValue, f.allowMissing)
+	f.informers[informerType] = inf
+	return inf
+}
+
+// Cleanup unregisters all event handlers.
+func (f *FilteredNetworkSharedInformerFactory) Cleanup() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, inf := range f.informers {
+		inf.Cleanup()
+	}
+	f.informers = make(map[string]*localFilteredInformer) // Reset the cache
+}
+
+// Networking returns a wrapped Interface.
+func (f *FilteredNetworkSharedInformerFactory) Networking() network.Interface {
+	return &FilteredNetworkWrapper{
+		Interface: f.SharedInformerFactory.Networking(),
+		factory:   f,
+	}
+}
+
+// FilteredNetworkWrapper wraps network.Interface to return filtered versions.
+type FilteredNetworkWrapper struct {
+	network.Interface
+	factory *FilteredNetworkSharedInformerFactory
+}
+
+// V1 returns a wrapped networkv1.Interface.
+func (w *FilteredNetworkWrapper) V1() networkv1.Interface {
+	return &FilteredNetworkV1Wrapper{
+		Interface: w.Interface.V1(),
+		factory:   w.factory,
+	}
+}
+
+// FilteredNetworkV1Wrapper wraps networkv1.Interface to return filtered informers.
+type FilteredNetworkV1Wrapper struct {
+	networkv1.Interface
+	factory *FilteredNetworkSharedInformerFactory
+}
+
+// Networks returns a filtered NetworkInformer.
+func (w *FilteredNetworkV1Wrapper) Networks() networkv1.NetworkInformer {
+	return &FilteredNetworkInformer{
+		NetworkInformer: w.Interface.Networks(),
+		factory:         w.factory,
+	}
+}
+
+// GKENetworkParamSets returns a filtered GKENetworkParamSetInformer.
+func (w *FilteredNetworkV1Wrapper) GKENetworkParamSets() networkv1.GKENetworkParamSetInformer {
+	return &FilteredGKENetworkParamSetInformer{
+		GKENetworkParamSetInformer: w.Interface.GKENetworkParamSets(),
+		factory:                    w.factory,
+	}
+}
+
+// FilteredNetworkInformer wraps networkv1.NetworkInformer.
+type FilteredNetworkInformer struct {
+	networkv1.NetworkInformer
+	factory *FilteredNetworkSharedInformerFactory
+}
+
+// Informer returns the filtered index informer.
+func (i *FilteredNetworkInformer) Informer() cache.SharedIndexInformer {
+	return i.factory.getOrCreateInformer("networks", i.NetworkInformer.Informer())
+}
+
+// Lister returns the filtered lister.
+func (i *FilteredNetworkInformer) Lister() networklisters.NetworkLister {
+	return networklisters.NewNetworkLister(i.Informer().GetIndexer())
+}
+
+// FilteredGKENetworkParamSetInformer wraps networkv1.GKENetworkParamSetInformer.
+type FilteredGKENetworkParamSetInformer struct {
+	networkv1.GKENetworkParamSetInformer
+	factory *FilteredNetworkSharedInformerFactory
+}
+
+// Informer returns the filtered index informer.
+func (i *FilteredGKENetworkParamSetInformer) Informer() cache.SharedIndexInformer {
+	return i.factory.getOrCreateInformer("gkenetworkparamsets", i.GKENetworkParamSetInformer.Informer())
+}
+
+// Lister returns the filtered lister.
+func (i *FilteredGKENetworkParamSetInformer) Lister() networklisters.GKENetworkParamSetLister {
+	return networklisters.NewGKENetworkParamSetLister(i.Informer().GetIndexer())
+}
+
+// localFilteredInformer implements cache.SharedIndexInformer with custom filtering.
+type localFilteredInformer struct {
+	cache.SharedIndexInformer
+	filterKey    string
+	filterValue  string
+	allowMissing bool
+
+	mu            sync.Mutex
+	registrations []cache.ResourceEventHandlerRegistration
+}
+
+func newLocalFilteredInformer(parent cache.SharedIndexInformer, key, value string, allowMissing bool) *localFilteredInformer {
+	return &localFilteredInformer{
+		SharedIndexInformer: parent,
+		filterKey:           key,
+		filterValue:         value,
+		allowMissing:        allowMissing,
+	}
+}
+
+func (f *localFilteredInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	reg, err := f.SharedIndexInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: f.FilterFunc,
+		Handler:    handler,
+	})
+	if err == nil {
+		f.mu.Lock()
+		f.registrations = append(f.registrations, reg)
+		f.mu.Unlock()
+	}
+	return reg, err
+}
+
+func (f *localFilteredInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
+	reg, err := f.SharedIndexInformer.AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{
+		FilterFunc: f.FilterFunc,
+		Handler:    handler,
+	}, resyncPeriod)
+	if err == nil {
+		f.mu.Lock()
+		f.registrations = append(f.registrations, reg)
+		f.mu.Unlock()
+	}
+	return reg, err
+}
+
+func (f *localFilteredInformer) Cleanup() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, reg := range f.registrations {
+		_ = f.SharedIndexInformer.RemoveEventHandler(reg)
+	}
+	f.registrations = nil
+}
+
+func (f *localFilteredInformer) FilterFunc(obj interface{}) bool {
+	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = deletedState.Obj
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		klog.Errorf("FilterFunc: failed to get meta accessor for object %v: %v", obj, err)
+		return false
+	}
+	val, ok := accessor.GetLabels()[f.filterKey]
+	return filtered.MatchValue(val, ok, f.filterValue, f.allowMissing)
+}
+
+func (f *localFilteredInformer) GetStore() cache.Store {
+	return &localFilteredCache{
+		Indexer:      f.SharedIndexInformer.GetIndexer(),
+		filterKey:    f.filterKey,
+		filterValue:  f.filterValue,
+		allowMissing: f.allowMissing,
+	}
+}
+
+func (f *localFilteredInformer) GetIndexer() cache.Indexer {
+	return &localFilteredCache{
+		Indexer:      f.SharedIndexInformer.GetIndexer(),
+		filterKey:    f.filterKey,
+		filterValue:  f.filterValue,
+		allowMissing: f.allowMissing,
+	}
+}
+
+// localFilteredCache wraps standard Indexer to filter lists/gets for the tenant.
+type localFilteredCache struct {
+	cache.Indexer
+	filterKey    string
+	filterValue  string
+	allowMissing bool
+}
+
+func (obj *localFilteredCache) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	items, err := obj.Indexer.ByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	return getFilteredListByValue(items, obj.filterKey, obj.filterValue, obj.allowMissing), nil
+}
+
+func (obj *localFilteredCache) Index(indexName string, item interface{}) ([]interface{}, error) {
+	items, err := obj.Indexer.Index(indexName, item)
+	if err != nil {
+		return nil, err
+	}
+	return getFilteredListByValue(items, obj.filterKey, obj.filterValue, obj.allowMissing), nil
+}
+
+func (obj *localFilteredCache) List() []interface{} {
+	return getFilteredListByValue(obj.Indexer.List(), obj.filterKey, obj.filterValue, obj.allowMissing)
+}
+
+func (obj *localFilteredCache) ListKeys() []string {
+	items := obj.List()
+	var keys []string
+	for _, item := range items {
+		if key, err := cache.MetaNamespaceKeyFunc(item); err == nil {
+			keys = append(keys, key)
+		} else {
+			klog.Errorf("ListKeys: failed to get key for item %v: %v", item, err)
+		}
+	}
+	return keys
+}
+
+func (obj *localFilteredCache) Get(item interface{}) (interface{}, bool, error) {
+	key, err := cache.MetaNamespaceKeyFunc(item)
+	if err != nil {
+		klog.Errorf("Get: failed to get key for item %v: %v", item, err)
+		return nil, false, err
+	}
+	return obj.GetByKey(key)
+}
+
+func (obj *localFilteredCache) GetByKey(key string) (item interface{}, exists bool, err error) {
+	item, exists, err = obj.Indexer.GetByKey(key)
+	if !exists || err != nil {
+		return nil, exists, err
+	}
+	if isObjectMatchingValue(item, obj.filterKey, obj.filterValue, obj.allowMissing) {
+		return item, true, nil
+	}
+	return nil, false, nil
+}
+
+func isObjectMatchingValue(obj interface{}, filterKey, filterValue string, allowMissing bool) bool {
+	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = deletedState.Obj
+	}
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		klog.Errorf("isObjectMatchingValue: failed to get meta accessor for object %v: %v", obj, err)
+		return false
+	}
+	val, ok := metaObj.GetLabels()[filterKey]
+	return filtered.MatchValue(val, ok, filterValue, allowMissing)
+}
+
+func getFilteredListByValue(items []interface{}, filterKey, filterValue string, allowMissing bool) []interface{} {
+	var filteredItems []interface{}
+	for _, item := range items {
+		if isObjectMatchingValue(item, filterKey, filterValue, allowMissing) {
+			filteredItems = append(filteredItems, item)
+		}
+	}
+	return filteredItems
+}
+
+func (obj *localFilteredCache) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	keys, err := obj.Indexer.IndexKeys(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	var filteredKeys []string
+	for _, key := range keys {
+		item, exists, err := obj.Indexer.GetByKey(key)
+		if err != nil || !exists {
+			continue
+		}
+		if isObjectMatchingValue(item, obj.filterKey, obj.filterValue, obj.allowMissing) {
+			filteredKeys = append(filteredKeys, key)
+		}
+	}
+	return filteredKeys, nil
+}
+
+func (obj *localFilteredCache) ListIndexFuncValues(indexName string) []string {
+	indexers := obj.GetIndexers()
+	indexFunc, ok := indexers[indexName]
+	if !ok {
+		return nil
+	}
+	values := make(map[string]struct{})
+	for _, item := range obj.List() {
+		if vals, err := indexFunc(item); err == nil {
+			for _, v := range vals {
+				values[v] = struct{}{}
+			}
+		}
+	}
+	var res []string
+	for v := range values {
+		res = append(res, v)
+	}
+	return res
+}
+
+func (obj *localFilteredCache) Add(item interface{}) error {
+	return fmt.Errorf("read-only filtered cache")
+}
+
+func (obj *localFilteredCache) Update(item interface{}) error {
+	return fmt.Errorf("read-only filtered cache")
+}
+
+func (obj *localFilteredCache) Delete(item interface{}) error {
+	return fmt.Errorf("read-only filtered cache")
+}
+
+func (obj *localFilteredCache) Replace(list []interface{}, resourceVersion string) error {
+	return fmt.Errorf("read-only filtered cache")
+}
+
+func (obj *localFilteredCache) Resync() error {
+	return fmt.Errorf("read-only filtered cache")
+}

--- a/pkg/controller/gketenantcontrollers/utils/filtered_network_informer_test.go
+++ b/pkg/controller/gketenantcontrollers/utils/filtered_network_informer_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+*/
+
+package utils
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	apinetworkv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/network/v1"
+	networkfake "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned/fake"
+	networkinformers "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestFilteredNetworkSharedInformerFactory_TenantIsolation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 1. Create fake network clientset and parent factory
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+
+	// 2. Wrap it with FilteredNetworkSharedInformerFactory for tenant-A
+	labelKey := "tenancy.gke.io/provider-config"
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, labelKey, "tenant-A", false)
+
+	// 3. Create Networks and GNPs for tenant-A and tenant-B
+	netA := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "net-a",
+			Labels: map[string]string{
+				labelKey: "tenant-A",
+			},
+		},
+	}
+	gnpA := &apinetworkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gnp-a",
+			Labels: map[string]string{
+				labelKey: "tenant-A",
+			},
+		},
+	}
+
+	netB := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "net-b",
+			Labels: map[string]string{
+				labelKey: "tenant-B",
+			},
+		},
+	}
+	gnpB := &apinetworkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gnp-b",
+			Labels: map[string]string{
+				labelKey: "tenant-B",
+			},
+		},
+	}
+
+	_, err := fakeNetworking.NetworkingV1().Networks().Create(ctx, netA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeNetworking.NetworkingV1().Networks().Create(ctx, netB, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeNetworking.NetworkingV1().GKENetworkParamSets().Create(ctx, gnpA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeNetworking.NetworkingV1().GKENetworkParamSets().Create(ctx, gnpB, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Start parent informer factory
+	// Create informers/listers from filtered factory
+	netInformer := filteredFactory.Networking().V1().Networks()
+	gnpInformer := filteredFactory.Networking().V1().GKENetworkParamSets()
+
+	// Retrieve list and check to trigger Informer() creation/registration
+	_ = netInformer.Informer()
+	_ = gnpInformer.Informer()
+
+	// Start parent informer factory
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	parentFactory.Start(stopCh)
+
+	// Wait for cache sync
+	parentFactory.WaitForCacheSync(stopCh)
+
+	// Verify tenant-A gets its own resources
+	netLister := netInformer.Lister()
+	gnpLister := gnpInformer.Lister()
+
+	// Retrieve list and check
+	nets, err := netLister.List(labels.Everything())
+	assert.NoError(t, err)
+	assert.Len(t, nets, 1)
+	assert.Equal(t, "net-a", nets[0].Name)
+
+	gnps, err := gnpLister.List(labels.Everything())
+	assert.NoError(t, err)
+	assert.Len(t, gnps, 1)
+	assert.Equal(t, "gnp-a", gnps[0].Name)
+
+	// Verify Get works for own tenant
+	gotNet, err := netLister.Get("net-a")
+	assert.NoError(t, err)
+	assert.NotNil(t, gotNet)
+
+	gotGNP, err := gnpLister.Get("gnp-a")
+	assert.NoError(t, err)
+	assert.NotNil(t, gotGNP)
+
+	// Verify Get fails (or returns not found/nil) for cross-tenant
+	gotNetB, err := netLister.Get("net-b")
+	assert.Error(t, err) // Should error or return not found since it is filtered out
+	assert.Nil(t, gotNetB)
+
+	gotGNPB, err := gnpLister.Get("gnp-b")
+	assert.Error(t, err)
+	assert.Nil(t, gotGNPB)
+}
+
+func TestFilteredNetworkSharedInformerFactory_SupervisorAccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+
+	labelKey := "tenancy.gke.io/provider-config"
+	// supervisor has allowMissing = true, filterValue = "supervisor"
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, labelKey, "supervisor", true)
+
+	// Resources:
+	// 1. Labeled supervisor
+	netSup := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "net-sup",
+			Labels: map[string]string{
+				labelKey: "supervisor",
+			},
+		},
+	}
+	// 2. Labeled tenant-A
+	netTenant := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "net-tenant-a",
+			Labels: map[string]string{
+				labelKey: "tenant-A",
+			},
+		},
+	}
+	// 3. No label (missing label)
+	netMissing := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "net-missing-label",
+			Labels: map[string]string{},
+		},
+	}
+
+	_, err := fakeNetworking.NetworkingV1().Networks().Create(ctx, netSup, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeNetworking.NetworkingV1().Networks().Create(ctx, netTenant, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = fakeNetworking.NetworkingV1().Networks().Create(ctx, netMissing, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	netInformer := filteredFactory.Networking().V1().Networks()
+	_ = netInformer.Informer()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	parentFactory.Start(stopCh)
+	parentFactory.WaitForCacheSync(stopCh)
+
+	netLister := netInformer.Lister()
+
+	nets, err := netLister.List(labels.Everything())
+	assert.NoError(t, err)
+
+	// Should contain net-sup and net-missing-label (since allowMissing: true)
+	// net-tenant-a should be filtered out
+	assert.Len(t, nets, 2)
+	names := []string{nets[0].Name, nets[1].Name}
+	assert.Contains(t, names, "net-sup")
+	assert.Contains(t, names, "net-missing-label")
+	assert.NotContains(t, names, "net-tenant-a")
+}
+
+func TestFilteredNetworkSharedInformerFactory_CacheImmutability(t *testing.T) {
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, "key", "val", false)
+
+	inf := filteredFactory.Networking().V1().Networks().Informer()
+	cacheStore := inf.GetStore()
+
+	assert.ErrorContains(t, cacheStore.Add(&apinetworkv1.Network{}), "read-only filtered cache")
+	assert.ErrorContains(t, cacheStore.Update(&apinetworkv1.Network{}), "read-only filtered cache")
+	assert.ErrorContains(t, cacheStore.Delete(&apinetworkv1.Network{}), "read-only filtered cache")
+	assert.ErrorContains(t, cacheStore.Replace(nil, ""), "read-only filtered cache")
+	assert.ErrorContains(t, cacheStore.Resync(), "read-only filtered cache")
+}
+
+func TestFilteredNetworkSharedInformerFactory_Indexing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+	parentFactory.Networking().V1().Networks().Informer().AddIndexers(cache.Indexers{
+		"test-index": func(obj interface{}) ([]string, error) {
+			net := obj.(*apinetworkv1.Network)
+			return []string{string(net.Spec.Type)}, nil
+		},
+	})
+
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, "tenant", "A", false)
+
+	netA := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-a", Labels: map[string]string{"tenant": "A"}},
+		Spec:       apinetworkv1.NetworkSpec{Type: "L3"},
+	}
+	fakeNetworking.NetworkingV1().Networks().Create(ctx, netA, metav1.CreateOptions{})
+	netB := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-b", Labels: map[string]string{"tenant": "B"}},
+		Spec:       apinetworkv1.NetworkSpec{Type: "L3"},
+	}
+	fakeNetworking.NetworkingV1().Networks().Create(ctx, netB, metav1.CreateOptions{})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	parentFactory.Start(stopCh)
+	parentFactory.WaitForCacheSync(stopCh)
+
+	inf := filteredFactory.Networking().V1().Networks().Informer()
+	indexer := inf.GetIndexer()
+
+	keys, err := indexer.IndexKeys("test-index", "L3")
+	assert.NoError(t, err)
+	assert.Len(t, keys, 1)
+	assert.Contains(t, keys, "net-a")
+
+	vals := indexer.ListIndexFuncValues("test-index")
+	assert.Contains(t, vals, "L3")
+}
+
+func TestFilteredNetworkSharedInformerFactory_DeletedFinalStateUnknown(t *testing.T) {
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, "tenant", "A", false)
+
+	inf := filteredFactory.Networking().V1().Networks().Informer()
+	// Using reflection or type assertion if possible, but since it's an interface, we can test FilterFunc directly
+	// Actually we can't access localFilteredInformer since it's private, we have to check its behavior.
+	// However, they are in the same package `utils`.
+	localInf, ok := inf.(*localFilteredInformer)
+	assert.True(t, ok)
+
+	validObj := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-a", Labels: map[string]string{"tenant": "A"}},
+	}
+	invalidObj := &apinetworkv1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-b", Labels: map[string]string{"tenant": "B"}},
+	}
+
+	assert.True(t, localInf.FilterFunc(validObj))
+	assert.False(t, localInf.FilterFunc(invalidObj))
+
+	unknownValid := cache.DeletedFinalStateUnknown{Key: "net-a", Obj: validObj}
+	unknownInvalid := cache.DeletedFinalStateUnknown{Key: "net-b", Obj: invalidObj}
+
+	assert.True(t, localInf.FilterFunc(unknownValid))
+	assert.False(t, localInf.FilterFunc(unknownInvalid))
+}
+
+func TestFilteredNetworkSharedInformerFactory_SingletonAndConcurrency(t *testing.T) {
+	fakeNetworking := networkfake.NewSimpleClientset()
+	parentFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+	filteredFactory := NewFilteredNetworkSharedInformerFactory(parentFactory, "tenant", "A", false)
+
+	netInformer := filteredFactory.Networking().V1().Networks()
+
+	inf1 := netInformer.Informer()
+	inf2 := netInformer.Informer()
+	assert.Same(t, inf1, inf2)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			inf1.AddEventHandler(cache.ResourceEventHandlerFuncs{})
+		}()
+	}
+	wg.Wait()
+
+	filteredFactory.Cleanup()
+}


### PR DESCRIPTION
[MT-MN] Introduce FilteredNetworkInformer utility for multi-tenancy
---
Context: GKE Multi-Tenant Multi-Networking (MT-MN) Integration
This change is part of the broader effort to support Multi-Networking
within GKE Multi-Tenant (MT) clusters.
---
Specific change details:
* **Introduces `FilteredNetworkSharedInformerFactory`**: A wrapper around `networkinformers.SharedInformerFactory` that provides tenant-isolated views of `Network` and `GKENetworkParamSet` resources based on a specified label (`filterKey` and `filterValue`).
* **Implements Event Filtering (`localFilteredInformer`)**: Wraps `cache.SharedIndexInformer` to automatically apply `cache.FilteringResourceEventHandler` to any registered event handlers, ensuring controllers only react to events for their assigned tenant.
* **Implements Cache Lookup Filtering (`localFilteredCache`)**: Wraps the standard `cache.Indexer` to intercept and filter read operations (`List`, `Get`, `ByIndex`, etc.) on the fly, scrubbing cross-tenant data from the results.
* **Enforces Cache Immutability**: Explicitly blocks mutative cache operations (`Add`, `Update`, `Delete`, `Replace`) on the `localFilteredCache` by returning "read-only filtered cache" errors, protecting the shared underlying cache from unintended modifications.
* **Adds Comprehensive Unit Tests**: Includes tests in `filtered_network_informer_test.go` covering tenant isolation, supervisor access (handling missing labels), cache immutability, indexer support, and concurrency.
