### PR TITLE
Add flags to override L4 LB HealthCheck source CIDRs

### DIFF
--- a/cmd/cloud-controller-manager/main.go
+++ b/cmd/cloud-controller-manager/main.go
@@ -84,6 +84,18 @@ var (
 
 	// enableL4ILBFineGrainedLocks enables resource-specific locking for L4 ILB.
 	enableL4ILBFineGrainedLocks bool
+
+	// overrideL4ILBHealthCheckSourceCIDRs overrides the default source IPv4 ranges
+	// used when configuring firewall rules to allow health check probes for L4 ILB
+	// load balancers. Provide the ranges as a comma-separated list of CIDRs.
+	// Example: --override-l4-ilb-health-check-src-cidrs=35.191.192.0/18
+	overrideL4ILBHealthCheckSourceCIDRs string
+
+	// overrideL4NetLBHealthCheckSourceCIDRs overrides the default source IPv4 ranges
+	// used when configuring firewall rules to allow health check probes for L4 NetLB
+	// load balancers. Provide the ranges as a comma-separated list of CIDRs.
+	// Example: --override-l4-netlb-health-check-src-cidrs=209.85.204.0/22
+	overrideL4NetLBHealthCheckSourceCIDRs string
 )
 
 func main() {
@@ -106,6 +118,8 @@ func main() {
 	cloudProviderFS.BoolVar(&enableL4DenyFirewallRollbackCleanup, "enable-l4-deny-firewall-rollback-cleanup", false, "Enable cleanup codepath of the deny firewalls for rollback. The reason for it not being enabled by default is the additional GCE API calls that are made for checking if the deny firewalls exist/deletion which will eat up the quota unnecessarily.")
 	cloudProviderFS.BoolVar(&enableGKETenantController, "enable-gke-tenant-controller", false, "Enables the GKE Tenant Controller Manager for Multi-Tenancy.")
 	cloudProviderFS.BoolVar(&enableL4ILBFineGrainedLocks, "enable-l4-ilb-fine-grained-lock", false, "Enable resource-specific locking for L4 ILB")
+	cloudProviderFS.StringVar(&overrideL4ILBHealthCheckSourceCIDRs, "override-l4-ilb-health-check-src-cidrs", "", "Overrides the default source IPv4 ranges used when configuring firewall rules to allow health check probes for L4 ILB load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-l4-ilb-health-check-src-cidrs=35.191.192.0/18")
+	cloudProviderFS.StringVar(&overrideL4NetLBHealthCheckSourceCIDRs, "override-l4-netlb-health-check-src-cidrs", "", "Overrides the default source IPv4 ranges used when configuring firewall rules to allow health check probes for L4 NetLB load balancers. Provide the ranges as a comma-separated list of CIDRs. Example: --override-l4-netlb-health-check-src-cidrs=209.85.204.0/22")
 
 	// add new controllers and initializers
 	nodeIpamController := nodeIPAMController{}
@@ -241,6 +255,13 @@ func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovid
 
 	// Record feature gate metrics
 	gce.RecordFeatureGateMetrics(enableL4ILBFineGrainedLocks)
+
+	if overrideL4ILBHealthCheckSourceCIDRs != "" {
+		gce.SetOverrideL4ILBHealthCheckSourceCIDRs(overrideL4ILBHealthCheckSourceCIDRs)
+	}
+	if overrideL4NetLBHealthCheckSourceCIDRs != "" {
+		gce.SetOverrideL4NetLBHealthCheckSourceCIDRs(overrideL4NetLBHealthCheckSourceCIDRs)
+	}
 
 	return cloud
 }

--- a/providers/gce/gce_instances.go
+++ b/providers/gce/gce_instances.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -110,7 +110,7 @@ func (g *Cloud) orderAddresses(addresses []v1.NodeAddress) []v1.NodeAddress {
 	for _, address := range addresses {
 		ip := net.ParseIP(address.Address)
 		// Non IP addresses as hostname will get a nil ip.
-		if ip == nil || utilnet.IsIPv6(ip) == preferIPv6 {
+		if ip == nil || netutils.IsIPv6(ip) == preferIPv6 {
 			sortedAddresses = append(sortedAddresses, address)
 		}
 	}
@@ -119,7 +119,7 @@ func (g *Cloud) orderAddresses(addresses []v1.NodeAddress) []v1.NodeAddress {
 	for _, address := range addresses {
 		ip := net.ParseIP(address.Address)
 		// Non IP addresses as hostname will get a nil ip.
-		if ip != nil && utilnet.IsIPv6(ip) != preferIPv6 {
+		if ip != nil && netutils.IsIPv6(ip) != preferIPv6 {
 			sortedAddresses = append(sortedAddresses, address)
 		}
 	}

--- a/providers/gce/gce_loadbalancer.go
+++ b/providers/gce/gce_loadbalancer.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"net"
 	"reflect"
 	"sort"
 	"strings"
@@ -66,7 +67,20 @@ func newLBSyncResult() *lbSyncResult {
 var (
 	l4LbSrcRngsFlag cidrs
 	l7lbSrcRngsFlag cidrs
+
+	overrideL4ILBHealthCheckSourceCIDRs   string
+	overrideL4NetLBHealthCheckSourceCIDRs string
 )
+
+// SetOverrideL4ILBHealthCheckSourceCIDRs sets the override source CIDRs for L4 ILB health checks.
+func SetOverrideL4ILBHealthCheckSourceCIDRs(cidrs string) {
+	overrideL4ILBHealthCheckSourceCIDRs = cidrs
+}
+
+// SetOverrideL4NetLBHealthCheckSourceCIDRs sets the override source CIDRs for L4 NetLB health checks.
+func SetOverrideL4NetLBHealthCheckSourceCIDRs(cidrs string) {
+	overrideL4NetLBHealthCheckSourceCIDRs = cidrs
+}
 
 func init() {
 	var err error
@@ -111,6 +125,117 @@ func (c *cidrs) Set(value string) error {
 		c.ipn.Insert(ipnet)
 	}
 	return nil
+}
+
+// parseHealthCheckCIDRs parses a comma-separated string of CIDRs and returns an IPNetSet.
+// Invalid CIDRs are logged and skipped.
+func parseHealthCheckCIDRs(cidrs string) netutils.IPNetSet {
+	if cidrs == "" {
+		return nil
+	}
+	ipNetSet := make(netutils.IPNetSet)
+	for _, c := range strings.Split(cidrs, ",") {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		_, ipnet, err := net.ParseCIDR(c)
+		if err != nil {
+			klog.Warningf("Ignoring invalid health check CIDR: %v", c)
+			continue
+		}
+		ipNetSet.Insert(ipnet)
+	}
+	return ipNetSet
+}
+
+func filterIPNetSetByFamily(ipns netutils.IPNetSet, isIPv6 bool) netutils.IPNetSet {
+	filtered := make(netutils.IPNetSet)
+	for _, ipn := range ipns {
+		if netutils.IsIPv6(ipn.IP) == isIPv6 {
+			filtered.Insert(ipn)
+		}
+	}
+	return filtered
+}
+
+// L4LBType represents the type of L4 load balancer.
+type L4LBType string
+
+const (
+	// L4LBTypeILB is the constant for Internal Load Balancer.
+	L4LBTypeILB L4LBType = "ILB"
+	// L4LBTypeNetLB is the constant for Network Load Balancer.
+	L4LBTypeNetLB L4LBType = "NetLB"
+)
+
+// getHCFirewallSourceRanges returns the list of source CIDR ranges for the health check firewall rule.
+//
+// Arguments:
+// l4Type: The type of L4 load balancer (ILB or XLB/NetLB).
+// shared: Indicates whether the firewall rule is shared between different K8s Services (e.g., when ExternalTrafficPolicy=Cluster).
+//
+//	If shared is true, the firewall rule must include the ranges for both ILB and NetLB because a single global firewall rule is used.
+//
+// isIPv6: Specifies if we are retrieving ranges for an IPv6 firewall rule. If false, we return IPv4 ranges.
+//
+// Logic:
+// The function gathers the appropriate CIDR ranges based on the LB type(s). If 'shared' is true, it aggregates
+// the CIDRs for both ILB and NetLB.
+// For each LB type, it parses the override flag (if provided) and extracts the requested IP family.
+// If the flag is not provided, or if the extracted ranges are empty (meaning the flag was missing that specific IP family),
+// it falls back to the default GCP health check ranges (l4LbSrcRngsFlag). Note that these default ranges only
+// contain IPv4 addresses because the controller's default configuration does not currently support IPv6.
+// Finally, it removes duplicates from the aggregated ranges.
+func getHCFirewallSourceRanges(l4Type L4LBType, shared bool, isIPv6 bool) netutils.IPNetSet {
+	ranges := make(netutils.IPNetSet)
+
+	lbTypesToProcess := []L4LBType{l4Type}
+	if shared {
+		lbTypesToProcess = []L4LBType{L4LBTypeILB, L4LBTypeNetLB}
+	}
+
+	for _, lbType := range lbTypesToProcess {
+		currentRanges := make(netutils.IPNetSet)
+
+		// use custom HC ranges if provided (could contain IPv4/v6 ranges)
+		var overrideStr string
+		switch lbType {
+		case L4LBTypeILB:
+			overrideStr = overrideL4ILBHealthCheckSourceCIDRs
+		case L4LBTypeNetLB:
+			overrideStr = overrideL4NetLBHealthCheckSourceCIDRs
+		}
+		if overrideStr != "" {
+			ipns := parseHealthCheckCIDRs(overrideStr)
+			currentRanges = filterIPNetSetByFamily(ipns, isIPv6)
+		}
+
+		// use the default HC ranges
+		if len(currentRanges) == 0 {
+			// l4LbSrcRngsFlag contains IPv4 only ranges for both ILB and NetLB
+			// Controller does not support IPv6
+			currentRanges = filterIPNetSetByFamily(l4LbSrcRngsFlag.ipn, isIPv6)
+		}
+
+		for _, ipn := range currentRanges {
+			ranges.Insert(ipn)
+		}
+	}
+
+	return ranges
+}
+
+// L4ILBHealthCheckSrcRanges returns the ranges of ips used by the GCE L4 ILB load balancers
+// for performing health checks.
+func L4ILBHealthCheckSrcRanges(shared bool, isIPv6 bool) netutils.IPNetSet {
+	return getHCFirewallSourceRanges(L4LBTypeILB, shared, isIPv6)
+}
+
+// L4NetLBHealthCheckSrcRanges returns the ranges of ips used by the GCE L4 NetLB load balancers
+// for performing health checks.
+func L4NetLBHealthCheckSrcRanges(shared bool, isIPv6 bool) netutils.IPNetSet {
+	return getHCFirewallSourceRanges(L4LBTypeNetLB, shared, isIPv6)
 }
 
 // L4LoadBalancerSrcRanges contains the ranges of ips used by the L3/L4 GCE load balancers

--- a/providers/gce/gce_loadbalancer_external.go
+++ b/providers/gce/gce_loadbalancer_external.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
-	utilnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 
 	"google.golang.org/api/compute/v1"
 	"k8s.io/klog/v2"
@@ -983,7 +983,7 @@ func translateAffinityType(affinityType v1.ServiceAffinity) string {
 	}
 }
 
-func (g *Cloud) firewallNeedsUpdate(name, serviceName, ipAddress string, ports []v1.ServicePort, sourceRanges utilnet.IPNetSet, priority int64) (exists bool, needsUpdate bool, err error) {
+func (g *Cloud) firewallNeedsUpdate(name, serviceName, ipAddress string, ports []v1.ServicePort, sourceRanges netutils.IPNetSet, priority int64) (exists bool, needsUpdate bool, err error) {
 	fw, err := g.GetFirewall(MakeFirewallName(name))
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
@@ -1007,7 +1007,7 @@ func (g *Cloud) firewallNeedsUpdate(name, serviceName, ipAddress string, ports [
 	}
 
 	// The service controller already verified that the protocol matches on all ports, no need to check.
-	actualSourceRanges, err := utilnet.ParseIPNets(fw.SourceRanges...)
+	actualSourceRanges, err := netutils.ParseIPNets(fw.SourceRanges...)
 	if err != nil {
 		// This really shouldn't happen... GCE has returned something unexpected
 		klog.Warningf("Error parsing firewall SourceRanges: %v", fw.SourceRanges)
@@ -1038,7 +1038,8 @@ func (g *Cloud) ensureHTTPHealthCheckFirewall(svc *v1.Service, serviceName, ipAd
 	if !isNodesHealthCheck {
 		desc = makeFirewallDescription(serviceName, ipAddress)
 	}
-	sourceRanges := l4LbSrcRngsFlag.ipn
+	isIPv6 := netutils.IsIPv6String(ipAddress)
+	sourceRanges := L4NetLBHealthCheckSrcRanges(isNodesHealthCheck, isIPv6)
 	ports := []v1.ServicePort{{Protocol: "tcp", Port: hcPort}}
 	allowPriority := firewallPriorityDefault
 	if g.enableL4DenyFirewallRule {
@@ -1105,7 +1106,7 @@ func createForwardingRule(s CloudForwardingRuleService, name, serviceName, regio
 	return nil
 }
 
-func (g *Cloud) createFirewall(svc *v1.Service, name, desc, destinationIP string, sourceRanges utilnet.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) error {
+func (g *Cloud) createFirewall(svc *v1.Service, name, desc, destinationIP string, sourceRanges netutils.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) error {
 	firewall, err := g.firewallObject(name, desc, destinationIP, sourceRanges, ports, hosts, priority)
 	if err != nil {
 		return err
@@ -1123,7 +1124,7 @@ func (g *Cloud) createFirewall(svc *v1.Service, name, desc, destinationIP string
 	return nil
 }
 
-func (g *Cloud) updateFirewall(svc *v1.Service, name, desc, destinationIP string, sourceRanges utilnet.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) error {
+func (g *Cloud) updateFirewall(svc *v1.Service, name, desc, destinationIP string, sourceRanges netutils.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) error {
 	firewall, err := g.firewallObject(name, desc, destinationIP, sourceRanges, ports, hosts, priority)
 	if err != nil {
 		return err
@@ -1142,7 +1143,7 @@ func (g *Cloud) updateFirewall(svc *v1.Service, name, desc, destinationIP string
 	return nil
 }
 
-func (g *Cloud) firewallObject(name, desc, destinationIP string, sourceRanges utilnet.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) (*compute.Firewall, error) {
+func (g *Cloud) firewallObject(name, desc, destinationIP string, sourceRanges netutils.IPNetSet, ports []v1.ServicePort, hosts []*gceInstance, priority int) (*compute.Firewall, error) {
 	// destinationIP can be empty string "" and this means that it is not set.
 	// GCE considers empty destinationRanges as "all" for ingress firewall-rules.
 	// Concatenate service ports into port ranges. This help to workaround the gce firewall limitation where only
@@ -1410,11 +1411,11 @@ func parsePort(portStr string) (int, int, error) {
 }
 
 func ipRangesEqual(a, b []string) (bool, error) {
-	as, err := utilnet.ParseIPNets(a...)
+	as, err := netutils.ParseIPNets(a...)
 	if err != nil {
 		return false, err
 	}
-	bs, err := utilnet.ParseIPNets(b...)
+	bs, err := netutils.ParseIPNets(b...)
 	if err != nil {
 		return false, err
 	}

--- a/providers/gce/gce_loadbalancer_external_test.go
+++ b/providers/gce/gce_loadbalancer_external_test.go
@@ -31,6 +31,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	cloudprovider "k8s.io/cloud-provider"
+	netutils "k8s.io/utils/net"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud/meta"
@@ -41,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -1561,10 +1561,10 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 	ipAddr := syncResult.status.Ingress[0].IP
 	lbName := gce.GetLoadBalancerName(context.TODO(), "", svc)
 
-	ipnet, err := utilnet.ParseIPNets("0.0.0.0/0")
+	ipnet, err := netutils.ParseIPNets("0.0.0.0/0")
 	require.NoError(t, err)
 
-	wrongIpnet, err := utilnet.ParseIPNets("1.0.0.0/10")
+	wrongIpnet, err := netutils.ParseIPNets("1.0.0.0/10")
 	require.NoError(t, err)
 
 	fwName := MakeFirewallName(lbName)
@@ -1575,7 +1575,7 @@ func TestFirewallNeedsUpdate(t *testing.T) {
 		lbName       string
 		ipAddr       string
 		ports        []v1.ServicePort
-		ipnet        utilnet.IPNetSet
+		ipnet        netutils.IPNetSet
 		fwIPProtocol string
 		getHook      func(context.Context, *meta.Key, *cloud.MockFirewalls, ...cloud.Option) (bool, *compute.Firewall, error)
 		sourceRange  string
@@ -1907,7 +1907,7 @@ func TestCreateAndUpdateFirewallSucceedsOnXPN(t *testing.T) {
 	hostNames := nodeNames(nodes)
 	hosts, err := gce.getInstancesByNames(hostNames)
 	require.NoError(t, err)
-	ipnet, err := utilnet.ParseIPNets("10.0.0.0/20")
+	ipnet, err := netutils.ParseIPNets("10.0.0.0/20")
 	require.NoError(t, err)
 	gce.createFirewall(
 		svc,
@@ -2246,7 +2246,7 @@ func TestFirewallObject(t *testing.T) {
 	require.NoError(t, err)
 	dstIP := "10.0.0.1"
 	srcRanges := []string{"10.10.0.0/24", "10.20.0.0/24"}
-	sourceRanges, _ := utilnet.ParseIPNets(srcRanges...)
+	sourceRanges, _ := netutils.ParseIPNets(srcRanges...)
 	fwName := "test-fw"
 	fwDesc := "test-desc"
 	baseFw := compute.Firewall{
@@ -2266,14 +2266,14 @@ func TestFirewallObject(t *testing.T) {
 
 	for _, tc := range []struct {
 		desc             string
-		sourceRanges     utilnet.IPNetSet
+		sourceRanges     netutils.IPNetSet
 		destinationIP    string
 		svcPorts         []v1.ServicePort
 		expectedFirewall func(fw compute.Firewall) compute.Firewall
 	}{
 		{
 			desc:         "empty source ranges",
-			sourceRanges: utilnet.IPNetSet{},
+			sourceRanges: netutils.IPNetSet{},
 			svcPorts: []v1.ServicePort{
 				{Name: "port1", Protocol: v1.ProtocolTCP, Port: int32(80), TargetPort: intstr.FromInt(80)},
 			},
@@ -2294,7 +2294,7 @@ func TestFirewallObject(t *testing.T) {
 		},
 		{
 			desc:          "has destination IP",
-			sourceRanges:  utilnet.IPNetSet{},
+			sourceRanges:  netutils.IPNetSet{},
 			destinationIP: dstIP,
 			svcPorts: []v1.ServicePort{
 				{Name: "port1", Protocol: v1.ProtocolTCP, Port: int32(80), TargetPort: intstr.FromInt(80)},

--- a/providers/gce/gce_loadbalancer_internal.go
+++ b/providers/gce/gce_loadbalancer_internal.go
@@ -38,6 +38,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	servicehelpers "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/klog/v2"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -613,7 +614,8 @@ func (g *Cloud) ensureInternalFirewalls(loadBalancerName, ipAddress, clusterID s
 
 	// Second firewall is for health checking nodes / services
 	fwHCName := makeHealthCheckFirewallName(loadBalancerName, clusterID, sharedHealthCheck)
-	hcSrcRanges := L4LoadBalancerSrcRanges()
+	isIPv6 := netutils.IsIPv6String(ipAddress)
+	hcSrcRanges := L4ILBHealthCheckSrcRanges(sharedHealthCheck, isIPv6).StringSlice()
 	return g.ensureInternalFirewall(svc, fwHCName, "", "", hcSrcRanges, []string{healthCheckPort}, v1.ProtocolTCP, nodes, "", sharedHealthCheck)
 }
 

--- a/providers/gce/gce_loadbalancer_test.go
+++ b/providers/gce/gce_loadbalancer_test.go
@@ -655,3 +655,112 @@ func TestUpdateLoadBalancerWithLoadBalancerClass(t *testing.T) {
 		}
 	}
 }
+
+func TestGetHCFirewallSourceRanges(t *testing.T) {
+	// Backup and restore global states
+	oldILB := overrideL4ILBHealthCheckSourceCIDRs
+	oldNetLB := overrideL4NetLBHealthCheckSourceCIDRs
+	defer func() {
+		SetOverrideL4ILBHealthCheckSourceCIDRs(oldILB)
+		SetOverrideL4NetLBHealthCheckSourceCIDRs(oldNetLB)
+	}()
+
+	defaultIPv4 := l4LbSrcRngsFlag.ipn.StringSlice()
+
+	testCases := []struct {
+		name           string
+		overrideILB    string
+		overrideNetLB  string
+		l4Type         L4LBType
+		shared         bool
+		isIPv6         bool
+		expectedRanges []string
+	}{
+		{
+			name:           "ILB default IPv4",
+			l4Type:         L4LBTypeILB,
+			shared:         false,
+			isIPv6:         false,
+			expectedRanges: defaultIPv4,
+		},
+		{
+			name:           "ILB default IPv6 (empty)",
+			l4Type:         L4LBTypeILB,
+			shared:         false,
+			isIPv6:         true,
+			expectedRanges: []string{}, // default only has IPv4
+		},
+		{
+			name:           "NetLB default IPv4",
+			l4Type:         L4LBTypeNetLB,
+			shared:         false,
+			isIPv6:         false,
+			expectedRanges: defaultIPv4,
+		},
+		{
+			name:           "ILB overridden IPv4",
+			overrideILB:    "1.2.3.0/24,2.3.4.0/24",
+			l4Type:         L4LBTypeILB,
+			shared:         false,
+			isIPv6:         false,
+			expectedRanges: []string{"1.2.3.0/24", "2.3.4.0/24"},
+		},
+		{
+			name:           "NetLB overridden IPv6",
+			overrideNetLB:  "2600::/64,1.2.3.0/24",
+			l4Type:         L4LBTypeNetLB,
+			shared:         false,
+			isIPv6:         true,
+			expectedRanges: []string{"2600::/64"}, // should filter out IPv4
+		},
+		{
+			name:           "Shared default IPv4",
+			l4Type:         L4LBTypeILB, // l4Type shouldn't matter when shared
+			shared:         true,
+			isIPv6:         false,
+			expectedRanges: defaultIPv4, // both use default
+		},
+		{
+			name:           "Shared mixed overrides IPv4",
+			overrideILB:    "1.2.3.0/24",
+			overrideNetLB:  "4.5.6.0/24",
+			l4Type:         L4LBTypeILB,
+			shared:         true,
+			isIPv6:         false,
+			expectedRanges: []string{"1.2.3.0/24", "4.5.6.0/24"}, // should union both
+		},
+		{
+			name:          "Shared mixed overrides deduplication",
+			overrideILB:   "1.2.3.0/24,10.0.0.0/8",
+			overrideNetLB: "1.2.3.0/24,20.0.0.0/8",
+			l4Type:        L4LBTypeILB,
+			shared:        true,
+			isIPv6:        false,
+			// The IPNetSet output string slice order is deterministic but let's test if it handles it correctly.
+			// Actually StringSlice() sorts the strings!
+			expectedRanges: []string{"1.2.3.0/24", "10.0.0.0/8", "20.0.0.0/8"},
+		},
+		{
+			name:        "Shared fallback IPv6",
+			overrideILB: "2600::/64",
+			// NetLB has no override, so it should fallback to default (empty for IPv6)
+			l4Type:         L4LBTypeNetLB,
+			shared:         true,
+			isIPv6:         true,
+			expectedRanges: []string{"2600::/64"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetOverrideL4ILBHealthCheckSourceCIDRs(tc.overrideILB)
+			SetOverrideL4NetLBHealthCheckSourceCIDRs(tc.overrideNetLB)
+
+			res := getHCFirewallSourceRanges(tc.l4Type, tc.shared, tc.isIPv6).StringSlice()
+
+			// netutils.IPNetSet.StringSlice() sorts the results, so we can directly assert Equal
+			// but we need to make sure tc.expectedRanges is sorted too.
+			assert.ElementsMatch(t, tc.expectedRanges, res)
+		})
+	}
+}


### PR DESCRIPTION
This introduces new flags

--override-l4-ilb-health-check-src-cidrs - for L4 ILB could contain both IPv4/v6
--override-l4-netlb-health-check-src-cidrs - for L4 NetLB could contain both IPv4/v6
to support custom health check source ranges for Trusted Partner Cloud environments.

if flag is missing or needed IP ranges are missing, then default hardcoded IP ranges are used.

Controller behaviour for different L4 LB type (ILB/NetLB):
if flag is specified: only specified LB_TYPE ranges will be used
without flag (existing behaviour):
 - IPv4 - always contains ranges ILB + NETLB using func: L4LoadBalancerSrcRanges()
 - IPv6 - is not supported, so it skipped

"shared" FR (for ETP:Cluster) contains ILB + NETLB ranges