### PR TITLE
Move NodeNetworkConfig CR creation to Cloud CIDR Allocator in CCM

### DIFF
--- a/cmd/cloud-controller-manager/gketenantcontrollermanager.go
+++ b/cmd/cloud-controller-manager/gketenantcontrollermanager.go
@@ -12,6 +12,7 @@ import (
 	providerconfigcr "github.com/GoogleCloudPlatform/gke-enterprise-mt/pkg/providerconfigcr"
 	networkclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned"
 	networkinformers "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	topologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -82,6 +83,11 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 	nodeTopologyClient, err := topologyclientset.NewForConfig(clientConfig)
 	if err != nil {
 		klog.Errorf("Failed to create topology client: %v", err)
+		return nil, nil, false, err
+	}
+	nncClient, err := nncclientset.NewForConfig(clientConfig)
+	if err != nil {
+		klog.Errorf("Failed to create nnc client: %v", err)
 		return nil, nil, false, err
 	}
 
@@ -168,6 +174,7 @@ func startGKETenantControllerManager(mgrCfg gkeTenantControllerManagerConfig) (c
 				networkInformer,
 				gnpInformer,
 				nodeTopologyClient,
+				nncClient,
 				ipam.CIDRAllocatorType(mgrCfg.completedConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType),
 				cfg.ControllerContext.ControllerManagerMetrics,
 				defaultNetworkName,

--- a/cmd/cloud-controller-manager/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/nodeipamcontroller.go
@@ -22,6 +22,7 @@ import (
 
 	networkclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/network/clientset/versioned"
 	networkinformers "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	nodetopologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
@@ -66,6 +67,10 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 	if err != nil {
 		return nil, false, err
 	}
+	nncClient, err := nncclientset.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, false, err
+	}
 
 	nwInfFactory := networkinformers.NewSharedInformerFactory(networkClient, 30*time.Second)
 	nwInformer := nwInfFactory.Networking().V1().Networks()
@@ -87,6 +92,7 @@ func startNodeIpamController(ccmConfig *cloudcontrollerconfig.CompletedConfig, n
 		nwInformer,
 		gnpInformer,
 		nodeTopologyClient,
+		nncClient,
 		ipam.CIDRAllocatorType(ccmConfig.ComponentConfig.KubeCloudShared.CIDRAllocatorType),
 		ctx.ControllerManagerMetrics,
 		"",

--- a/cmd/cloud-controller-manager/options/nodeipamcontroller.go
+++ b/cmd/cloud-controller-manager/options/nodeipamcontroller.go
@@ -41,6 +41,7 @@ func (o *NodeIPAMControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&o.NodeCIDRMaskSizeIPv6, "node-cidr-mask-size-ipv6", o.NodeCIDRMaskSizeIPv6, "Mask size for IPv6 node cidr in dual-stack cluster. Default is 64.")
 	fs.BoolVar(&o.EnableMultiSubnetCluster, "enable-multi-subnet-cluster", o.EnableMultiSubnetCluster, "Enabled multi-subnet cluster feature. This enables generating updated nodeTopology custom resource. ")
 	fs.BoolVar(&o.EnableMultiNetworking, "enable-multi-networking", o.EnableMultiNetworking, "Enabled multi-networking related logics such as multi-networking IPAM.")
+	fs.BoolVar(&o.EnableNodeNetworkConfig, "enable-node-network-config", o.EnableNodeNetworkConfig, "Enabled node network config feature. This enables generating nodeNetworkConfig custom resource for each node.")
 }
 
 // ApplyTo fills up NodeIpamController config with options.
@@ -63,6 +64,7 @@ func (o *NodeIPAMControllerOptions) ApplyTo(cfg *nodeipamconfig.NodeIPAMControll
 	cfg.NodeCIDRMaskSizeIPv6 = o.NodeCIDRMaskSizeIPv6
 	cfg.EnableMultiSubnetCluster = o.EnableMultiSubnetCluster
 	cfg.EnableMultiNetworking = o.EnableMultiNetworking
+	cfg.EnableNodeNetworkConfig = o.EnableNodeNetworkConfig
 
 	return nil
 }

--- a/pkg/controller/nodeipam/config/types.go
+++ b/pkg/controller/nodeipam/config/types.go
@@ -40,4 +40,7 @@ type NodeIPAMControllerConfiguration struct {
 	// when the cluster-level "enable-multi-networking" flag is true to enable
 	// the multi-networking related logics such as multi-networking IPAM.
 	EnableMultiNetworking bool
+	// EnableNodeNetworkConfig is bound to a command-line flag. When true, it enables
+	// generating NodeNetworkConfig custom resource for each node.
+	EnableNodeNetworkConfig bool
 }

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	networkinformer "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	nodetopologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	"k8s.io/klog/v2"
 
@@ -117,7 +118,7 @@ type CIDRAllocatorParams struct {
 }
 
 // New creates a new CIDR range allocator.
-func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, enableMultiSubnetCluster bool, enableMultiNetworking bool, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
+func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, nncClient nncclientset.Interface, enableMultiSubnetCluster bool, enableMultiNetworking bool, enableNodeNetworkConfig bool, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
 	nodeList, err := listNodes(kubeClient)
 	if err != nil {
 		return nil, err
@@ -127,7 +128,7 @@ func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInfo
 	case RangeAllocatorType:
 		return NewCIDRRangeAllocator(kubeClient, nodeInformer, allocatorParams, nodeList)
 	case CloudAllocatorType:
-		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, enableMultiNetworking, nodeInformer, allocatorParams)
+		return NewCloudCIDRAllocator(kubeClient, cloud, nwInformer, gnpInformer, nodeTopologyClient, nncClient, enableMultiSubnetCluster, enableMultiNetworking, enableNodeNetworkConfig, nodeInformer, allocatorParams)
 	default:
 		return nil, fmt.Errorf("invalid CIDR allocator type: %v", allocatorType)
 	}

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go
@@ -37,6 +37,7 @@ import (
 
 	networkinformer "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
 	networklister "github.com/GoogleCloudPlatform/gke-networking-api/client/network/listers/network/v1"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	nodetopologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -79,6 +80,10 @@ const (
 // nodeTopology CR named 'default' is already installed.
 var enableNodeTopology bool
 
+// enableNodeNetworkConfig is bound to a command-line flag. When true, it enables
+// generating NodeNetworkConfig custom resource for each node.
+var enableNodeNetworkConfig bool
+
 // cloudCIDRAllocator allocates node CIDRs according to IP address aliases
 // assigned by the cloud provider. In this case, the allocation and
 // deallocation is delegated to the external provider, and the controller
@@ -100,9 +105,11 @@ type cloudCIDRAllocator struct {
 	networksSynced cache.InformerSynced
 	gnpsSynced     cache.InformerSynced
 
-	recorder          record.EventRecorder
-	queue             workqueue.RateLimitingInterface
-	nodeTopologyQueue *TaskQueue
+	recorder               record.EventRecorder
+	queue                  workqueue.RateLimitingInterface
+	nodeTopologyQueue      *TaskQueue
+	nodeNetworkConfigQueue *TaskQueue
+	nncClient              nncclientset.Interface
 
 	stackType             clusterStackType
 	enableMultiNetworking bool
@@ -112,7 +119,7 @@ type cloudCIDRAllocator struct {
 var _ CIDRAllocator = (*cloudCIDRAllocator)(nil)
 
 // NewCloudCIDRAllocator creates a new cloud CIDR allocator.
-func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Interface, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, enableMultiSubnetCluster bool, enableMultiNetworking bool, nodeInformer informers.NodeInformer, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
+func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Interface, nwInformer networkinformer.NetworkInformer, gnpInformer networkinformer.GKENetworkParamSetInformer, nodeTopologyClient nodetopologyclientset.Interface, nncClient nncclientset.Interface, enableMultiSubnetCluster bool, enableMultiNetworking bool, enableNNC bool, nodeInformer informers.NodeInformer, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
 	if client == nil {
 		klog.Fatalf("kubeClient is nil when starting NodeController")
 	}
@@ -164,6 +171,7 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 		stackType:             stackType,
 		enableMultiNetworking: enableMultiNetworking,
 		defaultNetworkName:    allocatorParams.DefaultNetworkName,
+		nncClient:             nncClient,
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -208,6 +216,23 @@ func NewCloudCIDRAllocator(client clientset.Interface, cloud cloudprovider.Inter
 			UpdateFunc: nodeutil.CreateUpdateNodeHandler(ca.updateUniqueNode),
 			DeleteFunc: nodeutil.CreateDeleteNodeHandler(func(node *v1.Node) error {
 				nodetopologyQueue.Enqueue(node)
+				return nil
+			}),
+		})
+	}
+
+	enableNodeNetworkConfig = enableNNC
+	if enableNodeNetworkConfig {
+		nncSyncer := NewNodeNetworkConfigSyncer(nncClient, nodeInformer.Lister())
+		ca.nodeNetworkConfigQueue = NewTaskQueue("nodeNetworkConfigTaskQueue", "nodeNetworkConfigCRD", nodeNetworkConfigWorkers, nodeNetworkConfigKeyFun, nncSyncer.sync)
+
+		nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: nodeutil.CreateAddNodeHandler(func(node *v1.Node) error {
+				ca.nodeNetworkConfigQueue.Enqueue(node)
+				return nil
+			}),
+			UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node) error {
+				ca.nodeNetworkConfigQueue.Enqueue(newNode)
 				return nil
 			}),
 		})
