### PR TITLE
[MT-MN] Refactor Node IPAM Controller for Multi-Tenant Multi-Networking (MT-MN) 

### DIFF
--- a/cmd/cloud-controller-manager/gketenantcontrollermanager.go
+++ b/cmd/cloud-controller-manager/gketenantcontrollermanager.go
@@ -132,8 +132,10 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 			// overwriting the global "default" NodeTopology CR with tenant-specific subnets.
 			// We only enable this feature if the current controller belongs to the supervisor.
 			tenantNodeIPAMConfig := mgrCfg.nodeIPAMConfig
+			defaultNetworkName := ""
 			if !utils.IsSupervisor(cfg.ProviderConfig) {
-				tenantNodeIPAMConfig.EnableMultiSubnetCluster = false
+				defaultNetworkName = cfg.ProviderConfig.Name + "-default"
+				klog.Infof("Node IPAM Controller for %s using default network name %s", cfg.ProviderConfig.Name, defaultNetworkName)
 			}
 
 			// Wrap the informer to filter nodes
@@ -160,6 +162,7 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 				nodeTopologyClient,
 				ipam.CIDRAllocatorType(mgrCfg.completedConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType),
 				cfg.ControllerContext.ControllerManagerMetrics,
+				defaultNetworkName,
 			)
 			if err != nil {
 				return err

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -89,6 +89,7 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 		nodeTopologyClient,
 		ipam.CIDRAllocatorType(ccmConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType),
 		ctx.ControllerManagerMetrics,
+		"",
 	)
 
 	if err != nil {

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -112,6 +112,8 @@ type CIDRAllocatorParams struct {
 	SecondaryServiceCIDR *net.IPNet
 	// NodeCIDRMaskSizes is list of node cidr mask sizes
 	NodeCIDRMaskSizes []int
+	// DefaultNetworkName is the name of the default network for the tenant/cluster
+	DefaultNetworkName string
 }
 
 // New creates a new CIDR range allocator.

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -104,9 +104,9 @@ type cloudCIDRAllocator struct {
 	queue             workqueue.RateLimitingInterface
 	nodeTopologyQueue *TaskQueue
 
-	stackType clusterStackType
-
+	stackType             clusterStackType
 	enableMultiNetworking bool
+	defaultNetworkName    string
 }
 
 var _ CIDRAllocator = (*cloudCIDRAllocator)(nil)
@@ -163,6 +163,7 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 		),
 		stackType:             stackType,
 		enableMultiNetworking: enableMultiNetworking,
+		defaultNetworkName:    allocatorParams.DefaultNetworkName,
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -666,4 +667,14 @@ func nodeMultiNetworkChanged(oldNode *v1.Node, newNode *v1.Node) bool {
 		return true
 	}
 	return false
