### PR TITLE
Mitigate informer cache staleness with ConsistencyStore in controllers

### DIFF
--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller.go
@@ -18,6 +18,7 @@ package gkenetworkparamset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -36,15 +37,18 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
+	consistencyutil "k8s.io/cloud-provider-gcp/pkg/controller/util/consistency"
 	"k8s.io/cloud-provider-gcp/pkg/controllermetrics"
 	utilnode "k8s.io/cloud-provider-gcp/pkg/util/node"
 	"k8s.io/cloud-provider-gcp/providers/gce"
@@ -81,6 +85,8 @@ type Controller struct {
 	nodeInformerSynced        cache.InformerSynced
 	clusterDefaultIPv4PodCIDR string
 	defaultGNPName            string
+
+	consistencyStore consistencyutil.ConsistencyStore
 }
 
 // NewGKENetworkParamSetController returns a new
@@ -102,6 +108,14 @@ func NewGKENetworkParamSetController(
 		defaultGNPName = networkv1.DefaultPodNetworkName
 	}
 
+	gnpGroupResource := schema.GroupResource{Group: "networking.gke.io", Resource: "gkenetworkparamsets"}
+	networkGroupResource := schema.GroupResource{Group: "networking.gke.io", Resource: "networks"}
+
+	consistencyStore := consistencyutil.NewConsistencyStore(map[schema.GroupResource]consistencyutil.LastSyncRVGetter{
+		gnpGroupResource:     gkeNetworkParamsInformer.Informer().GetStore(),
+		networkGroupResource: networkInformer.Informer().GetStore(),
+	})
+
 	c := &Controller{
 		networkClientset:         networkClientset,
 		gkeNetworkParamsInformer: gkeNetworkParamsInformer,
@@ -112,6 +126,7 @@ func NewGKENetworkParamSetController(
 		nodeLister:               nodeInformer.Lister(),
 		nodeInformerSynced:       nodeInformer.Informer().HasSynced,
 		defaultGNPName:           defaultGNPName,
+		consistencyStore:         consistencyStore,
 	}
 
 	gkeNetworkParamsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -128,6 +143,16 @@ func NewGKENetworkParamSetController(
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
+			gnp, ok := obj.(*networkv1.GKENetworkParamSet)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if ok {
+					gnp, _ = tombstone.Obj.(*networkv1.GKENetworkParamSet)
+				}
+			}
+			if gnp != nil {
+				c.consistencyStore.Clear(types.NamespacedName{Name: gnp.Name}, gnp.UID)
+			}
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 			if err == nil {
 				c.queue.Add(key)
@@ -165,8 +190,17 @@ func NewGKENetworkParamSetController(
 		},
 
 		DeleteFunc: func(obj interface{}) {
-			network := obj.(*networkv1.Network)
-			if network.Spec.ParametersRef != nil && strings.EqualFold(network.Spec.ParametersRef.Kind, gnpKind) {
+			network, ok := obj.(*networkv1.Network)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if ok {
+					network, _ = tombstone.Obj.(*networkv1.Network)
+				}
+			}
+			if network != nil {
+				c.consistencyStore.Clear(types.NamespacedName{Name: network.Name}, network.UID)
+			}
+			if network != nil && network.Spec.ParametersRef != nil && strings.EqualFold(network.Spec.ParametersRef.Kind, gnpKind) {
 				c.queue.Add(network.Spec.ParametersRef.Name)
 			}
 		},
@@ -297,10 +331,22 @@ func removeFinalizerInPlace(params *networkv1.GKENetworkParamSet) {
 }
 
 func (c *Controller) reconcile(ctx context.Context, key string) error {
+	namespacedName := types.NamespacedName{Name: key}
+
+	// 1. Ensure the cache is ready (not stale)
+	if err := c.consistencyStore.EnsureReady(namespacedName); err != nil {
+		var consistencyErr *consistencyutil.ConsistencyError
+		if errors.As(err, &consistencyErr) {
+			klog.V(4).Infof("Consistency store not ready for GKENetworkParamSet %q: %v", key, err)
+		}
+		return err
+	}
+
 	originalParams, err := c.gkeNetworkParamsInformer.Lister().Get(key)
 
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
+			c.consistencyStore.Clear(namespacedName, "")
 			return c.cleanupGNPDeletion(ctx, key) // GNP was deleted, run cleanup
 		}
 		klog.Errorf("Fetching object with key %s from store failed with %v", key, err)
@@ -539,7 +585,7 @@ func (c *Controller) handleGNPDelete(ctx context.Context, params *networkv1.GKEN
 
 	network, err := c.networkClientset.NetworkingV1().Networks().Get(ctx, params.Status.NetworkName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return c.executeGNPDelete(ctx, params, nil)
 		}
 		return err
@@ -577,9 +623,16 @@ func (c *Controller) cleanupGNPDeletion(ctx context.Context, gnpName string) err
 		Reason:  string(networkv1.GNPDeleted),
 		Message: fmt.Sprintf("GKENetworkParamSet resource was deleted: %v", gnpName),
 	})
-	if _, err := c.networkClientset.NetworkingV1().Networks().UpdateStatus(ctx, newNetwork, metav1.UpdateOptions{}); err != nil {
+	updatedNetwork, err := c.networkClientset.NetworkingV1().Networks().UpdateStatus(ctx, newNetwork, metav1.UpdateOptions{})
+	if err != nil {
 		return err
 	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Name: updatedNetwork.Name},
+		updatedNetwork.UID,
+		schema.GroupResource{Group: "networking.gke.io", Resource: "networks"},
+		updatedNetwork.ResourceVersion,
+	)
 
 	return nil
 }