@@ -333,6 +358,13 @@ func (ca *cloudCIDRAllocator) Run(stopCh <-chan struct{}) {
 				},
 				nodeTopologyReconcileInterval, stopCh)
 		}()
+	}
+
+	if enableNodeNetworkConfig {
+		if ca.nodeNetworkConfigQueue != nil {
+			defer ca.nodeNetworkConfigQueue.Shutdown()
+			ca.nodeNetworkConfigQueue.Run()
+		}
 	}
 
 	<-stopCh

--- a/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/cloud_cidr_allocator_test.go
@@ -192,7 +192,7 @@ func TestNodeTopologyQueuePeriodicSync(t *testing.T) {
 	allocatorParams := CIDRAllocatorParams{}
 
 	KuberntesClientSet := fake.NewSimpleClientset()
-	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, true, false, fakeNodeInformer, allocatorParams)
+	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, nil, true, false, false, fakeNodeInformer, allocatorParams)
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 	cloudAllocator.nodeTopologyQueue.Run()
 
@@ -282,7 +282,7 @@ func TestNodeTopologyCR_AddOrUpdateNode(t *testing.T) {
 	allocatorParams := CIDRAllocatorParams{}
 
 	KuberntesClientSet := fake.NewSimpleClientset()
-	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, true, false, fakeNodeInformer, allocatorParams)
+	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, nil, true, false, false, fakeNodeInformer, allocatorParams)
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	stopCh := make(chan struct{})
@@ -376,7 +376,7 @@ func TestNodeTopologyCR_DeleteNode(t *testing.T) {
 	allocatorParams := CIDRAllocatorParams{}
 
 	KuberntesClientSet := fake.NewSimpleClientset()
-	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, true, false, fakeNodeInformer, allocatorParams)
+	ca, _ := NewCloudCIDRAllocator(KuberntesClientSet, fakeGCE, nwInformer, gnpInformer, nodeTopologyClient, nil, true, false, false, fakeNodeInformer, allocatorParams)
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	stopCh := make(chan struct{})