+}
+
+// isDefaultNetwork checks if the network name corresponds to the default network for this allocator.
+// Under GKE Multi-Tenancy, the condition ca.defaultNetworkName != "" is a perfect proxy
+// for identifying whether the controller is executing within a tenant context.
+func (ca *cloudCIDRAllocator) isDefaultNetwork(name string) bool {
+	if ca.defaultNetworkName != "" {
+		return name == ca.defaultNetworkName
+	}
+	return networkv1.IsDefaultNetwork(name)
 }

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator.go
@@ -44,7 +44,7 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 	// we do not filter Networks with DeletionTimestamp set, because we
 	// count on the Network "delete event" for cleanup
 	for _, network := range k8sNetworksList {
-		if meta.IsStatusConditionTrue(network.Status.Conditions, string(networkv1.NetworkConditionStatusReady)) || networkv1.IsDefaultNetwork(network.Name) {
+		if meta.IsStatusConditionTrue(network.Status.Conditions, string(networkv1.NetworkConditionStatusReady)) || ca.isDefaultNetwork(network.Name) {
 			networks = append(networks, network)
 		}
 	}
@@ -127,14 +127,15 @@ func (ca *cloudCIDRAllocator) performMultiNetworkCIDRAllocation(node *v1.Node, i
 				processedNetworks[network.Name] = struct{}{}
 				// for defaultNwCIDRs, if there're no NodeLabels keep this,
 				// otherwise get the CIDR with labels
-				if networkv1.IsDefaultNetwork(network.Name) && !hasNodeLabels {
+				if ca.isDefaultNetwork(network.Name) && !hasNodeLabels {
+					klog.V(2).Infof("Default network %s found for node %s with CIDR %s", network.Name, node.Name, ipRange.IpCidrRange)
 					defaultNwCIDRs = append(defaultNwCIDRs, ipRange.IpCidrRange)
 					ipv6Addr := ca.cloud.GetIPV6Address(inf)
 					if ipv6Addr != nil {
 						defaultNwCIDRs = append(defaultNwCIDRs, ipv6Addr.String())
 					}
 				}
-				if !networkv1.IsDefaultNetwork(network.Name) {
+				if !ca.isDefaultNetwork(network.Name) {
 					northInterfaces = append(northInterfaces, networkv1.NorthInterface{Network: network.Name, IpAddress: inf.NetworkIP})
 					if _, ok := upStatusNetworks[network.Name]; ok {
 						additionalNodeNetworks = append(additionalNodeNetworks, networkv1.NodeNetwork{Name: network.Name, Scope: "host-local", Cidrs: []string{ipRange.IpCidrRange}})

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -90,7 +90,8 @@ func NewNodeIpamController(
 	serviceCIDR *net.IPNet,
 	secondaryServiceCIDR *net.IPNet,
 	nodeCIDRMaskSizes []int,
-	allocatorType ipam.CIDRAllocatorType) (*Controller, error) {
+	allocatorType ipam.CIDRAllocatorType,
+	defaultNetworkName string) (*Controller, error) {
 
 	if kubeClient == nil {
 		klog.Fatalf("kubeClient is nil when starting Controller")
@@ -140,6 +141,7 @@ func NewNodeIpamController(
 			ServiceCIDR:          ic.serviceCIDR,
 			SecondaryServiceCIDR: ic.secondaryServiceCIDR,
 			NodeCIDRMaskSizes:    nodeCIDRMaskSizes,
+			DefaultNetworkName:   defaultNetworkName,
 		}
 
 		ic.cidrAllocator, err = ipam.New(kubeClient, cloud, nodeInformer, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, enableMultiNetworking, ic.allocatorType, allocatorParams)

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -63,7 +63,7 @@ func newTestNodeIpamController(clusterCIDR []*net.IPNet, serviceCIDR *net.IPNet,
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	return NewNodeIpamController(
 		fakeNodeInformer, fakeGCE, clientSet, fakeNwInformer, fakeGNPInformer, nodeTopologyFakeClient,
-		true, false, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType,
+		true, false, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType, "",
 	)
 }
 

--- a/pkg/controller/nodeipam/starter.go
+++ b/pkg/controller/nodeipam/starter.go
@@ -45,6 +45,7 @@ func StartNodeIpamController(
 	nodeTopologyClient nodetopologyclientset.Interface,
 	cidrAllocatorType ipam.CIDRAllocatorType,
 	controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics,
+	defaultNetworkName string,
 ) (controller.Interface, bool, error) {
 	var serviceCIDR *net.IPNet
 	var secondaryServiceCIDR *net.IPNet
@@ -120,6 +121,7 @@ func StartNodeIpamController(
 		secondaryServiceCIDR,
 		nodeCIDRMaskSizes,
 		cidrAllocatorType,
+		defaultNetworkName,
 	)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
[MT-MN] Refactor Node IPAM Controller 
---
Context: GKE Multi-Tenant Multi-Networking (MT-MN) Integration
This change is part of the broader effort to support Multi-Networking
within GKE Multi-Tenant (MT) clusters.
---
**Specific change details:**
* **Introduced `defaultNetworkName` parameter**: Added a `defaultNetworkName` string to `CIDRAllocatorParams` and the controller initialization chain (`StartNodeIpamController`, `NewNodeIpamController`, etc.). 
* **Tenant-aware network resolution**: Added a new `isDefaultNetwork` receiver method to `cloudCIDRAllocator`. If `defaultNetworkName` is set (indicating the controller is executing within a tenant context), the controller will match against it. If it is empty, it safely falls back to the legacy `networkv1.IsDefaultNetwork(name)` behavior.
* **Updated Multi-Network CIDR Allocation**: Replaced hardcoded calls to `networkv1.IsDefaultNetwork` with the new instance-aware `ca.isDefaultNetwork(network.Name)` check in `multinetwork_cloud_cidr_allocator.go` to ensure network filtering and CIDR appending behaves correctly in a tenant context.
* **Updated Callers & Tests**: Updated `cmd/cloud-controller-manager/nodeipamcontroller.go` and test initializations to pass an empty string `""` by default, preserving existing behavior for non-tenant setups.