@@ -615,18 +668,30 @@ func paramSetIncludesRange(params *networkv1.GKENetworkParamSet, secondaryRangeN
 }
 
 func (c *Controller) updateGKENetworkParamSet(ctx context.Context, params *networkv1.GKENetworkParamSet) error {
-	_, err := c.networkClientset.NetworkingV1().GKENetworkParamSets().Update(ctx, params, metav1.UpdateOptions{})
+	updated, err := c.networkClientset.NetworkingV1().GKENetworkParamSets().Update(ctx, params, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update GKENetworkParamSet: %w", err)
 	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Name: updated.Name},
+		updated.UID,
+		schema.GroupResource{Group: "networking.gke.io", Resource: "gkenetworkparamsets"},
+		updated.ResourceVersion,
+	)
 	return nil
 }
 
 func (c *Controller) updateGKENetworkParamSetStatus(ctx context.Context, params *networkv1.GKENetworkParamSet) error {
-	_, err := c.networkClientset.NetworkingV1().GKENetworkParamSets().UpdateStatus(ctx, params, metav1.UpdateOptions{})
+	updated, err := c.networkClientset.NetworkingV1().GKENetworkParamSets().UpdateStatus(ctx, params, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update GKENetworkParamSet Status: %w", err)
 	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Name: updated.Name},
+		updated.UID,
+		schema.GroupResource{Group: "networking.gke.io", Resource: "gkenetworkparamsets"},
+		updated.ResourceVersion,
+	)
 	return nil
 }
 
@@ -670,9 +735,16 @@ func (c *Controller) updateNetworkConditionForPodRanges(ctx context.Context, par
 		Reason:  string(networkv1.GNPParamsNotReady),
 		Message: "New Pod ranges in default VPC requires CIDRs update in default Network",
 	})
-	if _, err := c.networkClientset.NetworkingV1().Networks().UpdateStatus(ctx, newNetwork, metav1.UpdateOptions{}); err != nil {
+	updatedNetwork, err := c.networkClientset.NetworkingV1().Networks().UpdateStatus(ctx, newNetwork, metav1.UpdateOptions{})
+	if err != nil {
 		return err
 	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Name: updatedNetwork.Name},
+		updatedNetwork.UID,
+		schema.GroupResource{Group: "networking.gke.io", Resource: "networks"},
+		updatedNetwork.ResourceVersion,
+	)
 	return nil
 }
 
@@ -702,10 +774,9 @@ func (c *Controller) RemoveTenantParamSetFinalizers(ctx context.Context, tenantN
 				}
 				gnpCopy := latest.DeepCopy()
 				removeFinalizerInPlace(gnpCopy)
-				_, err = c.networkClientset.NetworkingV1().GKENetworkParamSets().Update(ctx, gnpCopy, metav1.UpdateOptions{})
-				return err
+				return c.updateGKENetworkParamSet(ctx, gnpCopy)
 			})
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil && !apierrors.IsNotFound(err) {
 				klog.Errorf("Failed to remove finalizer from GNP %s: %v", gnp.Name, err)
 				errs = multierror.Append(errs, err)
 			}

--- a/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
+++ b/pkg/controller/gkenetworkparamset/gkenetworkparamset_controller_test.go
@@ -16,14 +16,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	condmeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	consistencyutil "k8s.io/cloud-provider-gcp/pkg/controller/util/consistency"
 	utilnode "k8s.io/cloud-provider-gcp/pkg/util/node"
 	"k8s.io/cloud-provider-gcp/providers/gce"
 	"k8s.io/component-base/metrics/prometheus/controllers"
