### PR TITLE
gce: dynamically refresh managed zones on resource cache miss and periodic sync

### DIFF
--- a/providers/gce/gce.go
+++ b/providers/gce/gce.go
@@ -46,6 +46,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -824,6 +825,9 @@ func (g *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 
 	go g.watchClusterID(stop)
 	go g.metricsCollector.Run(stop)
+	if g.dynamicZones {
+		go g.syncManagedZonesPeriodically(stop)
+	}
 }
 
 // LoadBalancer returns an implementation of LoadBalancer for Google Compute Engine.
@@ -1170,4 +1174,12 @@ func (g *Cloud) refreshManagedZones() error {
 	}
 
 	return nil
+}
+
+func (g *Cloud) syncManagedZonesPeriodically(stop <-chan struct{}) {
+	wait.Until(func() {
+		if err := g.refreshManagedZones(); err != nil {
+			klog.Errorf("Periodic refresh of GCE managed zones failed: %v", err)
+		}
+	}, 5*time.Minute, stop)
 }

--- a/providers/gce/gce_disks.go
+++ b/providers/gce/gce_disks.go
@@ -929,6 +929,34 @@ func (g *Cloud) getRegionalDiskByName(diskName string) (*Disk, error) {
 	return disk, err
 }
 
+func (g *Cloud) findDiskInZones(diskName string, zones []string) (*Disk, error) {
+	var found *Disk
+	for _, zone := range zones {
+		disk, err := g.findDiskByName(diskName, zone)
+		if err != nil {
+			return nil, err
+		}
+		if disk == nil {
+			continue
+		}
+		if found != nil {
+			switch zoneInfo := disk.ZoneInfo.(type) {
+			case multiZone:
+				if zoneInfo.replicaZones.Has(zone) {
+					klog.Warningf("GCE PD name (%q) was found in multiple zones (%q), but ok because it is a RegionalDisk.",
+						diskName, zoneInfo.replicaZones)
+					continue
+				}
+				return nil, fmt.Errorf("GCE PD name was found in multiple zones: %q", diskName)
+			default:
+				return nil, fmt.Errorf("GCE PD name was found in multiple zones: %q", diskName)
+			}
+		}
+		found = disk
+	}
+	return found, nil
+}
+
 // GetDiskByNameUnknownZone scans all managed zones to return the GCE PD
 // Prefer getDiskByName, if the zone can be established
 // Return cloudprovider.DiskNotFound if the given disk cannot be found in any zone