--- a/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
+++ b/pkg/controller/nodeipam/ipam/multinetwork_cloud_cidr_allocator_test.go
@@ -476,7 +476,7 @@ func TestDefaultNetworkCIDRs_IPv4Only(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), nil, false, true, false, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -565,7 +565,7 @@ func TestDefaultNetworkCIDRs_DualStack_NoLabels(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), nil, false, true, false, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -656,7 +656,7 @@ func TestDefaultNetworkCIDRs_DualStack_WithLabels(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), nil, false, true, false, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -748,7 +748,7 @@ func TestDefaultNetworkCIDRs_IPv6Only(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), nil, false, true, false, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{
@@ -815,7 +815,7 @@ func TestDefaultNetworkCIDRs_DefaultNetworkNotUp(t *testing.T) {
 	k8sInformerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	nodeInformer := k8sInformerFactory.Core().V1().Nodes()
 
-	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), false, true, nodeInformer, CIDRAllocatorParams{})
+	ca, _ := NewCloudCIDRAllocator(kubeClient, fakeGCE, nwInfFactory.V1().Networks(), nwInfFactory.V1().GKENetworkParamSets(), ntfakeclient.NewSimpleClientset(), nil, false, true, false, nodeInformer, CIDRAllocatorParams{})
 	cloudAllocator, _ := ca.(*cloudCIDRAllocator)
 
 	node := &v1.Node{

--- a/pkg/controller/nodeipam/ipam/node_network_config_syncer.go
+++ b/pkg/controller/nodeipam/ipam/node_network_config_syncer.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+
+	nncv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodenetworkconfig/v1"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+var (
+	// nodeNetworkConfigKeyFun maps node to a namespaced name as key for the task queue.
+	nodeNetworkConfigKeyFun = cache.DeletionHandlingMetaNamespaceKeyFunc
+)
+
+const (
+	// The no. of workers in parallel to update nodenetworkconfig CR
+	nodeNetworkConfigWorkers = 30
+)
+
+// NodeNetworkConfigSyncer processes nodenetworkconfig CR based on node add/update events.
+type NodeNetworkConfigSyncer struct {
+	nncClient  nncclientset.Interface
+	nodeLister corelisters.NodeLister
+}
+
+// NewNodeNetworkConfigSyncer creates a new NodeNetworkConfigSyncer.
+func NewNodeNetworkConfigSyncer(nncClient nncclientset.Interface, nodeLister corelisters.NodeLister) *NodeNetworkConfigSyncer {
+	return &NodeNetworkConfigSyncer{
+		nncClient:  nncClient,
+		nodeLister: nodeLister,
+	}
+}
+
+func (syncer *NodeNetworkConfigSyncer) sync(key string) error {
+	klog.V(4).InfoS("Syncing node network config CR for node", "key", key)
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		klog.ErrorS(err, "Failed to split namespace key", "key", key)
+		return nil
+	}
+	return syncer.ensureNodeNetworkConfig(name)
+}
+
+// ensureNodeNetworkConfig creates the NodeNetworkConfig CR for nodeName if it does not exist.
+func (syncer *NodeNetworkConfigSyncer) ensureNodeNetworkConfig(nodeName string) error {
+	ctx := context.Background()
+	_, err := syncer.nncClient.NetworkingV1().NodeNetworkConfigs().Get(ctx, nodeName, metav1.GetOptions{})
+	if err == nil {
+		return nil // Already exists
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to get NodeNetworkConfig for node %s: %w", nodeName, err)
+	}
+
+	node, err := syncer.nodeLister.Get(nodeName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Node deleted, nothing to do
+			return nil
+		}
+		return fmt.Errorf("failed to get node %s for owner reference: %w", nodeName, err)
+	}
+
+	isController := true
+	nnc := &nncv1.NodeNetworkConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "Node",
+					Name:       nodeName,
+					UID:        node.UID,
+					Controller: &isController,
+				},
+			},
+		},
+		Spec: nncv1.NodeNetworkConfigSpec{},
+	}
+	_, err = syncer.nncClient.NetworkingV1().NodeNetworkConfigs().Create(ctx, nnc, metav1.CreateOptions{})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			klog.V(2).Infof("NodeNetworkConfig was created concurrently for node %s", nodeName)
+			return nil
+		}
+		return fmt.Errorf("failed to create NodeNetworkConfig for node %s: %w", nodeName, err)
+	}
+	klog.V(2).Infof("Successfully created NodeNetworkConfig CR with owner reference to Node %s", nodeName)
+	return nil
+}