@@ -1976,4 +1980,116 @@ func TestRemoveTenantParamSetFinalizers(t *testing.T) {
 	if !slices.Contains(remainingGNP.Finalizers, GNPFinalizer) {
 		t.Errorf("expected tenant-2 GNP to retain finalizer, got %v", remainingGNP.Finalizers)
 	}
+}
+
+type fakeRVGetter struct {
+	rv string
+}
+
+func (f *fakeRVGetter) LastStoreSyncResourceVersion() string {
+	return f.rv
+}
+
+func (f *fakeRVGetter) setRV(rv string) {
+	f.rv = rv
+}
+
+type gnpTestFixture struct {
+	controller       *Controller
+	gnpGetter        *fakeRVGetter
+	netGetter        *fakeRVGetter
+	consistencyStore consistencyutil.ConsistencyStore
+	networkClient    *networkfake.Clientset
+	gnp              *networkv1.GKENetworkParamSet
+}
+
+func setupGNPTestFixture() *gnpTestFixture {
+	fakeNetworking := networkfake.NewSimpleClientset()
+	nwInfFactory := networkinformers.NewSharedInformerFactory(fakeNetworking, 0*time.Second)
+	nwInformer := nwInfFactory.Networking().V1().Networks()
+	gnpInformer := nwInfFactory.Networking().V1().GKENetworkParamSets()
+
+	testClusterValues := gce.DefaultTestClusterValues()
+	testClusterValues.NetworkURL = fmt.Sprintf("projects/%v/global/networks/%v", testClusterValues.ProjectID, defaultTestNetworkName)
+	testClusterValues.SubnetworkURL = fmt.Sprintf("projects/%v/regions/%v/subnetworks/%v", testClusterValues.ProjectID, testClusterValues.Region, defaultTestSubnetworkName)
+	fakeGCE := gce.NewFakeGCECloud(testClusterValues)
+
+	fakeInformerFactory := informers.NewSharedInformerFactory(&fake.Clientset{}, 0*time.Second)
+	fakeNodeInformer := fakeInformerFactory.Core().V1().Nodes()
+	_, ipnet, _ := net.ParseCIDR(defaultPodCIDR)
+
+	controller := NewGKENetworkParamSetController(
+		fakeNodeInformer,
+		fakeNetworking,
+		gnpInformer,
+		nwInformer,
+		fakeGCE,
+		nwInfFactory,
+		[]*net.IPNet{ipnet},
+		"",
+	)
+	controller.nodeInformerSynced = func() bool { return true }
+
+	gnpGetter := &fakeRVGetter{rv: "1"}
+	netGetter := &fakeRVGetter{rv: "1"}
+	consistencyStore := consistencyutil.NewConsistencyStore(map[schema.GroupResource]consistencyutil.LastSyncRVGetter{
+		{Group: "networking.gke.io", Resource: "gkenetworkparamsets"}: gnpGetter,
+		{Group: "networking.gke.io", Resource: "networks"}:            netGetter,
+	})
+	controller.consistencyStore = consistencyStore
+
+	gnp := &networkv1.GKENetworkParamSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-gnp",
+			UID:             apitypes.UID("gnp-uid-1"),
+			ResourceVersion: "1",
+		},
+		Spec: networkv1.GKENetworkParamSetSpec{
+			VPC:       defaultTestNetworkName,
+			VPCSubnet: defaultTestSubnetworkName,
+		},
+	}
+
+	return &gnpTestFixture{
+		controller:       controller,
+		gnpGetter:        gnpGetter,
+		netGetter:        netGetter,
+		consistencyStore: consistencyStore,
+		networkClient:    fakeNetworking,
+		gnp:              gnp,
+	}
+}
+
+func TestGKENetworkParamSetController_ConsistencyStoreStallAndCatchUp(t *testing.T) {
+	f := setupGNPTestFixture()
+	ctx := context.Background()
+
+	key := apitypes.NamespacedName{Name: f.gnp.Name}
+
+	// 1. Initially consistent
+	assert.NoError(t, f.consistencyStore.EnsureReady(key))
+
+	// 2. Add GNP to fake client and simulate an update with RV "2"
+	_, err := f.networkClient.NetworkingV1().GKENetworkParamSets().Create(ctx, f.gnp, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	f.gnp.ResourceVersion = "2"
+	err = f.controller.updateGKENetworkParamSet(ctx, f.gnp)
+	assert.NoError(t, err)
+
+	// 3. Reconciler stalls because informer is still at RV "1"
+	err = f.controller.reconcile(ctx, f.gnp.Name)
+	assert.Error(t, err)
+	assert.Error(t, f.consistencyStore.EnsureReady(key))
+
+	// 4. Informer catches up to RV "2"
+	f.gnpGetter.setRV("2")
+	assert.NoError(t, f.consistencyStore.EnsureReady(key))
+
+	// 5. Add GNP to informer cache and reconcile proceeds cleanly
+	err = f.controller.gkeNetworkParamsInformer.Informer().GetStore().Add(f.gnp)
+	assert.NoError(t, err)
+
+	err = f.controller.reconcile(ctx, f.gnp.Name)
+	assert.NoError(t, err)
 }

--- a/pkg/controller/service/controller.go
+++ b/pkg/controller/service/controller.go
@@ -29,6 +29,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -41,6 +43,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	cloudprovider "k8s.io/cloud-provider"
+	consistencyutil "k8s.io/cloud-provider-gcp/pkg/controller/util/consistency"
 	"k8s.io/cloud-provider/api"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/component-base/featuregate"
@@ -97,6 +100,8 @@ type Controller struct {
 	// service and node controllers, hence it is protected by a lock.
 	lastSyncedNodes     map[string][]*v1.Node
 	lastSyncedNodesLock sync.Mutex
+
+	consistencyStore consistencyutil.ConsistencyStore
 }
 
 // New returns a new service controller to keep cloud provider service resources
@@ -110,6 +115,14 @@ func New(
 	featureGate featuregate.FeatureGate,
 ) (*Controller, error) {
 	registerMetrics()
+
+	serviceGroupResource := schema.GroupResource{Group: "", Resource: "services"}
+	nodeGroupResource := schema.GroupResource{Group: "", Resource: "nodes"}
+
+	consistencyStore := consistencyutil.NewConsistencyStore(map[schema.GroupResource]consistencyutil.LastSyncRVGetter{
+		serviceGroupResource: serviceInformer.Informer().GetStore(),
+		nodeGroupResource:    nodeInformer.Informer().GetStore(),
+	})
 
 	s := &Controller{
 		cloud:            cloud,
@@ -126,7 +139,8 @@ func New(
 			workqueue.NewTypedItemExponentialFailureRateLimiter[string](minRetryDelay, maxRetryDelay),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node"},
 		),
-		lastSyncedNodes: make(map[string][]*v1.Node),
+		lastSyncedNodes:  make(map[string][]*v1.Node),
+		consistencyStore: consistencyStore,
 	}
 
 	if err := s.init(); err != nil {
@@ -150,8 +164,18 @@ func New(
 					s.enqueueService(cur)
 				}
 			},
-			// No need to handle deletion event because the deletion would be handled by
-			// the update path when the deletion timestamp is added.
+			DeleteFunc: func(cur interface{}) {
+				svc, ok := cur.(*v1.Service)
+				if !ok {
+					tombstone, ok := cur.(cache.DeletedFinalStateUnknown)
+					if ok {
+						svc, _ = tombstone.Obj.(*v1.Service)
+					}
+				}
+				if svc != nil {
+					s.consistencyStore.Clear(types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}, svc.UID)
+				}
+			},
 		},
 		serviceSyncPeriod,
 	)