@@ -948,35 +976,33 @@ func (g *Cloud) GetDiskByNameUnknownZone(diskName string) (*Disk, error) {
 	// admission control, but that might be a little weird (values changing
 	// on create)
 
-	var found *Disk
-	for _, zone := range g.getManagedZones() {
-		disk, err := g.findDiskByName(diskName, zone)
-		if err != nil {
-			return nil, err
-		}
-		// findDiskByName returns (nil,nil) if the disk doesn't exist, so we can't
-		// assume that a disk was found unless disk is non-nil.
-		if disk == nil {
-			continue
-		}
-		if found != nil {
-			switch zoneInfo := disk.ZoneInfo.(type) {
-			case multiZone:
-				if zoneInfo.replicaZones.Has(zone) {
-					klog.Warningf("GCE PD name (%q) was found in multiple zones (%q), but ok because it is a RegionalDisk.",
-						diskName, zoneInfo.replicaZones)
-					continue
-				}
-				return nil, fmt.Errorf("GCE PD name was found in multiple zones: %q", diskName)
-			default:
-				return nil, fmt.Errorf("GCE PD name was found in multiple zones: %q", diskName)
-			}
-		}
-		found = disk
+	initialZones := g.getManagedZones()
+	found, err := g.findDiskInZones(diskName, initialZones)
+	if err != nil {
+		return nil, err
 	}
 	if found != nil {
 		return found, nil
 	}
+
+	if g.dynamicZones {
+		if err := g.refreshManagedZones(); err != nil {
+			klog.Errorf("Failed to refresh GCE managed zones for disk %s: %v", diskName, err)
+		} else {
+			refreshedZones := g.getManagedZones()
+			newZones := sets.NewString(refreshedZones...).Difference(sets.NewString(initialZones...)).List()
+			if len(newZones) > 0 {
+				found, err := g.findDiskInZones(diskName, newZones)
+				if err != nil {
+					return nil, err
+				}
+				if found != nil {
+					return found, nil
+				}
+			}
+		}
+	}
+
 	klog.Warningf("GCE persistent disk %q not found in managed zones (%s)",
 		diskName, strings.Join(g.getManagedZones(), ","))
 

--- a/providers/gce/gce_disks_test.go
+++ b/providers/gce/gce_disks_test.go
@@ -21,10 +21,12 @@ package gce
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
-	"fmt"
-
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
+	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
@@ -32,7 +34,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	cloudprovider "k8s.io/cloud-provider"
 )
 
 // TODO TODO write a test for GetDiskByNameUnknownZone and make sure casting logic works
@@ -916,7 +917,7 @@ func (manager *FakeServiceManager) GetDiskFromCloudProvider(
 	zone string, diskName string) (*Disk, error) {
 
 	if manager.zonalDisks[zone] == "" {
-		return nil, cloudprovider.DiskNotFound
+		return nil, &googleapi.Error{Code: http.StatusNotFound}
 	}
 
 	if manager.resourceInUse {
@@ -941,7 +942,7 @@ func (manager *FakeServiceManager) GetRegionalDiskFromCloudProvider(
 	diskName string) (*Disk, error) {
 
 	if _, ok := manager.regionalDisks[diskName]; !ok {
-		return nil, cloudprovider.DiskNotFound
+		return nil, &googleapi.Error{Code: http.StatusNotFound}
 	}
 
 	if manager.resourceInUse {
@@ -1018,4 +1019,43 @@ func createNodeZones(zones []string) map[string]sets.String {
 		nodeZones[zone] = sets.NewString("dummynode")
 	}
 	return nodeZones
+}
+
+func TestGetDiskByNameUnknownZone_DynamicRefresh(t *testing.T) {
+	gceProjectID := "test-project"
+	gceRegion := "us-central1"
+	fakeManager := newFakeManager(gceProjectID, gceRegion)
+	fakeManager.zonalDisks["us-central1-c"] = "my-disk"
+
+	gce := Cloud{
+		manager:      fakeManager,
+		managedZones: []string{"us-central1-b"},
+		projectID:    gceProjectID,
+		region:       gceRegion,
+		dynamicZones: true,
+	}
+
+	mockGCE := cloud.NewMockGCE(&gceProjectRouter{&gce})
+	keyC := meta.GlobalKey("key-c")
+	mockGCE.MockZones.Objects[*keyC] = &cloud.MockZonesObj{
+		Obj: &compute.Zone{Name: "us-central1-c", Region: gce.getRegionLink("us-central1")},
+	}
+	keyB := meta.GlobalKey("key-b")
+	mockGCE.MockZones.Objects[*keyB] = &cloud.MockZonesObj{
+		Obj: &compute.Zone{Name: "us-central1-b", Region: gce.getRegionLink("us-central1")},
+	}
+	gce.c = mockGCE
+
+	disk, err := gce.GetDiskByNameUnknownZone("my-disk")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if disk == nil || disk.Name != "my-disk" {
+		t.Fatalf("expected disk my-disk, got %v", disk)
+	}
+
+	expectedZones := []string{"us-central1-b", "us-central1-c"}
+	if !sets.NewString(gce.getManagedZones()...).Equal(sets.NewString(expectedZones...)) {
+		t.Fatalf("expected managed zones %v, got %v", expectedZones, gce.getManagedZones())
+	}
 }

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -72,11 +72,17 @@ func getZone(node *v1.Node) string {
 		return zone
 	}
 	zone, ok = node.Labels[v1.LabelFailureDomainBetaZone]
-	if !ok {
-		klog.Warningf("Node without zone label, returning %q as zone. Node name: %v, node labels: %v", emptyZone, node.Name, node.Labels)
-		return emptyZone
+	if ok {
+		return zone
 	}
-	return zone
+	if node.Spec.ProviderID != "" {
+		_, zone, _, err := splitProviderID(node.Spec.ProviderID)
+		if err == nil && zone != "" {
+			return zone
+		}
+	}
+	klog.Warningf("Node without zone label or providerID, returning %q as zone. Node name: %v, node labels: %v", emptyZone, node.Name, node.Labels)
+	return emptyZone
 }
 
 func makeHostURL(projectsAPIEndpoint, projectID, zone, host string) string {
@@ -715,7 +721,8 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 		found[name] = nil
 	}
 
-	for _, zone := range g.getManagedZones() {
+	initialZones := g.getManagedZones()
+	for _, zone := range initialZones {
 		if remaining == 0 {
 			break
 		}
@@ -745,6 +752,47 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 		}
 	}
 
+	if remaining > 0 && g.dynamicZones {
+		if err := g.refreshManagedZones(); err != nil {
+			klog.Errorf("Failed to refresh GCE managed zones for remaining instances: %v", err)
+		} else {
+			refreshedZones := g.getManagedZones()
+			checkedZones := sets.NewString(initialZones...)
+			for _, zone := range refreshedZones {
+				if remaining == 0 {
+					break
+				}
+				if checkedZones.Has(zone) {
+					continue
+				}
+				instances, err := g.c.Instances().List(ctx, zone, filter.Regexp("name", nodeInstancePrefix+".*"))
+				if err != nil {
+					return nil, err
+				}
+				for _, inst := range instances {
+					if remaining == 0 {
+						break
+					}
+					if _, ok := found[inst.Name]; !ok {
+						continue
+					}
+					if found[inst.Name] != nil {
+						klog.Errorf("Instance name %q was duplicated (in zone %q and %q)", inst.Name, zone, found[inst.Name].Zone)
+						continue
+					}
+					found[inst.Name] = &gceInstance{
+						Zone:  zone,
+						Name:  inst.Name,
+						ID:    inst.Id,
+						Disks: inst.Disks,
+						Type:  lastComponent(inst.MachineType),
+					}
+					remaining--
+				}
+			}
+		}
+	}
+
 	var ret []*gceInstance
 	var failed []string
 	for name, instance := range found {
@@ -761,12 +809,8 @@ func (g *Cloud) getFoundInstanceByNames(names []string) ([]*gceInstance, error) 
 	return ret, nil
 }
 
-// Gets the named instance, returning cloudprovider.InstanceNotFound if the instance is not found
-func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
-	klog.Infof("Searching node %s in managed zones %v", name, g.getManagedZones())
-
-	// Avoid changing behaviour when not managing multiple zones
-	for _, zone := range g.getManagedZones() {
+func (g *Cloud) findInstanceInZones(name string, zones []string) (*gceInstance, error) {
+	for _, zone := range zones {
 		instance, err := g.getInstanceFromProjectInZoneByName(g.projectID, zone, name)
 		if err != nil {
 			if isHTTPErrorCode(err, http.StatusNotFound) {
@@ -776,6 +820,33 @@ func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
 			return nil, err
 		}
 		return instance, nil
+	}
+	return nil, nil
+}
+
+// Gets the named instance, returning cloudprovider.InstanceNotFound if the instance is not found
+func (g *Cloud) getInstanceByName(name string) (*gceInstance, error) {
+	initialZones := g.getManagedZones()
+	klog.Infof("Searching node %s in managed zones %v", name, initialZones)
+
+	if instance, err := g.findInstanceInZones(name, initialZones); err != nil || instance != nil {
+		return instance, err
+	}
+
+	if g.dynamicZones {
+		klog.Infof("Node %s not found in managed zones %v; attempting dynamic zone refresh", name, initialZones)
+		if err := g.refreshManagedZones(); err != nil {
+			klog.Errorf("Failed to refresh GCE managed zones: %v", err)
+		} else {
+			refreshedZones := g.getManagedZones()
+			newZones := sets.NewString(refreshedZones...).Difference(sets.NewString(initialZones...)).List()
+			if len(newZones) > 0 {
+				klog.Infof("Searching node %s in newly discovered zones %v", name, newZones)
+				if instance, err := g.findInstanceInZones(name, newZones); err != nil || instance != nil {
+					return instance, err
+				}
+			}
+		}
 	}
 
 	return nil, cloudprovider.InstanceNotFound

--- a/providers/gce/gce_instances_test.go
+++ b/providers/gce/gce_instances_test.go
@@ -722,3 +722,160 @@ func TestUpdateNodeZonesDynamicRefresh(t *testing.T) {
 	expectedZones := []string{"us-central1-b", "us-central1-c"}
 	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
 }
+
+func TestGetInstanceByNameDynamicRefresh(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	gce.dynamicZones = true
+
+	// Initial managed zones only contain us-central1-b
+	assert.Equal(t, []string{"us-central1-b"}, gce.getManagedZones())
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+
+	// Mock GCE zones.List call to return us-central1-c in addition to us-central1-b
+	keyC := meta.GlobalKey("key-c")
+	mockGCE.MockZones.Objects[*keyC] = &cloud.MockZonesObj{
+		Obj: &ga.Zone{Name: "us-central1-c", Region: gce.getRegionLink("us-central1")},
+	}
+
+	// Insert instance into us-central1-c in GCE
+	err = gce.InsertInstance(
+		gce.ProjectID(),
+		"us-central1-c",
+		&ga.Instance{
+			Name: "node-in-c",
+			Zone: "us-central1-c",
+		},
+	)
+	require.NoError(t, err)
+
+	// Lookup instance by name without prior node registration or label
+	inst, err := gce.getInstanceByName("node-in-c")
+	require.NoError(t, err)
+	require.NotNil(t, inst)
+	assert.Equal(t, "node-in-c", inst.Name)
+	assert.Equal(t, "us-central1-c", inst.Zone)
+
+	// Managed zones should have refreshed to include both zones
+	expectedZones := []string{"us-central1-b", "us-central1-c"}
+	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
+}
+
+func TestInstanceMetadataUninitializedNodeDynamicRefresh(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	gce.dynamicZones = true
+
+	// Initial managed zones only contain us-central1-b
+	assert.Equal(t, []string{"us-central1-b"}, gce.getManagedZones())
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+
+	// Mock GCE zones.List call to return us-central1-c in addition to us-central1-b
+	keyC := meta.GlobalKey("key-c")
+	mockGCE.MockZones.Objects[*keyC] = &cloud.MockZonesObj{
+		Obj: &ga.Zone{Name: "us-central1-c", Region: gce.getRegionLink("us-central1")},
+	}
+
+	// Insert instance into us-central1-c in GCE
+	err = gce.InsertInstance(
+		gce.ProjectID(),
+		"us-central1-c",
+		&ga.Instance{
+			Name: "node-in-c",
+			Zone: "us-central1-c",
+			NetworkInterfaces: []*ga.NetworkInterface{
+				{
+					NetworkIP: "10.0.0.2",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Uninitialized node as registered by kubelet with external cloud provider:
+	// No zone labels, no providerID.
+	uninitializedNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-in-c",
+		},
+		Spec: v1.NodeSpec{},
+	}
+
+	metadata, err := gce.InstanceMetadata(context.Background(), uninitializedNode)
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "us-central1-c", metadata.Zone)
+	assert.Equal(t, "us-central1", metadata.Region)
+	assert.Equal(t, "gce://"+gce.ProjectID()+"/us-central1-c/node-in-c", metadata.ProviderID)
+
+	expectedZones := []string{"us-central1-b", "us-central1-c"}
+	assert.ElementsMatch(t, expectedZones, gce.getManagedZones())
+}
+
+func TestGetZoneProviderIDFallback(t *testing.T) {
+	nodeWithProviderID := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-in-c",
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: "gce://my-project/us-central1-c/node-in-c",
+		},
+	}
+
+	zone := getZone(nodeWithProviderID)
+	assert.Equal(t, "us-central1-c", zone)
+
+	nodeWithoutZone := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "uninitialized-node",
+		},
+	}
+	assert.Equal(t, emptyZone, getZone(nodeWithoutZone))
+}
+
+func TestGetFoundInstanceByNamesDynamicRefresh(t *testing.T) {
+	vals := DefaultTestClusterValues()
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+	gce.dynamicZones = true
+
+	mockGCE := gce.c.(*cloud.MockGCE)
+	keyC := meta.GlobalKey("key-c")
+	mockGCE.MockZones.Objects[*keyC] = &cloud.MockZonesObj{
+		Obj: &ga.Zone{Name: "us-central1-c", Region: gce.getRegionLink("us-central1")},
+	}
+
+	// Insert instance in default zone us-central1-b
+	err = gce.InsertInstance(
+		gce.ProjectID(),
+		"us-central1-b",
+		&ga.Instance{
+			Name: "node-in-b",
+			Zone: "us-central1-b",
+		},
+	)
+	require.NoError(t, err)
+
+	// Insert instance in new zone us-central1-c
+	err = gce.InsertInstance(
+		gce.ProjectID(),
+		"us-central1-c",
+		&ga.Instance{
+			Name: "node-in-c",
+			Zone: "us-central1-c",
+		},
+	)
+	require.NoError(t, err)
+
+	instances, err := gce.getFoundInstanceByNames([]string{"node-in-b", "node-in-c"})
+	require.NoError(t, err)
+	require.Len(t, instances, 2)
+
+	foundZones := []string{instances[0].Zone, instances[1].Zone}
+	assert.ElementsMatch(t, []string{"us-central1-b", "us-central1-c"}, foundZones)
+	assert.ElementsMatch(t, []string{"us-central1-b", "us-central1-c"}, gce.getManagedZones())
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes dynamic zone discovery in external Cloud Controller Manager (CCM) mode where newly created nodes register without topology zone labels, preventing node informer event handlers from detecting unmanaged zones during initial bootstrap.

### Problem
In #1164, dynamic refresh was triggered in `nodeInformer` event handlers by checking `getZone(newNode)`. However, when Kubelet runs with `--cloud-provider=external`, newly registered nodes do not have `topology.kubernetes.io/zone` labels. As a result:
1. `getZone(newNode)` returned `""` (`emptyZone`), and the informer event exited without refreshing `managedZones`.
2. CCM's node controller then attempted to initialize the node via `InstanceMetadata` -> `getInstanceByName`, which searched only the stale `managedZones` cache from startup.
3. `getInstanceByName` failed with `InstanceNotFound`, preventing the node from ever being initialized or labeled with its zone.

### Solution
1. **Cache-miss refresh**: When `getInstanceByName`, `getFoundInstanceByNames`, or `GetDiskByNameUnknownZone` misses across current `managedZones`, dynamically refresh `managedZones` via `refreshManagedZones()` and retry across any newly discovered zones before returning not found.
2. **ProviderID fallback**: Extract zone from `node.Spec.ProviderID` in `getZone()` if labels are not yet present.
3. **Periodic background sync**: Periodically refresh `managedZones` in `Initialize()` if `dynamicZones` is enabled to proactively discover allowlisted zones in the background.
4. **Unit tests**: Added comprehensive unit tests simulating uninitialized, unlabeled node registrations, batch lookups, and disk discovery.