--- a/pkg/controller/nodeipam/ipam/node_network_config_syncer_test.go
+++ b/pkg/controller/nodeipam/ipam/node_network_config_syncer_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"context"
+	"testing"
+
+	nncv1 "github.com/GoogleCloudPlatform/gke-networking-api/apis/nodenetworkconfig/v1"
+	nncfake "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned/fake"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestNodeNetworkConfigSyncer_EnsureNodeNetworkConfig(t *testing.T) {
+	nodeName := "test-node-1"
+	testNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+			UID:  "test-node-uid-12345",
+		},
+	}
+
+	tests := []struct {
+		desc          string
+		existingNodes []*v1.Node
+		existingNNCs  []*nncv1.NodeNetworkConfig
+		syncKey       string
+		wantErr       bool
+		verifyNNC     bool
+		wantOwnerUID  string
+	}{
+		{
+			desc:          "create new NodeNetworkConfig CR when node exists and CR does not exist",
+			existingNodes: []*v1.Node{testNode},
+			existingNNCs:  nil,
+			syncKey:       nodeName,
+			wantErr:       false,
+			verifyNNC:     true,
+			wantOwnerUID:  "test-node-uid-12345",
+		},
+		{
+			desc:          "do nothing when NodeNetworkConfig CR already exists",
+			existingNodes: []*v1.Node{testNode},
+			existingNNCs: []*nncv1.NodeNetworkConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nodeName,
+					},
+				},
+			},
+			syncKey:      nodeName,
+			wantErr:      false,
+			verifyNNC:    true,
+			wantOwnerUID: "",
+		},
+		{
+			desc:          "do nothing when node does not exist in lister",
+			existingNodes: nil,
+			existingNNCs:  nil,
+			syncKey:       "non-existent-node",
+			wantErr:       false,
+			verifyNNC:     false,
+		},
+		{
+			desc:          "sync with namespaced key works correctly",
+			existingNodes: []*v1.Node{testNode},
+			existingNNCs:  nil,
+			syncKey:       "default/" + nodeName,
+			wantErr:       false,
+			verifyNNC:     true,
+			wantOwnerUID:  "test-node-uid-12345",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			var k8sObjs []runtime.Object
+			for _, n := range tc.existingNodes {
+				k8sObjs = append(k8sObjs, n)
+			}
+			kubeClient := fake.NewSimpleClientset(k8sObjs...)
+			informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
+			nodeInformer := informerFactory.Core().V1().Nodes()
+			for _, n := range tc.existingNodes {
+				nodeInformer.Informer().GetStore().Add(n)
+			}
+
+			var nncObjs []runtime.Object
+			for _, nnc := range tc.existingNNCs {
+				nncObjs = append(nncObjs, nnc)
+			}
+			nncClient := nncfake.NewSimpleClientset(nncObjs...)
+
+			syncer := NewNodeNetworkConfigSyncer(nncClient, nodeInformer.Lister())
+
+			err := syncer.sync(tc.syncKey)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("sync(%q) error = %v, wantErr = %v", tc.syncKey, err, tc.wantErr)
+			}
+
+			if tc.verifyNNC {
+				nnc, err := nncClient.NetworkingV1().NodeNetworkConfigs().Get(context.Background(), nodeName, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get NodeNetworkConfig CR: %v", err)
+				}
+				if nnc.Name != nodeName {
+					t.Errorf("NodeNetworkConfig name = %s, want %s", nnc.Name, nodeName)
+				}
+				if tc.wantOwnerUID != "" {
+					if len(nnc.OwnerReferences) == 0 || string(nnc.OwnerReferences[0].UID) != tc.wantOwnerUID {
+						t.Errorf("NodeNetworkConfig owner reference UID mismatch, got %#v", nnc.OwnerReferences)
+					}
+					if nnc.OwnerReferences[0].Kind != "Node" {
+						t.Errorf("NodeNetworkConfig owner reference Kind = %s, want Node", nnc.OwnerReferences[0].Kind)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -25,6 +25,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	networkinformer "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	nodetopologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -84,8 +85,10 @@ func NewNodeIpamController(
 	nwInformer networkinformer.NetworkInformer,
 	gnpInformer networkinformer.GKENetworkParamSetInformer,
 	nodeTopologyClient nodetopologyclientset.Interface,
+	nncClient nncclientset.Interface,
 	enableMultiSubnetCluster bool,
 	enableMultiNetworking bool,
+	enableNodeNetworkConfig bool,
 	clusterCIDRs []*net.IPNet,
 	serviceCIDR *net.IPNet,
 	secondaryServiceCIDR *net.IPNet,
@@ -144,7 +147,7 @@ func NewNodeIpamController(
 			DefaultNetworkName:   defaultNetworkName,
 		}
 
-		ic.cidrAllocator, err = ipam.New(kubeClient, cloud, nodeInformer, nwInformer, gnpInformer, nodeTopologyClient, enableMultiSubnetCluster, enableMultiNetworking, ic.allocatorType, allocatorParams)
+		ic.cidrAllocator, err = ipam.New(kubeClient, cloud, nodeInformer, nwInformer, gnpInformer, nodeTopologyClient, nncClient, enableMultiSubnetCluster, enableMultiNetworking, enableNodeNetworkConfig, ic.allocatorType, allocatorParams)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/nodeipam/node_ipam_controller_test.go
+++ b/pkg/controller/nodeipam/node_ipam_controller_test.go
@@ -62,8 +62,8 @@ func newTestNodeIpamController(clusterCIDR []*net.IPNet, serviceCIDR *net.IPNet,
 	fakeGNPInformer := fakeNwInformerFactory.Networking().V1().GKENetworkParamSets()
 	fakeGCE := gce.NewFakeGCECloud(gce.DefaultTestClusterValues())
 	return NewNodeIpamController(
-		fakeNodeInformer, fakeGCE, clientSet, fakeNwInformer, fakeGNPInformer, nodeTopologyFakeClient,
-		true, false, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType, "",
+		fakeNodeInformer, fakeGCE, clientSet, fakeNwInformer, fakeGNPInformer, nodeTopologyFakeClient, nil,
+		true, false, false, clusterCIDR, serviceCIDR, secondaryServiceCIDR, nodeCIDRMaskSizes, allocatorType, "",
 	)
 }
 

--- a/pkg/controller/nodeipam/starter.go
+++ b/pkg/controller/nodeipam/starter.go
@@ -11,6 +11,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	networkinformer "github.com/GoogleCloudPlatform/gke-networking-api/client/network/informers/externalversions/network/v1"
+	nncclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodenetworkconfig/clientset/versioned"
 	nodetopologyclientset "github.com/GoogleCloudPlatform/gke-networking-api/client/nodetopology/clientset/versioned"
 	cloudprovider "k8s.io/cloud-provider"
 	nodeipamconfig "k8s.io/cloud-provider-gcp/pkg/controller/nodeipam/config"
@@ -43,6 +44,7 @@ func StartNodeIpamController(
 	nwInformer networkinformer.NetworkInformer,
 	gnpInformer networkinformer.GKENetworkParamSetInformer,
 	nodeTopologyClient nodetopologyclientset.Interface,
+	nncClient nncclientset.Interface,
 	cidrAllocatorType ipam.CIDRAllocatorType,
 	controllerManagerMetrics *controllersmetrics.ControllerManagerMetrics,
 	defaultNetworkName string,
@@ -114,8 +116,10 @@ func StartNodeIpamController(
 		nwInformer,
 		gnpInformer,
 		nodeTopologyClient,
+		nncClient,
 		nodeIPAMConfig.EnableMultiSubnetCluster,
 		nodeIPAMConfig.EnableMultiNetworking,
+		nodeIPAMConfig.EnableNodeNetworkConfig,
 		clusterCIDRs,
 		serviceCIDR,
 		secondaryServiceCIDR,


### PR DESCRIPTION
Create NodeNetworkConfig CRs for nodes within CCM using a dedicated TaskQueue syncer behind the `--enable-node-network-config` CLI flag.

When enabled, `cloudCIDRAllocator` initializes a `NodeNetworkConfigSyncer` and task queue to automatically create a NodeNetworkConfig CR for each node (with an OwnerReference pointing to the Node object) upon node creation or update. The workqueue will retry indefinitely, with backoff, until per node CRD is successfully created.

The CRD creation implementation is moved from metis, to support other features that require the same nodenetworkconfig CRD. We will delete the creation logic from metis as a next step.


## Key Changes

### 1. Command-Line Flag & Configuration
* **[`cmd/cloud-controller-manager/options/nodeipamcontroller.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/cmd/cloud-controller-manager/options/nodeipamcontroller.go)**: Added `--enable-node-network-config` CLI flag to `NodeIPAMControllerOptions`.
* **[`pkg/controller/nodeipam/config/types.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/config/types.go)**: Added `EnableNodeNetworkConfig` boolean field to `NodeIPAMControllerConfiguration`.

### 2. Client & Starter Plumbing
* **[`cmd/cloud-controller-manager/nodeipamcontroller.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/cmd/cloud-controller-manager/nodeipamcontroller.go)** & **[`cmd/cloud-controller-manager/gketenantcontrollermanager.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/cmd/cloud-controller-manager/gketenantcontrollermanager.go)**: Instantiated `nncClient` (`nodenetworkconfig/clientset/versioned`) and passed it down to `StartNodeIpamController`.
* **[`pkg/controller/nodeipam/starter.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/starter.go)** & **[`pkg/controller/nodeipam/node_ipam_controller.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/node_ipam_controller.go)**: Plumbed `nncClient` and `enableNodeNetworkConfig` through `StartNodeIpamController`, `NewNodeIpamController`, and `ipam.New`.

### 3. Syncer & Task Queue Implementation
* **[`pkg/controller/nodeipam/ipam/node_network_config_syncer.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/ipam/node_network_config_syncer.go)**: Implemented `NodeNetworkConfigSyncer` which reconciles `NodeNetworkConfig` CRs for nodes and attaches owner references.
* **[`pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go`](file:///usr/local/google/home/zivy/cloud-provider-gcp/pkg/controller/nodeipam/ipam/cloud_cidr_allocator.go)**: Wired event handlers for node Add/Update events to enqueue tasks in `nodeNetworkConfigQueue` when `EnableNodeNetworkConfig` is true, and managed queue lifecycle during `Run()`.


## Verification
UT and created CCM component in GKE test env. The CRD can be successfully created.