@@ -892,11 +916,22 @@ func (c *Controller) syncService(ctx context.Context, key string) error {
 	if err != nil {
 		return err
 	}
+	namespacedName := types.NamespacedName{Namespace: namespace, Name: name}
+
+	// 1. Ensure the cache is ready (not stale)
+	if err := c.consistencyStore.EnsureReady(namespacedName); err != nil {
+		var consistencyErr *consistencyutil.ConsistencyError
+		if errors.As(err, &consistencyErr) {
+			klog.V(4).Infof("Consistency store not ready for service %s: %v", key, err)
+		}
+		return err
+	}
 
 	// service holds the latest service info from apiserver
 	service, err := c.serviceLister.Services(namespace).Get(name)
 	switch {
 	case apierrors.IsNotFound(err):
+		c.consistencyStore.Clear(namespacedName, "")
 		// service absence in store means watcher caught the deletion, ensure LB info is cleaned
 		err = c.processServiceDeletion(ctx, key)
 	case err != nil:
@@ -953,8 +988,17 @@ func (c *Controller) addFinalizer(service *v1.Service) error {
 	updated.ObjectMeta.Finalizers = append(updated.ObjectMeta.Finalizers, servicehelper.LoadBalancerCleanupFinalizer)
 
 	klog.V(2).Infof("Adding finalizer to service %s/%s", updated.Namespace, updated.Name)
-	_, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
-	return err
+	patched, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
+	if err != nil {
+		return err
+	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Namespace: patched.Namespace, Name: patched.Name},
+		patched.UID,
+		schema.GroupResource{Group: "", Resource: "services"},
+		patched.ResourceVersion,
+	)
+	return nil
 }
 
 // removeFinalizer patches the service to remove finalizer.
@@ -968,8 +1012,17 @@ func (c *Controller) removeFinalizer(service *v1.Service) error {
 	updated.ObjectMeta.Finalizers = removeString(updated.ObjectMeta.Finalizers, servicehelper.LoadBalancerCleanupFinalizer)
 
 	klog.V(2).Infof("Removing finalizer from service %s/%s", updated.Namespace, updated.Name)
-	_, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
-	return err
+	patched, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
+	if err != nil {
+		return err
+	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Namespace: patched.Namespace, Name: patched.Name},
+		patched.UID,
+		schema.GroupResource{Group: "", Resource: "services"},
+		patched.ResourceVersion,
+	)
+	return nil
 }
 
 // removeString returns a newly created []string that contains all items from slice that
@@ -994,8 +1047,17 @@ func (c *Controller) patchStatus(service *v1.Service, previousStatus, newStatus 
 	updated.Status.LoadBalancer = *newStatus
 
 	klog.V(2).Infof("Patching status for service %s/%s", updated.Namespace, updated.Name)
-	_, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
-	return err
+	patched, err := servicehelper.PatchService(c.kubeClient.CoreV1(), service, updated)
+	if err != nil {
+		return err
+	}
+	c.consistencyStore.WroteAt(
+		types.NamespacedName{Namespace: patched.Namespace, Name: patched.Name},
+		patched.UID,
+		schema.GroupResource{Group: "", Resource: "services"},
+		patched.ResourceVersion,
+	)
+	return nil
 }
 
 // NodeConditionPredicate is a function that indicates whether the given node's conditions meet

--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	testingcore "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	cloudprovider "k8s.io/cloud-provider"
+	consistencyutil "k8s.io/cloud-provider-gcp/pkg/controller/util/consistency"
+	"k8s.io/component-base/featuregate"
+)
+
+type fakeRVGetter struct {
+	rv string
+}
+
+func (f *fakeRVGetter) LastStoreSyncResourceVersion() string {
+	return f.rv
+}
+
+func (f *fakeRVGetter) setRV(rv string) {
+	f.rv = rv
+}
+
+type fakeCloud struct {
+	cloudprovider.Interface
+	balancer *fakeBalancer
+}
+
+func (f *fakeCloud) ProviderName() string {
+	return "fake"
+}
+
+func (f *fakeCloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	return f.balancer, true
+}
+
+type fakeBalancer struct {
+	cloudprovider.LoadBalancer
+}
+
+func (b *fakeBalancer) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	return &v1.LoadBalancerStatus{}, true, nil
+}
+
+func (b *fakeBalancer) EnsureLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	return &v1.LoadBalancerStatus{
+		Ingress: []v1.LoadBalancerIngress{{IP: "1.2.3.4"}},
+	}, nil
+}
+
+func (b *fakeBalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
+	return nil
+}
+
+func (b *fakeBalancer) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	return nil
+}
+
+type serviceTestFixture struct {
+	controller       *Controller
+	serviceGetter    *fakeRVGetter
+	nodeGetter       *fakeRVGetter
+	consistencyStore consistencyutil.ConsistencyStore
+	serviceInformer  coreinformers.ServiceInformer
+	kubeClient       *fake.Clientset
+	service          *v1.Service
+}
+
+func setupServiceTestFixture() *serviceTestFixture {
+	lbClass := "networking.gke.io/l4-regional-external-legacy"
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "test-service",
+			UID:             types.UID("svc-uid-1"),
+			ResourceVersion: "1",
+		},
+		Spec: v1.ServiceSpec{
+			Type:              v1.ServiceTypeLoadBalancer,
+			LoadBalancerClass: &lbClass,
+		},
+	}
+
+	kubeClient := fake.NewSimpleClientset(service)
+	kubeClient.PrependReactor("patch", "services", func(action testingcore.Action) (handled bool, ret runtime.Object, err error) {
+		svc := service.DeepCopy()
+		svc.ResourceVersion = "2"
+		return true, svc, nil
+	})
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0*time.Second)
+	serviceInformer := informerFactory.Core().V1().Services()
+	nodeInformer := informerFactory.Core().V1().Nodes()
+
+	cloud := &fakeCloud{balancer: &fakeBalancer{}}
+	controller, err := New(
+		cloud,
+		kubeClient,
+		serviceInformer,
+		nodeInformer,
+		"test-cluster",
+		featuregate.NewFeatureGate(),
+	)
+	if err != nil {
+		panic(err)
+	}
+	controller.eventRecorder = record.NewFakeRecorder(100)
+
+	serviceGetter := &fakeRVGetter{rv: "1"}
+	nodeGetter := &fakeRVGetter{rv: "1"}
+	consistencyStore := consistencyutil.NewConsistencyStore(map[schema.GroupResource]consistencyutil.LastSyncRVGetter{
+		{Group: "", Resource: "services"}: serviceGetter,
+		{Group: "", Resource: "nodes"}:    nodeGetter,
+	})
+	controller.consistencyStore = consistencyStore
+
+	return &serviceTestFixture{
+		controller:       controller,
+		serviceGetter:    serviceGetter,
+		nodeGetter:       nodeGetter,
+		consistencyStore: consistencyStore,
+		serviceInformer:  serviceInformer,
+		kubeClient:       kubeClient,
+		service:          service,
+	}
+}
+
+func TestServiceController_ConsistencyStoreStallsUntilInformerCatchesUp(t *testing.T) {
+	f := setupServiceTestFixture()
+	ctx := context.Background()
+	key := "default/test-service"
+	namespacedName := types.NamespacedName{Namespace: "default", Name: "test-service"}
+
+	// 1. Initially consistent
+	require.NoError(t, f.consistencyStore.EnsureReady(namespacedName))
+
+	// 2. Add finalizer which mutates service and tracks write
+	err := f.controller.addFinalizer(f.service)
+	require.NoError(t, err)
+
+	// 3. Reconciler stalls because informer is still at RV "1"
+	err = f.controller.syncService(ctx, key)
+	assert.Error(t, err)
+	assert.Error(t, f.consistencyStore.EnsureReady(namespacedName))
+
+	// 4. Advance informer RV to catch up
+	f.serviceGetter.setRV("2")
+	assert.NoError(t, f.consistencyStore.EnsureReady(namespacedName))
+
+	// 5. Populate service in informer store and reconcile proceeds
+	f.service.ResourceVersion = "2"
+	f.service.Finalizers = []string{"service.k8s.io/load-balancer-cleanup"}
+	err = f.serviceInformer.Informer().GetStore().Add(f.service)
+	require.NoError(t, err)
+
+	err = f.controller.syncService(ctx, key)
+	assert.NoError(t, err)
+}

--- a/pkg/controller/util/consistency/consistency.go
+++ b/pkg/controller/util/consistency/consistency.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consistency
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// LastSyncRVGetter is an interface for retrieving the latest resource version that the store has seen.
+// cache.Store in client-go implements this interface via LastStoreSyncResourceVersion().
+type LastSyncRVGetter interface {
+	LastStoreSyncResourceVersion() string
+}
+
+// ConsistencyError is returned by EnsureReady when the store's sync resource version lags behind the expected resource version.
+type ConsistencyError struct {
+	Key           types.NamespacedName
+	GroupResource schema.GroupResource
+	ExpectedRV    string
+	ActualRV      string
+}
+
+func (e *ConsistencyError) Error() string {
+	return fmt.Sprintf("cache for %s (%s) is stale: expected RV >= %s, got %s", e.Key, e.GroupResource, e.ExpectedRV, e.ActualRV)
+}
+
+// ConsistencyStore tracks writes to resources and checks whether informers have observed them.
+type ConsistencyStore interface {
+	// WroteAt records that the resource identified by key, uid, and gr was written at resourceVersion.
+	WroteAt(key types.NamespacedName, uid types.UID, gr schema.GroupResource, resourceVersion string)
+	// EnsureReady returns an error if any tracked resource for key is not yet reflected in the informer cache.
+	EnsureReady(key types.NamespacedName) error
+	// Clear removes tracked resource versions for key (and optionally uid).
+	Clear(key types.NamespacedName, uid types.UID)
+}
+
+type resourceExpectation struct {
+	uid types.UID
+	rv  string
+}
+
+type consistencyStoreImpl struct {
+	mu           sync.RWMutex
+	getters      map[schema.GroupResource]LastSyncRVGetter
+	expectations map[types.NamespacedName]map[schema.GroupResource]resourceExpectation
+}
+
+// NewConsistencyStore returns a new ConsistencyStore initialized with the given LastSyncRVGetters.
+func NewConsistencyStore(getters map[schema.GroupResource]LastSyncRVGetter) ConsistencyStore {
+	storeGetters := make(map[schema.GroupResource]LastSyncRVGetter, len(getters))
+	for gr, getter := range getters {
+		storeGetters[gr] = getter
+	}
+	return &consistencyStoreImpl{
+		getters:      storeGetters,
+		expectations: make(map[types.NamespacedName]map[schema.GroupResource]resourceExpectation),
+	}
+}
+
+// WroteAt records that a write was performed for the specified resource.
+func (s *consistencyStoreImpl) WroteAt(key types.NamespacedName, uid types.UID, gr schema.GroupResource, resourceVersion string) {
+	if resourceVersion == "" || resourceVersion == "0" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	expMap, ok := s.expectations[key]
+	if !ok {
+		expMap = make(map[schema.GroupResource]resourceExpectation)
+		s.expectations[key] = expMap
+	}
+
+	existing, exists := expMap[gr]
+	if exists && existing.uid == uid {
+		if isRVNewer(resourceVersion, existing.rv) {
+			expMap[gr] = resourceExpectation{uid: uid, rv: resourceVersion}
+		}
+	} else {
+		expMap[gr] = resourceExpectation{uid: uid, rv: resourceVersion}
+	}
+}
+
+// EnsureReady checks whether the stores associated with the key have observed the required resource versions.
+func (s *consistencyStoreImpl) EnsureReady(key types.NamespacedName) error {
+	s.mu.RLock()
+	expMap, ok := s.expectations[key]
+	if !ok || len(expMap) == 0 {
+		s.mu.RUnlock()
+		return nil
+	}
+
+	for gr, exp := range expMap {
+		getter, hasGetter := s.getters[gr]
+		if !hasGetter || getter == nil {
+			continue
+		}
+		actualRV := getter.LastStoreSyncResourceVersion()
+		if !isStoreReady(actualRV, exp.rv) {
+			s.mu.RUnlock()
+			return &ConsistencyError{
+				Key:           key,
+				GroupResource: gr,
+				ExpectedRV:    exp.rv,
+				ActualRV:      actualRV,
+			}
+		}
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if expMap, ok := s.expectations[key]; ok {
+		for gr, exp := range expMap {
+			getter, hasGetter := s.getters[gr]
+			if hasGetter && getter != nil {
+				if isStoreReady(getter.LastStoreSyncResourceVersion(), exp.rv) {
+					delete(expMap, gr)
+				}
+			}
+		}
+		if len(expMap) == 0 {
+			delete(s.expectations, key)
+		}
+	}
+
+	return nil
+}
+
+// Clear removes recorded resource version expectations for the specified key and optional uid.
+func (s *consistencyStoreImpl) Clear(key types.NamespacedName, uid types.UID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if uid == "" {
+		delete(s.expectations, key)
+		return
+	}
+
+	expMap, ok := s.expectations[key]
+	if !ok {
+		return
+	}
+
+	for gr, exp := range expMap {
+		if exp.uid == uid {
+			delete(expMap, gr)
+		}
+	}
+	if len(expMap) == 0 {
+		delete(s.expectations, key)
+	}
+}
+
+func isStoreReady(storeRV, expectedRV string) bool {
+	if expectedRV == "" || expectedRV == "0" {
+		return true
+	}
+	if storeRV == "" {
+		return false
+	}
+	storeNum, err1 := strconv.ParseUint(storeRV, 10, 64)
+	expNum, err2 := strconv.ParseUint(expectedRV, 10, 64)
+	if err1 == nil && err2 == nil {
+		return storeNum >= expNum
+	}
+	return storeRV == expectedRV
+}
+
+func isRVNewer(newRV, oldRV string) bool {
+	newNum, err1 := strconv.ParseUint(newRV, 10, 64)
+	oldNum, err2 := strconv.ParseUint(oldRV, 10, 64)
+	if err1 == nil && err2 == nil {
+		return newNum > oldNum
+	}
+	return newRV != oldRV
+}

--- a/pkg/controller/util/consistency/consistency_test.go
+++ b/pkg/controller/util/consistency/consistency_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consistency
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type fakeRVGetter struct {
+	mu sync.RWMutex
+	rv string
+}
+
+func (f *fakeRVGetter) LastStoreSyncResourceVersion() string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.rv
+}
+
+func (f *fakeRVGetter) setRV(rv string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rv = rv
+}
+
+func TestConsistencyStore_BasicReadinessAndStall(t *testing.T) {
+	nodeGR := schema.GroupResource{Group: "", Resource: "nodes"}
+	getter := &fakeRVGetter{rv: "100"}
+	store := NewConsistencyStore(map[schema.GroupResource]LastSyncRVGetter{
+		nodeGR: getter,
+	})
+
+	key := types.NamespacedName{Name: "node-1"}
+
+	// 1. Initial state is ready since no writes recorded
+	require.NoError(t, store.EnsureReady(key))
+
+	// 2. Record a write at RV 105
+	store.WroteAt(key, types.UID("uid-1"), nodeGR, "105")
+
+	// 3. EnsureReady should return a ConsistencyError because store is at RV 100 < 105
+	err := store.EnsureReady(key)
+	require.Error(t, err)
+	var consistencyErr *ConsistencyError
+	require.True(t, errors.As(err, &consistencyErr))
+	assert.Equal(t, key, consistencyErr.Key)
+	assert.Equal(t, nodeGR, consistencyErr.GroupResource)
+	assert.Equal(t, "105", consistencyErr.ExpectedRV)
+	assert.Equal(t, "100", consistencyErr.ActualRV)
+
+	// 4. Advance getter RV to 105 (caught up)
+	getter.setRV("105")
+	assert.NoError(t, store.EnsureReady(key))
+
+	// 5. Subsequent EnsureReady remains ready (expectations satisfied and cleared)
+	assert.NoError(t, store.EnsureReady(key))
+}
+
+func TestConsistencyStore_MultipleResourcesForSameKey(t *testing.T) {
+	gnpGR := schema.GroupResource{Group: "networking.gke.io", Resource: "gkenetworkparamsets"}
+	netGR := schema.GroupResource{Group: "networking.gke.io", Resource: "networks"}
+
+	gnpGetter := &fakeRVGetter{rv: "10"}
+	netGetter := &fakeRVGetter{rv: "20"}
+
+	store := NewConsistencyStore(map[schema.GroupResource]LastSyncRVGetter{
+		gnpGR: gnpGetter,
+		netGR: netGetter,
+	})
+
+	key := types.NamespacedName{Name: "default"}
+
+	// Record write for both GNP and Network
+	store.WroteAt(key, types.UID("gnp-uid"), gnpGR, "15")
+	store.WroteAt(key, types.UID("net-uid"), netGR, "25")
+
+	// Neither is ready
+	err := store.EnsureReady(key)
+	require.Error(t, err)
+
+	// Catch up GNP only
+	gnpGetter.setRV("15")
+	err = store.EnsureReady(key)
+	require.Error(t, err)
+	var cErr *ConsistencyError
+	require.True(t, errors.As(err, &cErr))
+	assert.Equal(t, netGR, cErr.GroupResource)
+
+	// Catch up Network
+	netGetter.setRV("30")
+	assert.NoError(t, store.EnsureReady(key))
+}
+
+func TestConsistencyStore_Clear(t *testing.T) {
+	nodeGR := schema.GroupResource{Group: "", Resource: "nodes"}
+	getter := &fakeRVGetter{rv: "10"}
+	store := NewConsistencyStore(map[schema.GroupResource]LastSyncRVGetter{
+		nodeGR: getter,
+	})
+
+	key := types.NamespacedName{Name: "node-1"}
+
+	// Record write with UID
+	store.WroteAt(key, types.UID("uid-1"), nodeGR, "20")
+	require.Error(t, store.EnsureReady(key))
+
+	// Clear with mismatched UID should not clear
+	store.Clear(key, types.UID("other-uid"))
+	require.Error(t, store.EnsureReady(key))
+
+	// Clear with matching UID should clear
+	store.Clear(key, types.UID("uid-1"))
+	assert.NoError(t, store.EnsureReady(key))
+
+	// Record write again and Clear with empty UID should clear unconditionally
+	store.WroteAt(key, types.UID("uid-2"), nodeGR, "30")
+	require.Error(t, store.EnsureReady(key))
+	store.Clear(key, "")
+	assert.NoError(t, store.EnsureReady(key))
+}
+
+func TestConsistencyStore_NonNumericRV(t *testing.T) {
+	nodeGR := schema.GroupResource{Group: "", Resource: "nodes"}
+	getter := &fakeRVGetter{rv: "abc"}
+	store := NewConsistencyStore(map[schema.GroupResource]LastSyncRVGetter{
+		nodeGR: getter,
+	})
+
+	key := types.NamespacedName{Name: "node-1"}
+
+	store.WroteAt(key, types.UID("uid-1"), nodeGR, "xyz")
+	require.Error(t, store.EnsureReady(key))
+
+	getter.setRV("xyz")
+	assert.NoError(t, store.EnsureReady(key))
+}
+
+func TestConsistencyStore_ConcurrentAccess(t *testing.T) {
+	nodeGR := schema.GroupResource{Group: "", Resource: "nodes"}
+	getter := &fakeRVGetter{rv: "0"}
+	store := NewConsistencyStore(map[schema.GroupResource]LastSyncRVGetter{
+		nodeGR: getter,
+	})
+
+	key := types.NamespacedName{Name: "node-1"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(3)
+		go func(val int) {
+			defer wg.Done()
+			store.WroteAt(key, types.UID("uid-1"), nodeGR, "10")
+		}(i)
+		go func(val int) {
+			defer wg.Done()
+			_ = store.EnsureReady(key)
+		}(i)
+		go func(val int) {
+			defer wg.Done()
+			store.Clear(key, types.UID("uid-1"))
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Integrates controllers in `cloud-provider-gcp` with the `ConsistencyStore` cache staleness mitigation framework to prevent race conditions and transient regressions caused by informer cache lag after API server mutations.

- Implements `pkg/controller/util/consistency` with `ConsistencyStore`, `LastSyncRVGetter`, `ConsistencyError`, and thread-safe operations.
- Updates `GKENetworkParamSetController` to stall on cache lag and track mutation resource versions across `gkenetworkparamsets` and `networks` stores.
- Updates `GKEServiceController` to stall on cache lag and track mutation resource versions across `services` and `nodes` stores.
- Adds unit test suites with test fixtures verifying stall and catch-up workflows.

#### Which issue(s) this PR fixes:
Fixes #1329 

